### PR TITLE
fix(ci): skip preview job when CLOUDFLARE_API_TOKEN is absent

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -31,7 +31,13 @@ concurrency:
 
 jobs:
   preview:
-    if: github.event.action != 'closed' && github.event.pull_request.head.ref != 'master'
+    # Dependabot-triggered pull_request runs do NOT receive repository
+    # secrets, so CLOUDFLARE_API_TOKEN is empty there and the deploy would
+    # fail. Skip cleanly (neutral) instead of erroring. To enable previews on
+    # dependabot PRs, add CLOUDFLARE_API_TOKEN to the repo's *Dependabot*
+    # secret store (Settings → Secrets → Dependabot) — that scope IS passed
+    # to dependabot-triggered runs.
+    if: github.event.action != 'closed' && github.event.pull_request.head.ref != 'master' && secrets.CLOUDFLARE_API_TOKEN != ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Dependabot-triggered `pull_request` runs do **not** receive repository secrets. PR #75 (a dependabot PR) hit this: its Preview Deploy failed with _"set a CLOUDFLARE_API_TOKEN"_ — not because of the github-script bump, but because the token was empty in that run.

This makes the `preview` job **skip cleanly (neutral)** when the token is absent, so dependabot PRs (or any PR without the secret) no longer show a red Preview Deploy check.

To actually **enable** previews on dependabot PRs, add `CLOUDFLARE_API_TOKEN` to the repo's **Dependabot** secret store (Settings → Secrets and variables → Dependabot) — that scope is passed to dependabot-triggered runs (the regular Actions secret store is not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)