### PR TITLE
fix(web): use shiki JS regex engine to stop intermittent article 500s

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,8 +58,8 @@ jobs:
           done
           echo "::error::dev server did not come up"; cat dev.log; exit 1
 
-      # Prime the dev server (first SSR hits compile shiki WASM / transforms and
-      # are slow on a cold CI worker, which made the auth tests flake with
+      # Prime the dev server (first SSR hits compile shiki grammars / transforms
+      # and are slow on a cold CI worker, which made the auth tests flake with
       # net::ERR_ABORTED). Hit each route a few times before the tests run.
       - name: Warm up dev server
         run: |

--- a/apps/web/src/components/comment-markdown.tsx
+++ b/apps/web/src/components/comment-markdown.tsx
@@ -9,8 +9,8 @@ type CommentMarkdownProps = {
  * Lightweight markdown renderer for comments.
  *
  * Deliberately does NOT reuse the post-body `<Markdown>` component: that one
- * pulls in shiki (oniguruma + WASM) and katex, which would balloon this client
- * island. Comments only need inline formatting + code/links/lists, so we run
+ * pulls in shiki + katex, which would balloon this client island. Comments
+ * only need inline formatting + code/links/lists, so we run
  * react-markdown + remark-gfm with no heavy rehype plugins.
  *
  * XSS posture matches docs/architecture.md §8: no `rehype-raw` (raw HTML is

--- a/apps/web/src/components/markdown.tsx
+++ b/apps/web/src/components/markdown.tsx
@@ -12,7 +12,11 @@ import rehypeKatex from 'rehype-katex';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import { createHighlighterCore } from 'shiki/core';
-import { createOnigurumaEngine } from 'shiki/engine/oniguruma';
+// JS regex engine, NOT oniguruma WASM: WebAssembly.instantiate failed
+// intermittently on the Worker under memory/CPU pressure, 500-ing article SSR
+// (logs 2026-07-26 ~05:45 UTC). shiki's JS engine needs no WASM and is the
+// recommended engine for edge runtimes. Don't switch back to oniguruma.
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
 
 type MarkdownProps = {
   content: string;
@@ -51,7 +55,7 @@ const highlighter = await createHighlighterCore({
     import('shiki/langs/rust.mjs'),
     import('shiki/langs/sql.mjs'),
   ],
-  engine: createOnigurumaEngine(() => import('shiki/wasm')),
+  engine: createJavaScriptRegexEngine(),
 });
 
 /**


### PR DESCRIPTION
## Root cause

Opening articles intermittently hung for minutes and returned **500**. Prod Workers Observability logs (`blog-web`, 2026-07-26 ~05:45 UTC) show 17 errors, all the same:

```
Error in renderToReadableStream
  at WebAssembly.instantiate (wasm-instantiate-shim.js)
  at Module.getWasmInstance
  at createOnigurumaEngine
  at createHighlighterCore
```

`markdown.tsx` built the shiki highlighter with the **oniguruma WASM engine** at module top-level. On the Worker, `WebAssembly.instantiate` failed intermittently under memory/CPU pressure (bot traffic amplifies it) → article SSR **and** the `_serverFn` loader threw 500 → the client retried/hung → the multi-minute "卡" you saw. Intermittent by nature (0 errors in the surrounding 30 min), which is why a one-off load usually looks fine.

## Fix

Switch the shiki engine from oniguruma-WASM to the **JS regex engine** (`shiki/engine/javascript`):

```diff
-import { createOnigurumaEngine } from 'shiki/engine/oniguruma';
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
 ...
-engine: createOnigurumaEngine(() => import('shiki/wasm')),
+engine: createJavaScriptRegexEngine(),
```

No WASM at all → no `WebAssembly.instantiate` → the failure mode is gone. This is the engine shiki recommends for edge runtimes; it also shrinks the per-isolate footprint and speeds cold starts. Trade-off: a few grammars may highlight marginally differently (code still renders).

## Verification

- `tsc --noEmit` clean, `vite build` green.
- Post-build grep: **no `.wasm` emitted**, `WebAssembly.instantiate` count **0** in server markdown chunk + worker entry, JS engine present.
- The only residual `createOnigurumaEngine` token is a deprecation-warning string (uncalled).

## Review

Per-PR preview deploy will post a clickable URL here — please eyeball a code-heavy post (e.g. the code blocks) before merge. No merge until you give the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)