### PR TITLE
chore: gitignore abandoned CMS, removed Vercel config, agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ test-results
 
 # OS
 .DS_Store
+
+# Stale local artifacts: abandoned CMS, removed Vercel integration, agent worktrees
+.vercel
+apps/**/.vercel
+apps/cms/
+.claude/worktrees/


### PR DESCRIPTION
Stops untracked local junk from showing in `git status` / breaking `pnpm lint` locally:

- `apps/cms/` — the abandoned Payload+Postgres CMS (the stack was dropped for D1+markdown; 689 MB)
- `.vercel` / `apps/**/.vercel` — the removed Vercel project config (Vercel is gone, migrated to CF Workers)
- `.claude/worktrees/` — agent worktree storage

These were all untracked (never committed), so CI was unaffected — but they made local `pnpm lint` fail on the generated `.next/` / `.vercel/` files. The files themselves are deleted from the working copy (~706 MB freed); this PR just adds the ignore entries so they can't come back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)