### PR TITLE
fix(web): top-align page content instead of forcing vertical centering

### DIFF
--- a/apps/web/src/components/layout.tsx
+++ b/apps/web/src/components/layout.tsx
@@ -11,9 +11,7 @@ export function AppLayout({ children }: AppLayoutProps) {
     <div>
       <Header />
       <div className='flex min-h-screen flex-col px-6'>
-        <main className='flex flex-grow items-center justify-center *:min-h-64 *:min-w-64'>
-          {children}
-        </main>
+        <main className='flex flex-grow flex-col'>{children}</main>
         <Footer />
       </div>
     </div>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -9,7 +9,7 @@ export const Route = createFileRoute('/')({
 
 function HomePage() {
   return (
-    <div className='flex flex-col items-center'>
+    <div className='flex flex-1 flex-col items-center justify-center'>
       <img className='m-0' src='/images/xm.jpg' alt='' />
       <div className='mt-8 text-[2.5rem] font-black'>
         是个什么都不会的废物.jpg


### PR DESCRIPTION
AppLayout centered `<main>` (`items-center justify-center`), so short pages (notably /admin/comments) floated mid-viewport with empty bands above/below. Now content flows from the top; the homepage hero self-centers (`flex-1 justify-center`) so the landing look is unchanged. typecheck/biome/build/size green (gzip 1.15 MiB).