### PR TITLE
chore: enforce conventional-commit PR titles; add CLAUDE.md and AGENTS conventions

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,35 @@
+name: PR title
+
+# Enforce conventional-commit PR titles (English), e.g. `fix(web): ...`, `ci: ...`.
+# Non-blocking by default (shows red but won't block merge unless made a required
+# check in GitHub branch-protection settings). See AGENTS.md §8.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          requireScope: false
+          types: |
+            fix
+            feat
+            chore
+            docs
+            ci
+            style
+            refactor
+            perf
+            test
+            build
+            revert

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,9 @@
 
 本文件给在本仓库工作的 agent / 工程师使用，目标是减少误操作并统一交付标准。
 
+> **架构单点真相 = `docs/architecture.md`**（含数据模型 / 两层权限 / 安全 / 备份 / agent 速查 §13）。
+> 本文件侧重流程与约束；架构细节以那份文档为准。
+
 ## 1. 项目定位
 
 - 单人博客，**全量运行在 Cloudflare 上、$0/月**。
@@ -71,3 +74,12 @@ pnpm --filter @blog/web exec wrangler deploy -c dist/server/wrangler.json --dry-
 ```
 
 冒烟：`/`、`/blog`、`/blog/:slug`、`/projects`。
+
+## 8. 提交与 PR 规范
+
+- **commit message 与 PR 标题一律用 conventional commits + 英文**：`type(scope): imperative subject`，
+  例如 `fix(web): ...`、`feat(web): ...`、`ci: ...`、`docs: ...`、`chore: ...`。**不要写中文标题**
+  （正文描述可中文）。`type` 取最主导的那类（安全修优先 `fix`）。
+- PR 标题由 `.github/workflows/pr-title.yml`（`amannn/action-semantic-pull-request`）自动校验，
+  不符合 conventional 格式会标红；如需"拦死"在 GitHub 设置里把它设为必需检查。
+- 一个 PR 尽量单一关注点；混合时标题用主导类型，其余在正文说明。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,33 +1,5 @@
 # CLAUDE.md
 
-给 Claude Code 的精简项目上下文。**架构单点真相 = `docs/architecture.md`**
-（改东西前先读它，尤其 §6 权限、§8 安全、§13 agent 速查）；完整 agent 指南见 `AGENTS.md`。
+本仓库的 **agent 规范 = `AGENTS.md`**(开工前先读);**架构单点真相 = `docs/architecture.md`**(改东西前读 §6 权限 / §8 安全 / §13 agent 速查)。
 
-## 这是啥
-
-单人博客，全 Cloudflare、$0/月。`apps/web`（TanStack Start）构建为 Worker `blog-web`；
-内容/用户/会话都在 D1 `blog`（`post` + better-auth 表）；无 CMS。
-
-## 必须遵守
-
-- **commit message & PR 标题：conventional commits + 英文**，`type(scope): imperative subject`
-  （`fix(web): ...`、`ci: ...`、`docs: ...`）。**不写中文标题**；PR 标题被
-  `.github/workflows/pr-title.yml` 校验。
-- **权限在两层强制**：route loader **和** 数据层 server fn。server fn 可被直接 RPC 调用，
-  所以鉴权必须在 handler 内部做——别只靠 loader（见架构文档 §6）。
-- **密钥只走 `wrangler secret` / `.dev.vars`**，绝不进客户端包、绝不进 git。
-- **守 Workers 免费版 3 MiB gzip 上限**；改完用 dry-run 看体积。
-- **文章走 D1 / admin**，不要再加 `content/blog/*.md`（已废弃）。
-
-## 提交前最低验证
-
-```bash
-pnpm typecheck && pnpm biome check ./apps ./packages && pnpm --filter @blog/web build
-pnpm --filter @blog/web exec wrangler deploy -c apps/web/dist/server/wrangler.json --dry-run  # 守 3 MiB
-```
-
-## 常用
-
-- 本地：`pnpm --filter @blog/web dev`（vite）；`pnpm --filter @blog/web exec wrangler dev`（worker 运行时）。
-- D1 迁移本地：`pnpm --filter @blog/web exec wrangler d1 migrations apply blog --local`。
-- 部署走 push `master`（`deploy.yml`）或 `/deploy` skill；别让手动部署和 CI 分叉。
+本文件只是入口指针,不重复上述内容——一律以那两份为准。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# CLAUDE.md
+
+给 Claude Code 的精简项目上下文。**架构单点真相 = `docs/architecture.md`**
+（改东西前先读它，尤其 §6 权限、§8 安全、§13 agent 速查）；完整 agent 指南见 `AGENTS.md`。
+
+## 这是啥
+
+单人博客，全 Cloudflare、$0/月。`apps/web`（TanStack Start）构建为 Worker `blog-web`；
+内容/用户/会话都在 D1 `blog`（`post` + better-auth 表）；无 CMS。
+
+## 必须遵守
+
+- **commit message & PR 标题：conventional commits + 英文**，`type(scope): imperative subject`
+  （`fix(web): ...`、`ci: ...`、`docs: ...`）。**不写中文标题**；PR 标题被
+  `.github/workflows/pr-title.yml` 校验。
+- **权限在两层强制**：route loader **和** 数据层 server fn。server fn 可被直接 RPC 调用，
+  所以鉴权必须在 handler 内部做——别只靠 loader（见架构文档 §6）。
+- **密钥只走 `wrangler secret` / `.dev.vars`**，绝不进客户端包、绝不进 git。
+- **守 Workers 免费版 3 MiB gzip 上限**；改完用 dry-run 看体积。
+- **文章走 D1 / admin**，不要再加 `content/blog/*.md`（已废弃）。
+
+## 提交前最低验证
+
+```bash
+pnpm typecheck && pnpm biome check ./apps ./packages && pnpm --filter @blog/web build
+pnpm --filter @blog/web exec wrangler deploy -c apps/web/dist/server/wrangler.json --dry-run  # 守 3 MiB
+```
+
+## 常用
+
+- 本地：`pnpm --filter @blog/web dev`（vite）；`pnpm --filter @blog/web exec wrangler dev`（worker 运行时）。
+- D1 迁移本地：`pnpm --filter @blog/web exec wrangler d1 migrations apply blog --local`。
+- 部署走 push `master`（`deploy.yml`）或 `/deploy` skill；别让手动部署和 CI 分叉。


### PR DESCRIPTION
仓库级 harness「PR 标题/commit 用 conventional + 英文」,软硬两层:

- **CLAUDE.md**(仓库根):Claude Code 每次 session 自动加载 → harness Claude;含规则 + 指向 `docs/architecture.md`(单点真相)与 AGENTS.md。
- **AGENTS.md §8**:把提交/PR 规范写进跨 agent 指南(+ 顶部指向 architecture 文档)。
- **`.github/workflows/pr-title.yml`**:`amannn/action-semantic-pull-request` 校验 PR 标题符合 conventional commits;默认非阻塞(标红不拦合并),要拦死去 branch protection 设为必需检查。

纯增量、可回退。注:AGENTS.md §1/§2 个别措辞还停留在迁移前(markdown 内联 / 仅 loader 鉴权),本次未动,如需我一并校正可再说。

🤖 Generated with [Claude Code](https://claude.com/claude-code)