### PR TITLE
ci(e2e): per-PR Playwright regression against isolated local worker

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -76,3 +76,13 @@ jobs:
           TEST_EXIT=$?
           kill "$DEV_PID" 2>/dev/null || true
           exit "$TEST_EXIT"
+
+      - name: Upload Playwright artifacts (screenshots/traces)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-e2e
+          path: |
+            test-results/
+            playwright-report/
+          if-no-files-found: ignore

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,8 +3,9 @@ name: E2E Regression
 # Per-PR E2E regression against an ISOLATED local workerd + fresh local D1 —
 # NOT the preview. The suite writes (signup + create-post), and the preview
 # shares production D1, so running it there would pollute prod. Instead: build
-# the branch, boot the built Worker via `wrangler dev --local`, apply migrations
-# to an empty local D1, then run Playwright against it.
+# the branch, derive a local config with APPS_WEB_URL pointed at the local
+# origin (so better-auth trusts the browser Origin), boot it via
+# `wrangler dev --local`, then run Playwright against it.
 
 on:
   pull_request:
@@ -41,9 +42,30 @@ jobs:
       - name: Install Playwright (Chrome)
         run: pnpm exec playwright install --with-deps chrome
 
+      # Derive a local config from the BUILT wrangler.json with the local origin
+      # baked into vars. APPS_WEB_URL must be 127.0.0.1:8787 so better-auth's
+      # trustedOrigins accept the browser's Origin header (the built config's
+      # perfectpan.org value would otherwise yield "Invalid origin"). Putting it
+      # in the config (not .dev.vars) avoids var-override ambiguity.
+      - name: Generate local E2E config
+        run: |
+          node <<'EOF'
+          const fs = require('fs');
+          const crypto = require('crypto');
+          const cfg = JSON.parse(fs.readFileSync('apps/web/dist/server/wrangler.json', 'utf8'));
+          cfg.vars = {
+            ...(cfg.vars || {}),
+            APPS_WEB_URL: 'http://127.0.0.1:8787',
+            ADMIN_EMAIL_ALLOWLIST: 'claude-verify@example.com',
+            BETTER_AUTH_SECRET: crypto.randomBytes(32).toString('hex'),
+          };
+          fs.writeFileSync('apps/web/dist/server/wrangler.e2e.json', JSON.stringify(cfg, null, 2));
+          console.log('wrote apps/web/dist/server/wrangler.e2e.json');
+          EOF
+
       - name: Apply local D1 migrations
         working-directory: apps/web
-        run: pnpm exec wrangler d1 migrations apply blog --local -c dist/server/wrangler.json
+        run: pnpm exec wrangler d1 migrations apply blog --local -c dist/server/wrangler.e2e.json
 
       - name: Boot local Worker + run E2E
         working-directory: apps/web
@@ -51,13 +73,8 @@ jobs:
           E2E_BASE_URL: http://127.0.0.1:8787
         run: |
           set -uo pipefail
-          # Local dev vars (random session secret; GitHub login left disabled —
-          # the tests authenticate with email/password). Written next to the
-          # BUILT config (dist/server/), which is the root `wrangler dev -c`
-          # reads .dev.vars from.
-          printf 'BETTER_AUTH_SECRET="%s"\nAPPS_WEB_URL="http://127.0.0.1:8787"\nADMIN_EMAIL_ALLOWLIST="claude-verify@example.com"\n' "$(openssl rand -hex 32)" > dist/server/.dev.vars
-          # Boot the built Worker on a local D1, in the background.
-          pnpm exec wrangler dev -c dist/server/wrangler.json --port 8787 --local > /tmp/wrangler.log 2>&1 &
+          # Boot the built Worker (local config, local D1) in the background.
+          pnpm exec wrangler dev -c dist/server/wrangler.e2e.json --port 8787 --local > /tmp/wrangler.log 2>&1 &
           DEV_PID=$!
           # Wait for readiness (poll /healthz).
           ready=0

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -91,6 +91,10 @@ jobs:
           # Run the suite (root package script).
           pnpm --filter blog test:e2e
           TEST_EXIT=$?
+          if [ "$TEST_EXIT" -ne 0 ]; then
+            echo "----- wrangler dev log (tail, for origin/trustedOrigins diagnostics) -----"
+            tail -80 /tmp/wrangler.log
+          fi
           kill "$DEV_PID" 2>/dev/null || true
           exit "$TEST_EXIT"
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,8 +52,10 @@ jobs:
         run: |
           set -uo pipefail
           # Local dev vars (random session secret; GitHub login left disabled —
-          # the tests authenticate with email/password).
-          printf 'BETTER_AUTH_SECRET="%s"\nAPPS_WEB_URL="http://127.0.0.1:8787"\nADMIN_EMAIL_ALLOWLIST="claude-verify@example.com"\n' "$(openssl rand -hex 32)" > .dev.vars
+          # the tests authenticate with email/password). Written next to the
+          # BUILT config (dist/server/), which is the root `wrangler dev -c`
+          # reads .dev.vars from.
+          printf 'BETTER_AUTH_SECRET="%s"\nAPPS_WEB_URL="http://127.0.0.1:8787"\nADMIN_EMAIL_ALLOWLIST="claude-verify@example.com"\n' "$(openssl rand -hex 32)" > dist/server/.dev.vars
           # Boot the built Worker on a local D1, in the background.
           pnpm exec wrangler dev -c dist/server/wrangler.json --port 8787 --local > /tmp/wrangler.log 2>&1 &
           DEV_PID=$!

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,76 @@
+name: E2E Regression
+
+# Per-PR E2E regression against an ISOLATED local workerd + fresh local D1 —
+# NOT the preview. The suite writes (signup + create-post), and the preview
+# shares production D1, so running it there would pollute prod. Instead: build
+# the branch, boot the built Worker via `wrangler dev --local`, apply migrations
+# to an empty local D1, then run Playwright against it.
+
+on:
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build Worker
+        run: pnpm --filter @blog/web build
+
+      - name: Install Playwright (Chrome)
+        run: pnpm exec playwright install --with-deps chrome
+
+      - name: Apply local D1 migrations
+        working-directory: apps/web
+        run: pnpm exec wrangler d1 migrations apply blog --local -c dist/server/wrangler.json
+
+      - name: Boot local Worker + run E2E
+        working-directory: apps/web
+        env:
+          E2E_BASE_URL: http://127.0.0.1:8787
+        run: |
+          set -uo pipefail
+          # Local dev vars (random session secret; GitHub login left disabled —
+          # the tests authenticate with email/password).
+          printf 'BETTER_AUTH_SECRET="%s"\nAPPS_WEB_URL="http://127.0.0.1:8787"\nADMIN_EMAIL_ALLOWLIST="claude-verify@example.com"\n' "$(openssl rand -hex 32)" > .dev.vars
+          # Boot the built Worker on a local D1, in the background.
+          pnpm exec wrangler dev -c dist/server/wrangler.json --port 8787 --local > /tmp/wrangler.log 2>&1 &
+          DEV_PID=$!
+          # Wait for readiness (poll /healthz).
+          ready=0
+          for i in $(seq 1 60); do
+            if curl -sf http://127.0.0.1:8787/healthz >/dev/null; then ready=1; echo "worker ready"; break; fi
+            sleep 2
+          done
+          if [ "$ready" -ne 1 ]; then
+            echo "::error::local Worker did not become ready in 120s"
+            echo "----- wrangler dev log -----"; cat /tmp/wrangler.log
+            kill "$DEV_PID" 2>/dev/null || true
+            exit 1
+          fi
+          # Run the suite (root package script).
+          pnpm --filter blog test:e2e
+          TEST_EXIT=$?
+          kill "$DEV_PID" 2>/dev/null || true
+          exit "$TEST_EXIT"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,5 +11,6 @@ export default defineConfig({
     baseURL: process.env.E2E_BASE_URL ?? 'http://127.0.0.1:3000',
     channel: 'chrome',
     trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
   },
 });


### PR DESCRIPTION
Adds `e2e.yml`: on each PR, build → boot the built Worker on a **local workerd + fresh local D1** (migrations applied) → run the Playwright suite.

**Why local, not the preview:** the suite writes (signup in `auth-logout`, signup + create-post + first-admin promotion in `admin-flow`), and the preview shares production D1. Running it against the preview would write a throwaway user and an `e2e-admin-post` into **prod**. A local workerd with an empty migrated D1 keeps it clean and lets first-admin promotion work (the first signup becomes admin on a fresh DB).

Setup: random `BETTER_AUTH_SECRET`, `APPS_WEB_URL` → the local origin, Chrome installed for Playwright (`channel: 'chrome'`). GitHub login is left disabled — the tests use email/password.

Self-tests on this PR; will iterate if the boot/wait/test chain needs tweaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)