### PR TITLE
docs: align AGENTS.md with D1-driven stack and two-layer authz

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,18 +9,19 @@
 
 - 单人博客，**全量运行在 Cloudflare 上、$0/月**。
 - `apps/web`（TanStack Start）部署为 **Cloudflare Worker**；`packages/shared` 放共享类型。
-- 文章是 `content/blog` 下的 **git markdown**，构建期内联（无 CMS、无内容数据库）。
+- 文章存在 **D1 `post` 表**（由 `/admin` 管理；历史 markdown 已一次性迁入 D1，`content/blog` 源文件已删）。无 CMS、无外部内容数据库。
 - 登录与角色用 **Better Auth + Cloudflare D1**。
-- 旧架构已移除：Waku、Payload CMS、Postgres、Vercel adapter 都不再维护。
+- 旧架构已移除：Waku、Payload CMS、Postgres、Vercel adapter、构建期内联 markdown / `gray-matter` 都不再维护。
 
 ## 2. 必须遵守的约束
 
 1. 路由兼容性不可破坏：`/blog`、`/blog/:slug`。
-2. 权限裁决必须在服务端做（route loader 里），前端只做展示。
+2. 权限裁决必须在**两层**服务端做：route loader（UX/状态码）+ 数据层 server fn。
+   server fn 可被直接 RPC 调用，**鉴权必须在 handler 内部**，不能只靠 loader（见 `docs/architecture.md` §6）。前端只做展示。
 3. `BETTER_AUTH_SECRET` 绝不能进客户端包，只走 `wrangler secret` / `.dev.vars`。
 4. worker 体积必须守住 Workers 免费版 **3 MiB gzip** 上限——这是 $0 的命根子。
    每次改动后用 `wrangler deploy -c dist/server/wrangler.json --dry-run` 看 gzip 数。
-5. 文章可见性分级靠 frontmatter 的 `visibility` 字段，默认 `public`。
+5. 文章可见性分级靠 `post.visibility` 字段（`public | member | vip | admin | password`），默认 `public`。
 
 ## 3. 常用命令
 


### PR DESCRIPTION
校正 AGENTS.md 里两句还停在迁移前的描述(架构单点真相已是 docs/architecture.md,本 PR 让 AGENTS.md 与之一致):

- §1:内容是 D1 post 表(admin 管理;历史 markdown 已迁入,content/blog 已删)——不再是构建期内联 markdown。
- §2.2:权限在**两层**服务端做(route loader + 数据层 server fn);server fn 可被 RPC 直调,鉴权必须在 handler 内。
- §2.5:visibility 是 post.visibility 字段,不是 frontmatter。

纯文档,§3 命令(db:migrate 等)核对过仍是真脚本,未动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)