### PR TITLE
fix(ci): run D1 backup steps from apps/web so paths resolve

### DIFF
--- a/.github/workflows/backup-d1.yml
+++ b/.github/workflows/backup-d1.yml
@@ -38,6 +38,7 @@ jobs:
 
       - name: Export D1 + decide whether it changed
         id: decide
+        working-directory: apps/web
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
@@ -62,6 +63,7 @@ jobs:
 
       - name: Upload new backup
         if: steps.decide.outputs.changed == 'true'
+        working-directory: apps/web
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |


### PR DESCRIPTION
修 #55 里备份 workflow 的 cwd bug。

**症状**: 首次手动触发失败 —— `sha256sum: dump.sql: No such file or directory`。
**根因**:export/upload 步骤用 `pnpm --filter @blog/web exec wrangler`,wrangler 在 `apps/web/` 跑,`--output dump.sql` 写到 `apps/web/dump.sql`;但同一步骤里的 bash(`sha256sum`/`cat`/`put --file`)在仓库根目录跑,找不到文件 → `set -e` 退出。
**修复**:给这两个步骤加 `working-directory: apps/web`,让 wrangler 和 bash 同 cwd。(deploy 不受影响,因为它不读取 wrangler 的输出文件。)

合并后我再手动触发一次,顺便验证 CI token 的 R2 权限是否到位。

🤖 Generated with [Claude Code](https://claude.com/claude-code)