### PR TITLE
fix(web): reset main scroll on blog nav and stabilize list width

### DIFF
--- a/apps/web/src/components/layout.tsx
+++ b/apps/web/src/components/layout.tsx
@@ -1,5 +1,4 @@
-import { useRouterState } from '@tanstack/react-router';
-import { type ReactNode, useEffect, useRef } from 'react';
+import type { ReactNode } from 'react';
 import { Footer } from './footer.js';
 import { Header } from './header.js';
 
@@ -10,23 +9,15 @@ type AppLayoutProps = {
 /**
  * App shell. The header sits OUTSIDE the scroll container (`main`), so page
  * overscroll only rubber-bands the content — the pinned header never moves
- * (no macOS "fixed header drags on overscroll"). The window itself doesn't
- * scroll, so we reset the `main` scroll position on route change ourselves
- * (the browser / TanStack window-scroll-restoration targets the window).
+ * (no macOS "fixed header drags on overscroll"). Window doesn't scroll; route
+ * scroll reset/restore for `main` is handled by TanStack via
+ * `scrollToTopSelectors: ['main']` in router.tsx.
  */
 export function AppLayout({ children }: AppLayoutProps) {
-  const mainRef = useRef<HTMLElement>(null);
-  const pathname = useRouterState({ select: (s) => s.location.pathname });
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: reset on route change, pathname unused in body on purpose
-  useEffect(() => {
-    mainRef.current?.scrollTo({ top: 0 });
-  }, [pathname]);
-
   return (
     <div className='flex h-dvh flex-col'>
       <Header />
-      <main ref={mainRef} className='flex-1 overflow-y-auto'>
+      <main className='flex-1 overflow-y-auto'>
         <div className='flex min-h-full flex-col'>
           <div className='flex flex-grow items-center justify-center px-6 *:min-h-64 *:min-w-64'>
             {children}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -8,6 +8,9 @@ export function getRouter() {
     routerInstance = createRouter({
       routeTree,
       scrollRestoration: true,
+      // App scroll lives on <main>, not window — without this, TanStack carries
+      // the previous route's main.scrollTop into the next page on PUSH.
+      scrollToTopSelectors: ['main'],
       defaultPreload: 'intent',
     });
   }

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -86,8 +86,8 @@ function BlogListPage() {
   }, [data.page]);
 
   return (
-    <div className='flex flex-col gap-8 self-start'>
-      <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
+    <div className='mx-auto flex w-full max-w-[80ch] flex-col gap-8 self-start pt-8'>
+      <div className='w-full'>
         {showDevHint ? (
           <div className='mb-8 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900'>
             {devScopeHint}
@@ -121,7 +121,7 @@ function BlogListPage() {
       </div>
       {data.totalPages > 1 ? (
         <nav
-          className='mx-auto flex w-full max-w-[80ch] items-center justify-center gap-4 text-sm sm:gap-6'
+          className='flex w-full items-center justify-center gap-4 text-sm sm:gap-6'
           aria-label='Pagination'
         >
           {data.page > 1 ? (


### PR DESCRIPTION
## Summary
- Fix list → post keeping the list `scrollTop` (scroll lives on `<main>`; TanStack needs `scrollToTopSelectors: ['main']`).
- Fix blog list horizontal jump when titles are short vs long by giving the list root a stable `w-full max-w-[80ch]` like the detail page.

## Test plan
- [x] Local `pnpm dev` + agent-browser: scroll list to 800 → click post → `main.scrollTop === 0`, title near top
- [x] agent-browser: `/blog?page=1` vs `?page=2` same `left`/`width` (785.625) despite title length range 3–52 vs 4–52
- [ ] Preview: visual check list pagination + open a mid-list post