### PR TITLE
fix(web): top-align content pages, keep homepage centered

### DIFF
--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -29,7 +29,7 @@ export const Route = createRootRoute({
   errorComponent: ({ error }) => (
     <RootDocument>
       <AppLayout>
-        <div className='mx-auto w-full max-w-[80ch] pt-24 lg:pt-32'>
+        <div className='mx-auto w-full self-start max-w-[80ch] pt-24 lg:pt-32'>
           <h2 className='mb-4 text-3xl'>Request Failed</h2>
           <p className='mb-4 opacity-70'>{String(error)}</p>
           <Link to='/blog' className='opacity-70 hover:opacity-100'>
@@ -42,7 +42,7 @@ export const Route = createRootRoute({
   notFoundComponent: () => (
     <RootDocument>
       <AppLayout>
-        <div className='mx-auto w-full max-w-[80ch] pt-24 lg:pt-32'>
+        <div className='mx-auto w-full self-start max-w-[80ch] pt-24 lg:pt-32'>
           <h2 className='mb-4 text-3xl'>404 Not Found</h2>
           <p className='mb-4 opacity-70'>你闯入了无人之境...</p>
           <Link to='/blog' className='opacity-70 hover:opacity-100'>

--- a/apps/web/src/routes/admin/$slug.tsx
+++ b/apps/web/src/routes/admin/$slug.tsx
@@ -19,7 +19,7 @@ export const Route = createFileRoute('/admin/$slug')({
 function EditPostPage() {
   const { post } = Route.useLoaderData();
   return (
-    <div className='mx-auto w-full max-w-5xl pt-24 lg:pt-28'>
+    <div className='mx-auto w-full self-start max-w-5xl pt-24 lg:pt-28'>
       <Link
         to='/admin'
         className='mb-4 inline-block text-sm opacity-60 hover:opacity-100'

--- a/apps/web/src/routes/admin/comments.tsx
+++ b/apps/web/src/routes/admin/comments.tsx
@@ -96,7 +96,7 @@ function AdminCommentsPage() {
   }
 
   return (
-    <div className='mx-auto w-full max-w-5xl pt-24 lg:pt-28'>
+    <div className='mx-auto w-full self-start max-w-5xl pt-24 lg:pt-28'>
       <Link
         to='/admin'
         className='mb-4 inline-block text-sm opacity-60 hover:opacity-100'

--- a/apps/web/src/routes/admin/index.tsx
+++ b/apps/web/src/routes/admin/index.tsx
@@ -28,7 +28,7 @@ function AdminListPage() {
   ).length;
 
   return (
-    <div className='mx-auto w-full max-w-5xl pt-24 lg:pt-28'>
+    <div className='mx-auto w-full self-start max-w-5xl pt-24 lg:pt-28'>
       <div className='mb-6 flex flex-wrap items-center justify-between gap-3'>
         <div>
           <h1 className='text-2xl font-black'>文章管理</h1>

--- a/apps/web/src/routes/admin/new.tsx
+++ b/apps/web/src/routes/admin/new.tsx
@@ -10,7 +10,7 @@ export const Route = createFileRoute('/admin/new')({
 
 function NewPostPage() {
   return (
-    <div className='mx-auto w-full max-w-5xl pt-24 lg:pt-28'>
+    <div className='mx-auto w-full self-start max-w-5xl pt-24 lg:pt-28'>
       <Link
         to='/admin'
         className='mb-4 inline-block text-sm opacity-60 hover:opacity-100'

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -77,7 +77,7 @@ function BlogDetailPage() {
   });
 
   return (
-    <div className='mx-auto w-full max-w-[80ch] pt-24 lg:pt-32'>
+    <div className='mx-auto w-full self-start max-w-[80ch] pt-24 lg:pt-32'>
       <div className='m-auto mb-8 flex flex-col gap-2'>
         <div className='text-3xl font-black'>{post.title}</div>
         <div className='opacity-60'>{date}</div>

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -71,7 +71,7 @@ function BlogListPage() {
 
   return (
     <div className='flex flex-col gap-8'>
-      <div className='mx-auto w-full max-w-[80ch] pt-24 lg:pt-32'>
+      <div className='mx-auto w-full self-start max-w-[80ch] pt-24 lg:pt-32'>
         {showDevHint ? (
           <div className='mb-8 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900'>
             {devScopeHint}

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -34,14 +34,14 @@ function LoginPage() {
 
   if (sessionData?.user?.id || isSessionPending) {
     return (
-      <section className='mx-auto w-full max-w-[80ch] pt-24 lg:pt-32'>
+      <section className='mx-auto w-full self-start max-w-[80ch] pt-24 lg:pt-32'>
         <p className='opacity-70'>Checking session...</p>
       </section>
     );
   }
 
   return (
-    <section className='mx-auto w-full max-w-[80ch] pt-24 lg:pt-32'>
+    <section className='mx-auto w-full self-start max-w-[80ch] pt-24 lg:pt-32'>
       <h1 className='mb-2 text-3xl font-black'>登录</h1>
       <p className='mb-6 opacity-70'>支持邮箱密码和 GitHub OAuth。</p>
 

--- a/apps/web/src/routes/logout.tsx
+++ b/apps/web/src/routes/logout.tsx
@@ -29,7 +29,7 @@ function LogoutPage() {
   }, [signOut]);
 
   return (
-    <section className='mx-auto w-full max-w-[80ch] pt-24 lg:pt-32'>
+    <section className='mx-auto w-full self-start max-w-[80ch] pt-24 lg:pt-32'>
       <h1 className='mb-2 text-3xl font-black'>退出登录</h1>
       <p className='mb-6 opacity-70'>
         {isPending ? '正在退出登录...' : '已退出或退出失败，请重试。'}

--- a/apps/web/src/routes/projects.tsx
+++ b/apps/web/src/routes/projects.tsx
@@ -25,7 +25,7 @@ function ProjectsPage() {
   const projects = sortProjects(PROJECTS);
 
   return (
-    <div className='mx-auto w-full max-w-[80ch] pt-24 lg:pt-32'>
+    <div className='mx-auto w-full self-start max-w-[80ch] pt-24 lg:pt-32'>
       <h1 className='mb-2 text-3xl font-black'>Projects</h1>
       <p className='mb-8 opacity-70'>我做过的一些东西，按需更新。</p>
 

--- a/apps/web/src/routes/signup.tsx
+++ b/apps/web/src/routes/signup.tsx
@@ -35,14 +35,14 @@ function SignUpPage() {
 
   if (sessionData?.user?.id || isSessionPending) {
     return (
-      <section className='mx-auto w-full max-w-[80ch] pt-24 lg:pt-32'>
+      <section className='mx-auto w-full self-start max-w-[80ch] pt-24 lg:pt-32'>
         <p className='opacity-70'>Checking session...</p>
       </section>
     );
   }
 
   return (
-    <section className='mx-auto w-full max-w-[80ch] pt-24 lg:pt-32'>
+    <section className='mx-auto w-full self-start max-w-[80ch] pt-24 lg:pt-32'>
       <h1 className='mb-2 text-3xl font-black'>注册</h1>
       <p className='mb-6 opacity-70'>注册后默认角色为 member，可在后台升权。</p>
 

--- a/apps/web/src/routes/unlock/$slug.tsx
+++ b/apps/web/src/routes/unlock/$slug.tsx
@@ -82,7 +82,7 @@ function UnlockPage() {
         : undefined;
 
   return (
-    <section className='mx-auto w-full max-w-[80ch] pt-24 lg:pt-32'>
+    <section className='mx-auto w-full self-start max-w-[80ch] pt-24 lg:pt-32'>
       <h1 className='mb-2 text-3xl font-black'>输入文章访问密码</h1>
       <p className='mb-6 opacity-70'>这篇文章使用了单文密码保护。</p>
 


### PR DESCRIPTION
Addresses the admin-page-floating complaint safely: add `self-start` to each content-page container (admin/blog/projects/login/…) so they top-align, while **<main> and the homepage are untouched** — homepage stays centered, all max-widths unaffected. Supersedes #79 (which I reverted in #80 after it regressed max-width). Verified typecheck/biome/build/size; will confirm on the preview deploy before merge.