### PR TITLE
fix(web): revert top-align layout change (#79)

### DIFF
--- a/apps/web/src/components/layout.tsx
+++ b/apps/web/src/components/layout.tsx
@@ -11,7 +11,9 @@ export function AppLayout({ children }: AppLayoutProps) {
     <div>
       <Header />
       <div className='flex min-h-screen flex-col px-6'>
-        <main className='flex flex-grow flex-col'>{children}</main>
+        <main className='flex flex-grow items-center justify-center *:min-h-64 *:min-w-64'>
+          {children}
+        </main>
         <Footer />
       </div>
     </div>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -9,7 +9,7 @@ export const Route = createFileRoute('/')({
 
 function HomePage() {
   return (
-    <div className='flex flex-1 flex-col items-center justify-center'>
+    <div className='flex flex-col items-center'>
       <img className='m-0' src='/images/xm.jpg' alt='' />
       <div className='mt-8 text-[2.5rem] font-black'>
         是个什么都不会的废物.jpg


### PR DESCRIPTION
#79 regressed content max-width (columns stretched full-width). Reverting to the centered layout; will redo the top-align fix with a local preview before shipping.