### PR TITLE
fix: perfectpan.org domain + www redirect + /healthz + docs (re-apply)

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -58,17 +58,14 @@ pnpm --filter @blog/web exec wrangler deploy -c dist/server/wrangler.json
 
 ## 6. Smoke test (confirm it actually serves)
 
-Production is `https://perfectpan.org` (the Worker Custom Domain). Verify the
-real routes (no `/healthz` route exists — use these):
+Production is `https://perfectpan.org` (the Worker Custom Domain). Use `/healthz`
+(the liveness probe) as the primary check, plus a couple of real routes (these
+mirror what the CI smoke step checks):
 
 ```bash
-# each should be HTTP 200 with no x-vercel-* header (proves the Worker, not Vercel)
-for p in / /blog /projects /login; do
-  curl -sI "https://perfectpan.org$p" | grep -iE "^(HTTP|server|x-vercel)"
-done
-curl -sI "https://perfectpan.org/api/auth/get-session" | grep -iE "^HTTP"   # 200
-# www must 301 to the apex, path preserved:
-curl -sI "https://www.perfectpan.org/blog" | grep -iE "^(HTTP|location)"     # 301 -> perfectpan.org/blog
+curl -fsS "https://perfectpan.org/healthz" | grep -q '"ok"'        # primary: 200 {"ok":true}
+curl -fsS -o /dev/null "https://perfectpan.org/blog"               # 200
+curl -sI  "https://www.perfectpan.org/blog" | grep -i "^location"  # 301 -> perfectpan.org/blog
 ```
 
 Also click through: `/`, `/blog`, `/blog/<slug>`, `/projects`, and a login.
@@ -89,3 +86,24 @@ Cloudflare recreates the records + cert (the zone's Universal SSL already covers
 `perfectpan.org` / `*.perfectpan.org`, so HTTPS is immediate). The `www → apex` 301
 is handled **inside the worker** (`apps/web/src/server.tsx`), not via a Cloudflare
 Redirect Rule (the token lacks `rulesets:write` too).
+
+## 8. Manual deploy vs CI deploy — do not let them diverge
+
+- `wrangler deploy` (this skill) deploys your **local** code.
+- CI (`deploy.yml`) deploys **`master`**.
+
+These can silently diverge. If you deploy manually with code that is not yet on
+`master`, **the next push to `master` reverts production** — CI redeploys
+`master`'s (older) code over your manual deploy. This exact regression happened
+2026-06-27: a manual `perfectpan.org` deploy was overwritten by a CI deploy of a
+`master` that still lacked the domain config (`APPS_WEB_URL` reverted to
+workers.dev, www redirect and `/healthz` disappeared).
+
+Rules to avoid it:
+
+1. **After committing, push.** Never leave production-bound work only on a local
+   branch — a merge done from the remote side won't include unpushed commits.
+2. **After a manual deploy, get the same code onto `master`** (push + merge)
+   before the next CI run, so manual and CI agree.
+3. **Before merging a branch, confirm it is fully pushed** and contains all the
+   intended work.

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -58,10 +58,34 @@ pnpm --filter @blog/web exec wrangler deploy -c dist/server/wrangler.json
 
 ## 6. Smoke test (confirm it actually serves)
 
+Production is `https://perfectpan.org` (the Worker Custom Domain). Verify the
+real routes (no `/healthz` route exists — use these):
+
 ```bash
-curl -fsS https://<deployed-url>/healthz   # if a health route exists
-curl -fsS https://<deployed-url>/blog | head -c 300
+# each should be HTTP 200 with no x-vercel-* header (proves the Worker, not Vercel)
+for p in / /blog /projects /login; do
+  curl -sI "https://perfectpan.org$p" | grep -iE "^(HTTP|server|x-vercel)"
+done
+curl -sI "https://perfectpan.org/api/auth/get-session" | grep -iE "^HTTP"   # 200
+# www must 301 to the apex, path preserved:
+curl -sI "https://www.perfectpan.org/blog" | grep -iE "^(HTTP|location)"     # 301 -> perfectpan.org/blog
 ```
 
 Also click through: `/`, `/blog`, `/blog/<slug>`, `/projects`, and a login.
-Report the deployed URL and what you verified. Only then is the deploy done.
+Report what you verified. Only then is the deploy done.
+
+## 7. Custom domains (managed by wrangler, not the dashboard)
+
+`perfectpan.org` and `www.perfectpan.org` are **Worker Custom Domains** declared
+in `apps/web/wrangler.jsonc` (`routes` → `custom_domain: true`). They attach
+automatically on `wrangler deploy` — do **not** wire them up in the dashboard.
+
+Known gotcha when binding/switching a hostname: Worker Custom Domains require the
+hostname to have **no existing DNS record**, otherwise deploy fails with
+`409 / code 100117: already has externally managed DNS records`. The `wrangler login`
+OAuth token has **no `dns:edit`** scope, so you cannot clear it yourself — delete the
+conflicting A/AAAA/CNAME records (apex + www) in the dashboard first, then redeploy;
+Cloudflare recreates the records + cert (the zone's Universal SSL already covers
+`perfectpan.org` / `*.perfectpan.org`, so HTTPS is immediate). The `www → apex` 301
+is handled **inside the worker** (`apps/web/src/server.tsx`), not via a Cloudflare
+Redirect Rule (the token lacks `rulesets:write` too).

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,3 +39,13 @@ jobs:
         run: pnpm --filter @blog/web exec wrangler deploy -c dist/server/wrangler.json
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+      - name: Smoke test (confirm production serves the new deploy)
+        # curl -f fails the step on any non-2xx, so a broken deploy turns the
+        # CI run red. Give the edge a moment to pick up the new version first.
+        run: |
+          sleep 5
+          curl -fsS "https://perfectpan.org/healthz" | grep -q '"ok"'
+          curl -fsS -o /dev/null "https://perfectpan.org/"
+          curl -fsS -o /dev/null "https://perfectpan.org/blog"
+

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as RssDotxmlRouteImport } from './routes/rss[.]xml'
 import { Route as ProjectsRouteImport } from './routes/projects'
 import { Route as LogoutRouteImport } from './routes/logout'
 import { Route as LoginRouteImport } from './routes/login'
+import { Route as HealthzRouteImport } from './routes/healthz'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as BlogIndexRouteImport } from './routes/blog/index'
 import { Route as AdminIndexRouteImport } from './routes/admin/index'
@@ -46,6 +47,11 @@ const LogoutRoute = LogoutRouteImport.update({
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
   path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const HealthzRoute = HealthzRouteImport.update({
+  id: '/healthz',
+  path: '/healthz',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -91,6 +97,7 @@ const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/healthz': typeof HealthzRoute
   '/login': typeof LoginRoute
   '/logout': typeof LogoutRoute
   '/projects': typeof ProjectsRoute
@@ -106,6 +113,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/healthz': typeof HealthzRoute
   '/login': typeof LoginRoute
   '/logout': typeof LogoutRoute
   '/projects': typeof ProjectsRoute
@@ -122,6 +130,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/healthz': typeof HealthzRoute
   '/login': typeof LoginRoute
   '/logout': typeof LogoutRoute
   '/projects': typeof ProjectsRoute
@@ -139,6 +148,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/healthz'
     | '/login'
     | '/logout'
     | '/projects'
@@ -154,6 +164,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/healthz'
     | '/login'
     | '/logout'
     | '/projects'
@@ -169,6 +180,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/healthz'
     | '/login'
     | '/logout'
     | '/projects'
@@ -185,6 +197,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  HealthzRoute: typeof HealthzRoute
   LoginRoute: typeof LoginRoute
   LogoutRoute: typeof LogoutRoute
   ProjectsRoute: typeof ProjectsRoute
@@ -234,6 +247,13 @@ declare module '@tanstack/react-router' {
       path: '/login'
       fullPath: '/login'
       preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/healthz': {
+      id: '/healthz'
+      path: '/healthz'
+      fullPath: '/healthz'
+      preLoaderRoute: typeof HealthzRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -297,6 +317,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  HealthzRoute: HealthzRoute,
   LoginRoute: LoginRoute,
   LogoutRoute: LogoutRoute,
   ProjectsRoute: ProjectsRoute,

--- a/apps/web/src/routes/healthz.ts
+++ b/apps/web/src/routes/healthz.ts
@@ -1,0 +1,16 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+// Lightweight liveness probe for CI smoke checks + external monitoring.
+// Deliberately has no DB / auth / env dependencies: it returns 200 as long as
+// the Worker is running. Keep it cheap — do not add lookups here.
+export const Route = createFileRoute('/healthz')({
+  server: {
+    handlers: {
+      GET: () =>
+        new Response(JSON.stringify({ ok: true }), {
+          headers: { 'content-type': 'application/json; charset=utf-8' },
+        }),
+    },
+  },
+  component: () => null,
+});

--- a/apps/web/src/server.tsx
+++ b/apps/web/src/server.tsx
@@ -5,12 +5,37 @@ import {
 
 const handler = createStartHandler(defaultStreamHandler);
 
+// Canonical apex host, derived from APPS_WEB_URL at module load. A missing
+// value (e.g. misconfigured env) just disables the redirect below rather than
+// blocking every request.
+const apexHost = hostFromUrl(process.env.APPS_WEB_URL);
+
+function hostFromUrl(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const withScheme = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+  try {
+    return new URL(withScheme).host;
+  } catch {
+    return undefined;
+  }
+}
+
 // Cloudflare Workers expects the default export to be an object with a `fetch`
 // method (not the raw handler, which bundles as a class and trips workerd's
 // "actor class as default entrypoint" check). Mirrors the shape of
 // @tanstack/react-start/server-entry.
 export default {
   async fetch(...args: Parameters<typeof handler>) {
+    const request = args[0] as Request;
+    // Canonicalize www -> apex with a 301 (e.g. www.perfectpan.org -> perfectpan.org),
+    // preserving path and query. Runs before the app/auth handler.
+    if (apexHost) {
+      const url = new URL(request.url);
+      if (url.host === `www.${apexHost}`) {
+        url.host = apexHost;
+        return Response.redirect(url.toString(), 301);
+      }
+    }
     return await handler(...args);
   },
 };

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -5,9 +5,13 @@
   "compatibility_flags": ["nodejs_compat"],
   "main": "src/server.tsx",
   "vars": {
-    "APPS_WEB_URL": "https://blog-web.perfectpan325.workers.dev",
+    "APPS_WEB_URL": "https://perfectpan.org",
     "ADMIN_EMAIL_ALLOWLIST": "perfectpan325@gmail.com"
   },
+  "routes": [
+    { "pattern": "perfectpan.org", "custom_domain": true },
+    { "pattern": "www.perfectpan.org", "custom_domain": true }
+  ],
   "assets": {
     "directory": "./dist/client",
     "binding": "ASSETS"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,166 +1,122 @@
-# 项目架构（2026-02）
+# 项目架构（全 Cloudflare，2026-06）
+
+> 本文是「当前架构」的单点真相。快速概览见 `README.md`，迁移决策与取舍见
+> `docs/plans/2026-06-22-cloudflare-migration-design.md`。
+> 旧版 Vercel + Payload + Railway 架构（2026-02）已废弃，归档文档见文末。
 
 ## 1. 总览
 
-当前仓库是一个 monorepo，采用「前台 + CMS + 共享类型」三层结构：
+整个博客跑在 Cloudflare 上，**$0/月**。monorepo 两层结构（CMS 已砍掉）：
 
-- `apps/web`：TanStack Start 前台站点（博客展示、登录、权限守卫）
-- `apps/cms`：Payload CMS（内容管理、后台管理、访问控制）
-- `packages/shared`：前后端共享类型（角色、可见性、文章结构）
+- `apps/web`：TanStack Start 应用，构建产物是一个 **Cloudflare Worker**（`blog-web`）——博客展示、登录、权限守卫、admin 后台全在这里。
+- `packages/shared`：前后端共享类型（角色、可见性、文章结构）。
+- `content/blog`：文章 = git 里的 markdown（无 CMS、无外部内容数据库）。
 
----
+已移除：`apps/cms`（Payload）、PostgreSQL、Vercel adapter、Node server 脚手架。
 
-## 2. 目录结构
+## 2. 部署拓扑
 
-```txt
-blog/
-├─ apps/
-│  ├─ web/                 # TanStack Start
-│  └─ cms/                 # Payload + Next admin
-├─ packages/
-│  └─ shared/              # 共享类型与常量
-├─ content/blog/           # 历史 markdown 文章（迁移来源）
-├─ docs/
-│  ├─ deploy-vercel-railway.md
-│  ├─ architecture.md
-│  ├─ selection.md         # 技术选型与备选对比
-│  ├─ request-flow.md      # 页面访问与权限调用链路图
-│  └─ retrospectives/      # 事故复盘与改进动作
-└─ public/                 # 站点静态资源
+```
+perfectpan.org ─┐
+                ├─→  Worker blog-web (Cloudflare)  ──  ASSETS (dist/client 静态)
+www → 301 apex ─┘        ├─ DB binding → D1 "blog" (auth/session/admin)
+                         └─ 内容: content/blog/*.md (import.meta.glob 构建期内联)
 ```
 
----
+- **域名**：`perfectpan.org` 是 Worker Custom Domain（apex）。`www.perfectpan.org` 也是
+  Custom Domain，但 worker 入口（`apps/web/src/server.tsx`）在处理前先 **301 跳到 apex**
+  （保留 path/query），所以 canonical 只有 apex。
+- **`workers.dev` 路由有意关闭**（`blog-web.perfectpan325.workers.dev` 返回 404）——生产
+  只走 perfectpan.org，避免双域名。
+- `APPS_WEB_URL = https://perfectpan.org`：Better Auth 的 `baseURL`、`trustedOrigins`
+  以及 cookie 域都从它派生；apex-only 服务，不需要单独配 `COOKIE_DOMAIN`。
 
 ## 3. 核心请求链路
 
-### 3.1 博客列表/详情
+### 3.1 博客列表/详情（`GET /blog`、`GET /blog/:slug`）
 
-1. 浏览器请求 `apps/web` 路由（如 `/blog`、`/blog/:slug`）
-2. `apps/web` 在服务端读取会话，得到用户角色
-3. `apps/web` 通过 `PAYLOAD_SERVICE_TOKEN` 调用 `apps/cms` 的 `/api/web/*`
-4. `apps/cms` 根据角色和文章状态过滤后返回数据
-5. `apps/web` 渲染页面（仅使用 CMS 数据）
+1. Worker 入口先做 `www → apex` 301 判断（命中 www 才跳，否则继续）。
+2. TanStack route loader 在服务端读取会话（D1）→ 得到用户角色。
+3. 文章数据来自**构建期内联的 markdown**（frontmatter 决定可见性），不走任何外部 CMS。
+4. loader 用 `canAccessVisibility` 做服务端裁决，返回可见内容；SSR 渲染。
 
 ### 3.2 登录与会话
 
-- 前台登录用 Better Auth（`/api/auth/*`）
-- 会话数据存 PostgreSQL（`user/session/account/verification` 表）
-- CMS Admin 登录走 Payload 自身 `users` 集合认证
-- 两套登录态互相独立（这是预期）
+- 前台用 Better Auth（`/api/auth/*`），通过 `kysely-d1` 直连 **D1**。
+- 会话表（`user/session/account/verification`）由版本化 D1 迁移建表（`apps/web/migrations/`），
+  不在请求期建表。
+- GitHub OAuth 可选（secret 未配时自动禁用）；回调 `https://perfectpan.org/api/auth/callback/github`。
 
 ### 3.3 密码文章解锁
 
-1. 文章 `visibility=password`
-2. 用户在 `/unlock/:slug` 提交密码
-3. `apps/web` 调用 CMS 校验
-4. 成功后写入 `httpOnly + signed` 解锁 cookie（默认 24h）
-
----
+1. 文章 frontmatter `visibility: password`。
+2. 用户在 `/unlock/:slug` 提交密码。
+3. 服务端校验成功后写 `httpOnly + signed` 解锁 cookie（默认 24h）。
 
 ## 4. 权限模型
 
-### 4.1 角色
+### 4.1 角色（存 D1）
 
-- `member`
-- `vip`
-- `admin`
+- `member` / `vip` / `admin`
 
-### 4.2 文章可见性
+### 4.2 文章可见性（frontmatter）
 
-- `public`
-- `member`
-- `vip`
-- `admin`
-- `password`
+- `public` / `member` / `vip` / `admin` / `password`
 
-### 4.3 可见范围
+### 4.3 可见范围（服务端 route loader 裁决）
 
 - 游客：`public`
-- `member`：`public/member`
-- `vip`：`public/member/vip`
+- `member`：`public / member`
+- `vip`：`public / member / vip`
 - `admin`：全部已发布文章（含 `password`）
-
----
 
 ## 5. 数据与内容
 
-### 5.1 内容来源
+- **内容来源**：`content/blog/*.md`（git），构建期 `import.meta.glob` 内联进 worker 包；
+  写文章 = 加 `.md` + commit + push。
+- **数据库**：D1 `blog`（id `1ead9934-…`），只存用户/会话/admin 内容，不存博客正文。
+- **迁移**：schema 走版本化迁移 `apps/web/migrations/`，`pnpm --filter @blog/web db:migrate`
+  应用到远端。
 
-- 线上权威数据：Payload `posts` 集合
-- 迁移源：`content/blog/*.md`
-- 迁移脚本：`apps/cms/scripts/migrate-content.ts`
-
-### 5.2 当前策略
-
-- `apps/web` 不再使用 markdown fallback
-- 前台文章来源统一为 Payload CMS
-
----
-
-## 6. 本地运行（标准流程）
+## 6. 本地运行
 
 ```bash
 pnpm install
+cp apps/web/.dev.vars.example apps/web/.dev.vars   # 填 BETTER_AUTH_SECRET
+pnpm --filter @blog/web db:migrate:local           # 建 D1 + auth 表
+pnpm dev                  # vite dev server
+# 或跑 worker 运行时：pnpm --filter @blog/web preview   # wrangler dev
 ```
 
-1. 复制环境变量模板：
+## 7. 部署
 
-```bash
-cp apps/cms/.env.example apps/cms/.env
-cp apps/web/.env.example apps/web/.env
-```
+- **CI（push `master`）**：`.github/workflows/deploy.yml` → 迁移 D1 + `wrangler deploy`。
+- **手动**：`/deploy` skill（验证 → 构建 → 体积门 → 迁移 → 部署 → 冒烟），或
+  `pnpm --filter @blog/web deploy`（= `vite build && wrangler deploy`）。
+- **必需的生产配置**：secret `BETTER_AUTH_SECRET`；var `APPS_WEB_URL`（已在 `wrangler.jsonc`）；
+  D1 绑定 `DB`（已 provision）。可选 `GITHUB_CLIENT_ID/SECRET`。
+- **Custom Domain 由 `wrangler.jsonc` 的 `routes` 管理**（apex + www），随部署一起绑定，
+  不在 dashboard 单独维护。
 
-2. 启动 CMS：
+### 7.1 绑定/换域名的坑（已踩，留档）
 
-```bash
-pnpm dev:cms
-```
-
-3. 初始化/同步历史文章（首次或有 markdown 变更时）：
-
-```bash
-pnpm migrate:content
-```
-
-4. 初始化 Better Auth 表（首次）：
-
-```bash
-pnpm dlx @better-auth/cli migrate --cwd ./apps/web --config ./src/lib/auth.ts --yes
-```
-
-5. 启动前台：
-
-```bash
-pnpm dev:web
-```
-
----
-
-## 7. 部署架构
-
-- 前台：Vercel（`apps/web`）
-- CMS + DB：Railway（`apps/cms` + PostgreSQL）
-
-关键约束：
-
-- 浏览器不得直接调用 CMS 私有接口
-- `PAYLOAD_SERVICE_TOKEN` 只允许存在于服务端环境变量
-- CMS Postgres 适配器已配置 `push: false`，避免开发时误触发交互式删表
-
----
+Worker **Custom Domain** 要求该主机名下**没有**现存 DNS 记录，否则部署报
+`409 / code 100117: already has externally managed DNS records`，且 `wrangler login` 的
+OAuth token **没有 `dns:edit` 权限**，删不掉冲突记录。处理：在 CF dashboard 的
+DNS → Records 里**先删掉 apex + www 的旧记录**（A/AAAA/CNAME），再 `wrangler deploy`，
+CF 会自动重建指向 worker 的记录 + 证书（zone 已有 Universal SSL 覆盖
+`perfectpan.org` / `*.perfectpan.org`，HTTPS 立即可用）。`www → apex` 的 301 跳转在
+worker 里做（不是 CF Redirect Rule），因为该 token 也没有 `rulesets:write`。
 
 ## 8. 维护注意事项
 
-- 保持历史 URL 不变：`/blog`、`/blog/:slug`
-- Payload import map 文件需要入库：
-  - `apps/cms/src/app/(payload)/admin/importMap.js`
-  - 变更 admin 组件后可手动执行：`payload generate:importmap`
-- 根目录 pre-push 执行 `pnpm typecheck`（仅校验 `apps/web` + `apps/cms`）
-- 提交前建议至少执行：
-  - `pnpm --filter @blog/web typecheck`
-  - `pnpm --filter @blog/cms typecheck`
+- 保持历史 URL 不变：`/blog`、`/blog/:slug`。
+- 根目录 pre-push 执行 `pnpm typecheck`；提交前至少跑 `pnpm --filter @blog/web typecheck`。
+- worker 体积守门：免费版上限 3 MiB gzip；PR workflow 会在 dry-run 时检查，超了即红。
 
-## 9. 复盘记录
+## 9. 相关文档
 
-- 登录链路修复复盘（2026-03-01）：
-  - `docs/retrospectives/2026-03-01-auth-login-chain.md`
+- 迁移决策与取舍：`docs/plans/2026-06-22-cloudflare-migration-design.md`
+- 页面访问调用链路：`docs/request-flow.md`
+- 复盘记录：`docs/retrospectives/`
+- **已归档（2026-02 旧栈，仅供参考）**：`docs/deploy-vercel-railway.md`、`docs/selection.md`

--- a/docs/deploy-vercel-railway.md
+++ b/docs/deploy-vercel-railway.md
@@ -1,5 +1,9 @@
 # Deploy Guide (Vercel + Railway)
 
+> ⚠️ **历史归档（2026-02 旧栈）**：本文描述的 Vercel + Railway + PostgreSQL 部署已被
+> 废弃。当前站点全量跑在 Cloudflare（Worker + D1），部署方式见 `README.md` 的 Deploy
+> 小节、`/deploy` skill、以及 `docs/architecture.md`。保留本文仅供历史参考。
+
 ## 1) Railway
 
 1. Create PostgreSQL service.

--- a/docs/plans/2026-06-22-cloudflare-migration-design.md
+++ b/docs/plans/2026-06-22-cloudflare-migration-design.md
@@ -63,11 +63,22 @@ Workers 免费版上限: 3 MiB  →  约 58% 占用，留 ~1.75 MiB 余量
 - 验证通过：`pnpm typecheck` ✓、`biome check` ✓、`pnpm --filter @blog/web build` ✓、
   `wrangler deploy --dry-run` ✓（体积 1.28 MiB、`env.DB` 绑定解析正常）。
 
-## 尚未做（需要真实上线迭代，刻意留给人确认）
+## 状态（2026-06-27 更新）
 
-- **生产 `wrangler deploy` + 冒烟**：发布站点属外向操作，未擅自执行。上线步骤见 `/deploy` skill 与 README。
-  上线前需 `wrangler secret put BETTER_AUTH_SECRET`（GitHub OAuth 可选）。
-- **运行时端到端验证**：dry-run 验证了打包与绑定，但 Better Auth on D1 的登录/会话全链路
-  需真实部署后点一遍（登录、注册、角色、password 文章解锁）。
-- **GitHub Actions 部署所需 secret**：仓库需配 `CLOUDFLARE_API_TOKEN`。
+- ✅ **生产已上线**：`perfectpan.org` 作为 Worker Custom Domain 绑定到 `blog-web`，
+  `APPS_WEB_URL` 已切到 `https://perfectpan.org`；`www → apex` 301 在 worker 入口实现；
+  `workers.dev` 路由关闭；旧 Vercel 站已被取代（DNS 不再指向它）。
+- ✅ **冒烟通过**：`/`、`/blog`、`/projects`、`/login`、`/api/auth/get-session` 均 200
+  且无 `x-vercel-*` 头；`www.perfectpan.org/blog` → 301 `perfectpan.org/blog`。
+- ⚠️ **绑定域名踩的坑**（已留档在 `docs/architecture.md` §7.1）：Worker Custom Domain
+  要求主机名下无现存 DNS 记录，否则报 `409 / code 100117`；`wrangler login` 的 OAuth
+  token 没有 `dns:edit`，得在 dashboard 先删掉 apex + www 的旧记录再部署。
+
+## 尚未做
+
+- **CI 自动部署尚未激活**：本迁移分支（`worktree-cloudflare-migration`）还没合进
+  `master`，所以 `deploy.yml` / `pull-request.yml`（触发于 master）从未真正跑过；
+  当前是手动 `wrangler deploy`。激活需：合分支到 master + 仓库配 `CLOUDFLARE_API_TOKEN` secret。
+- **运行时登录全链路**：路由与 auth API 已验证 200，但 Better Auth on D1 的完整点击流
+  （注册、登录、角色、password 文章解锁）仍待用真实账号点一遍。
 - **重新设计**：等 Claude design 导出（TSX/截图）后单独迭代。

--- a/docs/request-flow.md
+++ b/docs/request-flow.md
@@ -1,23 +1,23 @@
 # 页面访问调用链路（小白版）
 
-本文描述「用户打开博客页面」时，代码会经过哪些文件与函数。
+本文描述「用户打开博客页面」时，代码会经过哪些文件与函数。当前架构下**没有
+CMS / Payload / Postgres**：文章内容是构建期内联的 git markdown，登录态来自 D1。
 
 ## 1) 读文章页/列表页：`GET /blog`、`GET /blog/:slug`
 
 ```mermaid
 flowchart TD
-  A["浏览器请求<br/>GET /blog 或 /blog/:slug"] --> B["TanStack 路由 loader<br/>apps/web/src/routes/blog/index.tsx<br/>apps/web/src/routes/blog/$slug.tsx"]
+  A["浏览器请求<br/>GET /blog 或 /blog/:slug"] --> W["Worker 入口<br/>www → apex 301 判断<br/>apps/web/src/server.tsx"]
+  W --> B["TanStack route loader<br/>apps/web/src/routes/blog/index.tsx<br/>apps/web/src/routes/blog/$slug.tsx"]
   B --> C["ServerFn<br/>getBlogListServerFn / getBlogPostServerFn<br/>apps/web/src/lib/blog-service.ts"]
-  C --> D["读取登录态<br/>getSessionUserFromRequest(request)<br/>apps/web/src/lib/session.ts"]
+  C --> D["读取登录态<br/>getSessionUserFromRequest(request)<br/>apps/web/src/lib/session-core.ts"]
   D --> E["Better Auth 取 session<br/>auth.api.getSession(headers)<br/>apps/web/src/lib/auth.ts"]
-  E --> F["Postgres（better-auth 用户/会话表）"]
-  C --> G["Web 服务端请求 CMS<br/>fetchVisiblePostsFromCms / fetchPostBySlugFromCms<br/>apps/web/src/lib/cms-client.ts"]
-  G --> H["CMS /api/web/posts*<br/>apps/cms/src/payload.config.ts"]
-  H --> I["校验服务令牌+来源<br/>assertServiceRequest()"]
-  I --> J["Payload 查询 posts 集合<br/>按已发布+角色过滤"]
-  J --> K["返回文章数据给 web"]
-  K --> L["详情页再做最终权限判断<br/>401 / 403 / 跳转 unlock<br/>apps/web/src/routes/blog/$slug.tsx"]
-  L --> M["React 渲染 HTML 返回浏览器"]
+  E --> F["D1（用户/会话表，kysely-d1）"]
+  C --> G["读文章内容<br/>getAllPublishedPosts / getPostBySlug<br/>apps/web/src/lib/content-service.ts"]
+  G --> H["构建期内联的 markdown<br/>import.meta.glob('content/blog/*.md')"]
+  H --> I["按角色过滤可见性<br/>canAccessVisibility(post.visibility, role)<br/>blog-service.ts / @blog/shared"]
+  I --> J["详情页最终权限判断<br/>401 / 403 / 跳 /unlock/:slug<br/>apps/web/src/routes/blog/$slug.tsx"]
+  J --> K["React SSR 渲染 HTML 返回浏览器"]
 ```
 
 ## 2) 密码文章解锁：`POST /unlock/:slug`
@@ -25,19 +25,23 @@ flowchart TD
 ```mermaid
 flowchart TD
   A["用户提交密码<br/>POST /unlock/:slug"] --> B["路由 handler<br/>apps/web/src/routes/unlock/$slug.tsx"]
-  B --> C{"是否触发限流?"}
+  B --> C{"触发限流?<br/>unlock-rate-limit.ts"}
   C -- "是" --> D["返回 429"]
-  C -- "否" --> E["调用 CMS 验证密码<br/>verifyPostPasswordWithCms()"]
+  C -- "否" --> E["校验密码<br/>verifyPostPassword(slug, password)<br/>apps/web/src/lib/content-service.ts"]
   E --> F{"密码正确?"}
   F -- "否" --> G["记录失败次数并重定向<br/>/unlock/:slug?error=invalid"]
   F -- "是" --> H["签发 HttpOnly 解锁 Cookie<br/>apps/web/src/lib/unlock-cookie.ts"]
   H --> I["303 重定向到 /blog/:slug"]
 ```
 
+密码来自文章 frontmatter（构建期内联），不在请求期查任何外部服务。
+
 ## 3) 关键代码定位
 
-- 登录态入口：`apps/web/src/lib/session.ts`
+- Worker 入口（www → apex 301）：`apps/web/src/server.tsx`
+- 登录态入口：`apps/web/src/lib/session-core.ts`
 - 页面服务端聚合：`apps/web/src/lib/blog-service.ts`
+- 文章内容（markdown 读取 + 密码校验）：`apps/web/src/lib/content-service.ts`
+- 认证（Better Auth on D1）：`apps/web/src/lib/auth.ts`
 - 详情页权限裁决：`apps/web/src/routes/blog/$slug.tsx`
-- 解锁流程：`apps/web/src/routes/unlock/$slug.tsx`
-- CMS 服务端接口：`apps/cms/src/payload.config.ts`
+- 解锁流程：`apps/web/src/routes/unlock/$slug.tsx` + `unlock-cookie.ts` / `unlock-rate-limit.ts`

--- a/docs/selection.md
+++ b/docs/selection.md
@@ -1,5 +1,9 @@
 # 技术选型说明（2026-02）
 
+> ⚠️ **历史归档**：本文是 2026-02 的选型对比（当时还含 Payload / Vercel / Railway 等
+> 备选）。最终结论已变——砍掉 Payload、换 Cloudflare D1、迁到 Workers。当前选型决策见
+> `docs/plans/2026-06-22-cloudflare-migration-design.md`。保留本文仅供历史参考。
+
 ## 1. 目标与约束
 
 当前博客系统的核心需求是：

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "typescript": "^5.7.3"
   },
   "lint-staged": {
-    "*.{mjs,js,jsx,mts,ts,tsx,css,json,md}": "pnpm biome check --write"
+    "*.{mjs,js,jsx,mts,ts,tsx,css,json}": "pnpm biome check --write"
   },
   "packageManager": "pnpm@8.15.5"
 }


### PR DESCRIPTION
PR #52 的 squash 合并没包含这 4 个 commit（当时还在本地没 push），导致 CI 用旧代码覆盖了线上（APPS_WEB_URL 退回 workers.dev、www 不跳转、/healthz 404）。本 PR 在干净 master 上重新应用：
- perfectpan.org custom domain + www→apex 301 跳转
- /healthz 探针 + deploy CI smoke 步骤
- 架构文档刷新 + /deploy skill 修正
- lint-staged 去掉 .md（Biome 1.9 不支持 markdown）

合并后 CI 会部署正确代码。