### PR TITLE
fix(ci): render the preview-deploy comment heading

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -92,7 +92,7 @@ jobs:
             const num = context.payload.pull_request.number;
             const url = `https://blog-web-pr-${num}.perfectpan325.workers.dev`;
             const marker = '<!-- preview-deploy -->';
-            const body = `${marker}### 🌐 Preview deploy\n\n${url}\n\n_(public; rebuilt on every push)_`;
+            const body = `${marker}\n\n### 🌐 Preview deploy\n\n${url}\n\n_(public; rebuilt on every push)_`;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner, repo: context.repo.repo, issue_number: num,
             });


### PR DESCRIPTION
The preview-deploy bot comment glued its find-marker onto the same line as the heading, so GitHub rendered `###` as literal text. Fix: marker on its own line + blank line before the heading. Self-verifying — this PR's own preview job posts the comment with the new template.