### PR TITLE
docs: add ux redesign prototype gallery (7 directions)

### DIFF
--- a/prototypes/a-terminal.html
+++ b/prototypes/a-terminal.html
@@ -1,0 +1,683 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>方向 A · 终端会话 · PerfectPan's Blog 原型</title>
+<style>
+  /* ============ tokens ============ */
+  :root {
+    --bg: #0A0F14;          /* page backdrop */
+    --term: #0C1218;        /* terminal bg */
+    --panel: #101923;       /* raised panel */
+    --line: #1D2A37;        /* borders */
+    --text: #C9D4DE;        /* main text */
+    --dim: #71828F;         /* secondary */
+    --faint: #465666;       /* faint */
+    --amber: #E9B44C;       /* prompt / cursor / interactive */
+    --cyan: #6FC5D8;        /* links / dirs */
+    --green: #7CBF8B;       /* published / success */
+    --red: #E06C75;         /* danger / errors */
+    --violet: #A78BC4;     /* vip */
+    --sel: #16222E;
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo, Consolas, "PingFang SC", "Microsoft YaHei", monospace;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scrollbar-color: #24313E var(--bg); }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--mono);
+    font-size: 14.5px;
+    line-height: 1.75;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+  a { color: var(--cyan); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  :focus-visible { outline: 1px dashed var(--amber); outline-offset: 3px; }
+
+  /* ============ prototype chrome (非站点 UI) ============ */
+  .pt-bar {
+    background: #16191D;
+    border-bottom: 1px solid #23262B;
+    font-family: "PingFang SC", system-ui, sans-serif;
+    font-size: 12.5px;
+    padding: 0 16px;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    flex-wrap: wrap;
+    color: #9A9FA6;
+    position: sticky; top: 0; z-index: 50;
+  }
+  .pt-bar .pt-title { color: #E8B14A; font-weight: 700; letter-spacing: 0.06em; }
+  .pt-bar nav { display: flex; gap: 2px; flex-wrap: wrap; }
+  .pt-tab {
+    font-family: inherit; font-size: 12.5px; color: #9A9FA6;
+    background: none; border: 0; padding: 9px 10px; cursor: pointer;
+  }
+  .pt-tab:hover { color: #E8E9EA; }
+  .pt-tab.active { color: #16191D; background: #E8B14A; font-weight: 700; }
+  .pt-links { margin-left: auto; display: flex; gap: 12px; }
+  .pt-links a { color: #63686F; }
+  .pt-links a:hover { color: #E8B14A; text-decoration: none; }
+
+  /* ============ terminal window ============ */
+  .term-shell { flex: 1; display: flex; padding: 28px 16px 60px; justify-content: center; }
+  .term {
+    width: 100%; max-width: 1060px;
+    background: var(--term);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    box-shadow: 0 0 0 1px rgba(0,0,0,0.4), 0 18px 60px rgba(0,0,0,0.45);
+    display: flex; flex-direction: column;
+    align-self: flex-start;
+    min-height: calc(100vh - 200px);
+  }
+  .term-titlebar {
+    display: flex; align-items: center; gap: 8px;
+    padding: 10px 14px; border-bottom: 1px solid var(--line);
+    background: linear-gradient(#0E1620, #0C1218);
+    border-radius: 10px 10px 0 0;
+    position: sticky; top: 44px; z-index: 10;
+  }
+  .dot { width: 11px; height: 11px; border-radius: 50%; }
+  .dot.r { background: #E5544B; } .dot.y { background: #D8A03C; } .dot.g { background: #47A258; }
+  .term-titlebar .t { margin-left: 8px; color: var(--dim); font-size: 12.5px; }
+  .term-titlebar .t b { color: var(--text); font-weight: 600; }
+  .term-titlebar .t .path { color: var(--cyan); }
+
+  .term-body { padding: 22px 26px 30px; overflow-x: auto; }
+
+  .page[hidden] { display: none; }
+
+  /* ============ prompt primitives ============ */
+  .pl { display: flex; gap: 10px; align-items: baseline; flex-wrap: wrap; }
+  .pl .u { color: var(--cyan); }
+  .pl .at { color: var(--faint); }
+  .pl .h { color: var(--green); }
+  .pl .p { color: var(--amber); }
+  .pl .cmd { color: var(--text); }
+  .out { padding-left: 0; margin: 4px 0; }
+  .comment { color: var(--faint); }
+  .hr { border: 0; border-top: 1px dashed var(--line); margin: 18px 0; }
+  .cursor {
+    display: inline-block; width: 8px; height: 1.15em; background: var(--amber);
+    vertical-align: text-bottom; animation: blink 1.1s steps(1) infinite;
+  }
+  @keyframes blink { 50% { opacity: 0; } }
+  @media (prefers-reduced-motion: reduce) {
+    .cursor { animation: none; }
+    .type { animation: none !important; width: auto !important; }
+  }
+
+  /* home typing */
+  .type {
+    display: inline-block; overflow: hidden; white-space: nowrap; vertical-align: bottom;
+    border-right: 8px solid var(--amber);
+    width: 17ch; animation: type 1.4s steps(17) .4s both, blinkcaret 1.1s steps(1) infinite;
+  }
+  @keyframes type { from { width: 0; } to { width: 17ch; } }
+  @keyframes blinkcaret { 50% { border-color: transparent; } }
+  .fade { animation: fadein .5s both; }
+  .fade.d1 { animation-delay: 1.6s } .fade.d2 { animation-delay: 1.9s } .fade.d3 { animation-delay: 2.2s } .fade.d4 { animation-delay: 2.5s } .fade.d5 { animation-delay: 2.8s }
+  @keyframes fadein { from { opacity: 0; } to { opacity: 1; } }
+
+  /* ============ home ============ */
+  .hero-name { font-size: 21px; color: #EAF1F7; font-weight: 700; margin-top: 14px; }
+  .hero-desc { color: var(--dim); max-width: 62ch; margin-top: 6px; }
+  .figlet { white-space: pre; color: var(--faint); line-height: 1.25; font-size: 11px; margin-top: 18px; user-select: none; }
+  .figlet b { color: var(--amber); font-weight: 400; }
+  .home-links { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 12px; margin-top: 22px; }
+  .home-links a {
+    display: block; border: 1px solid var(--line); background: var(--panel);
+    padding: 14px 16px; border-radius: 6px; color: var(--text);
+  }
+  .home-links a:hover { border-color: var(--amber); text-decoration: none; box-shadow: 0 0 18px rgba(233,180,76,0.07); }
+  .home-links a .k { color: var(--amber); }
+  .home-links a small { display: block; color: var(--dim); margin-top: 2px; }
+
+  /* ============ ls table (blog) ============ */
+  .ls { margin-top: 14px; }
+  .ls .row {
+    display: grid;
+    grid-template-columns: 11ch 7.5ch 6.5ch 8ch 1fr auto;
+    gap: 0 14px; padding: 5px 8px; border-radius: 4px;
+    align-items: baseline;
+  }
+  .ls .row.head { color: var(--faint); font-size: 12.5px; }
+  .ls a.row { color: var(--text); }
+  .ls a.row:hover { background: var(--sel); text-decoration: none; }
+  .ls .year { grid-column: 1 / -1; color: var(--amber); margin-top: 22px; font-weight: 700; }
+  .ls .year::before { content: "# "; color: var(--faint); font-weight: 400; }
+  .perms span { letter-spacing: 0.08em; }
+  .perm-guest { color: var(--green); }
+  .perm-mem { color: var(--cyan); }
+  .perm-vip { color: var(--violet); }
+  .perm-pw { color: var(--red); }
+  .ls .date, .ls .vis { color: var(--dim); font-size: 13px; }
+  .ls .size { color: var(--faint); font-size: 13px; text-align: right; }
+  .ls .title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .ls .tags { color: var(--faint); font-size: 12.5px; }
+  .pager { display: flex; gap: 18px; justify-content: center; margin-top: 26px; color: var(--dim); }
+  .pager a { color: var(--amber); }
+  .legend { margin-top: 26px; color: var(--faint); font-size: 12.5px; line-height: 1.9; }
+
+  /* ============ article ============ */
+  .art-head { margin: 18px 0 26px; }
+  .art-head h1 { font-size: 24px; color: #EAF1F7; font-weight: 700; line-height: 1.4; }
+  .art-head .meta { color: var(--dim); margin-top: 6px; font-size: 13px; display: flex; gap: 16px; flex-wrap: wrap; }
+  .md { max-width: 74ch; }
+  .md p { margin: 14px 0; color: var(--text); }
+  .md h2 { font-size: 17px; color: #EAF1F7; margin: 30px 0 10px; }
+  .md h2::before { content: "## "; color: var(--faint); font-weight: 400; }
+  .md ul { margin: 12px 0 12px 22px; }
+  .md li { margin: 4px 0; }
+  .md li::marker { color: var(--amber); }
+  .md blockquote {
+    border-left: 2px solid var(--amber); background: var(--panel);
+    padding: 10px 16px; margin: 16px 0; color: var(--dim); border-radius: 0 6px 6px 0;
+  }
+  .md code.inline { background: var(--panel); border: 1px solid var(--line); padding: 1px 6px; border-radius: 4px; font-size: 13px; color: var(--amber); }
+  .pre-wrap { position: relative; margin: 18px 0; }
+  .pre-wrap .fname {
+    position: absolute; top: -1px; right: 14px; background: var(--line); color: var(--dim);
+    font-size: 11.5px; padding: 2px 10px; border-radius: 0 0 6px 6px;
+  }
+  pre.code {
+    background: #0A1016; border: 1px solid var(--line); border-radius: 8px;
+    padding: 18px; overflow-x: auto; line-height: 1.7; font-size: 13px;
+  }
+  .kw { color: #C792EA; } .fn { color: #82AAFF; } .str { color: #C3E88D; }
+  .num { color: #F78C6C; } .com { color: #546E7A; } .ty { color: #FFCB6B; }
+
+  /* comments */
+  .cmt { border: 1px solid var(--line); border-radius: 8px; margin: 12px 0; overflow: hidden; }
+  .cmt .cmt-h { display: flex; gap: 10px; align-items: center; background: var(--panel); padding: 8px 14px; font-size: 13px; color: var(--dim); border-bottom: 1px solid var(--line); }
+  .cmt .cmt-h .who { color: var(--text); }
+  .cmt .cmt-b { padding: 10px 14px; }
+  .cmt .cmt-b p { margin: 0; }
+  .cmt.reply { margin-left: 34px; }
+  .cmt-form { display: flex; gap: 10px; margin-top: 16px; }
+  .cmt-form input[type=text] { flex: 1; }
+
+  /* ============ forms ============ */
+  input[type=text], input[type=email], input[type=password], textarea, select {
+    font-family: var(--mono); font-size: 14px; color: var(--text);
+    background: var(--panel); border: 1px solid var(--line); border-radius: 6px;
+    padding: 9px 12px; width: 100%;
+  }
+  input::placeholder, textarea::placeholder { color: var(--faint); }
+  input:focus, textarea:focus, select:focus { outline: none; border-color: var(--amber); box-shadow: 0 0 0 2px rgba(233,180,76,0.15); }
+  .field { margin: 14px 0; max-width: 460px; }
+  .field label { display: block; color: var(--dim); font-size: 13px; margin-bottom: 5px; }
+  .field label::before { content: "▸ "; color: var(--amber); }
+  .btn {
+    font-family: var(--mono); font-size: 13.5px; cursor: pointer;
+    background: var(--panel); color: var(--text);
+    border: 1px solid var(--line); border-radius: 6px; padding: 9px 18px;
+    transition: border-color .12s, color .12s;
+  }
+  .btn:hover { border-color: var(--amber); color: var(--amber); }
+  .btn.primary { background: var(--amber); border-color: var(--amber); color: #171106; font-weight: 700; }
+  .btn.primary:hover { background: #F0C268; color: #171106; }
+  .btn.danger:hover { border-color: var(--red); color: var(--red); }
+  .form-panel { max-width: 560px; }
+  .err { color: var(--red); margin: 10px 0; }
+  .err::before { content: "✗ "; }
+
+  /* ============ admin TUI ============ */
+  .tui { border: 1px solid var(--line); border-radius: 8px; overflow: hidden; margin-top: 16px; }
+  .tui-bar { background: var(--panel); border-bottom: 1px solid var(--line); padding: 8px 14px; display: flex; gap: 16px; align-items: center; flex-wrap: wrap; }
+  .tui-bar .tname { color: var(--amber); font-weight: 700; }
+  .tui-bar .thint { margin-left: auto; color: var(--faint); font-size: 12px; }
+  table.tui-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  .tui-table th { text-align: left; color: var(--faint); font-weight: 400; padding: 8px 14px; border-bottom: 1px solid var(--line); font-size: 12px; }
+  .tui-table td { padding: 8px 14px; border-bottom: 1px solid #131E29; color: var(--text); }
+  .tui-table tr:hover td { background: var(--sel); }
+  .badge { font-size: 11px; border: 1px solid var(--line); border-radius: 4px; padding: 1px 7px; color: var(--dim); }
+  .badge.pub { color: var(--green); border-color: rgba(124,191,139,0.35); }
+  .badge.mem { color: var(--cyan); border-color: rgba(111,197,216,0.35); }
+  .badge.vip { color: var(--violet); border-color: rgba(167,139,196,0.35); }
+  .badge.pw { color: var(--red); border-color: rgba(224,108,117,0.35); }
+  .badge.draft { color: var(--dim); }
+  .tui-table .ops a { margin-right: 10px; }
+  .editor-meta { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 0 20px; }
+  textarea.md-area { min-height: 340px; line-height: 1.8; }
+  .editor-foot { display: flex; gap: 12px; margin-top: 14px; align-items: center; flex-wrap: wrap; }
+  .editor-foot .stat { color: var(--faint); font-size: 12.5px; margin-left: auto; }
+
+  /* ============ 404 ============ */
+  .nf { padding: 40px 0; }
+  .nf .big { color: var(--red); font-size: 15px; }
+
+  /* ============ tmux status bar ============ */
+  .tmux {
+    margin-top: auto;
+    background: #10161D; border-top: 1px solid var(--line);
+    padding: 5px 12px; display: flex; align-items: center; gap: 4px;
+    font-size: 12.5px; border-radius: 0 0 10px 10px; flex-wrap: wrap;
+  }
+  .tmux .sess { color: var(--bg); background: var(--green); padding: 1px 8px; border-radius: 3px; margin-right: 8px; font-weight: 700; }
+  .tmux-win { color: var(--dim); background: none; border: 0; font: inherit; padding: 1px 8px; cursor: pointer; border-radius: 3px; }
+  .tmux-win:hover { color: var(--text); }
+  .tmux-win.on { background: var(--term); color: var(--amber); box-shadow: inset 0 0 0 1px var(--line); }
+  .tmux .right { margin-left: auto; color: var(--faint); display: flex; gap: 14px; }
+
+  /* ============ grep palette (⌘K) ============ */
+  .pal-veil {
+    position: fixed; inset: 0; background: rgba(4,8,12,0.7); backdrop-filter: blur(2px);
+    display: flex; justify-content: center; padding-top: 12vh; z-index: 100;
+  }
+  .pal-veil[hidden] { display: none; }
+  .pal {
+    width: min(640px, calc(100vw - 32px)); height: fit-content;
+    background: var(--term); border: 1px solid #2A3A4A; border-radius: 10px;
+    box-shadow: 0 24px 80px rgba(0,0,0,0.6); overflow: hidden;
+  }
+  .pal-in { display: flex; gap: 10px; align-items: center; padding: 13px 16px; border-bottom: 1px solid var(--line); }
+  .pal-in .p { color: var(--amber); }
+  .pal-in input { background: none; border: 0; padding: 0; font-size: 15px; }
+  .pal-in input:focus { box-shadow: none; border: none; }
+  .pal-list { max-height: 320px; overflow-y: auto; }
+  .pal-item { display: flex; gap: 12px; padding: 10px 16px; align-items: baseline; }
+  .pal-item .d { color: var(--faint); font-size: 12px; min-width: 7ch; }
+  .pal-item.sel, .pal-item:hover { background: var(--sel); }
+  .pal-foot { border-top: 1px solid var(--line); padding: 7px 16px; color: var(--faint); font-size: 11.5px; }
+
+  @media (max-width: 720px) {
+    .ls .row { grid-template-columns: 9ch 1fr auto; }
+    .ls .row.head, .ls .vis, .ls .size { display: none; }
+    .term-titlebar { position: static; }
+    .term-body { padding: 16px 14px 22px; }
+  }
+</style>
+</head>
+<body>
+
+<!-- prototype chrome -->
+<div class="pt-bar">
+  <span class="pt-title">原型 · 方向 A 终端会话</span>
+  <nav aria-label="原型页面">
+    <button class="pt-tab active" data-target="home">首页</button>
+    <button class="pt-tab" data-target="blog">博客列表</button>
+    <button class="pt-tab" data-target="post">文章页</button>
+    <button class="pt-tab" data-target="projects">项目</button>
+    <button class="pt-tab" data-target="login">登录</button>
+    <button class="pt-tab" data-target="signup">注册</button>
+    <button class="pt-tab" data-target="unlock">解锁</button>
+    <button class="pt-tab" data-target="admin">后台</button>
+    <button class="pt-tab" data-target="editor">编辑器</button>
+    <button class="pt-tab" data-target="404">404</button>
+  </nav>
+  <div class="pt-links"><a href="index.html">总览</a><a href="b-journal.html">方向 B</a><a href="c-swiss.html">方向 C</a></div>
+</div>
+
+<div class="term-shell">
+  <div class="term">
+    <div class="term-titlebar">
+      <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+      <span class="t"><b>perfectpan@blog</b> — <span class="path">~/perfectpan.org</span> — ⌘K grep</span>
+    </div>
+
+    <div class="term-body">
+
+      <!-- ================= HOME ================= -->
+      <section class="page" data-page="home">
+        <div class="pl"><span class="u">perfectpan</span><span class="at">@</span><span class="h">blog</span> <span class="p">~ %</span> <span class="type">whoami --verbose</span></div>
+        <div class="out fade d1">
+          <div class="hero-name">PerfectPan</div>
+          <p class="hero-desc">写代码的人。算法竞赛退役选手，现在的兴趣在前端工程、类型体操和把东西跑在 Cloudflare 免费额度上。</p>
+          <div class="figlet" aria-hidden="true">  ____              _   _        _   ____  __  __ ____
+ |  _ \ _   _  __ _| |_| |__    / \ |  _ \|  \/  |  _ \
+ | |_) | | | |/ _` | __| '_ \  / _ \| |_) | |\/| | |_) |
+ |  __/| |_| | (_| | |_| | | |/ ___ \  __/| |  | |  __/
+ |_|    \__,_|\__,_|\__|_| |_/_/   \_\_|  |_|  |_|_|   <b>.dev</b></div>
+        </div>
+        <div class="pl fade d2" style="margin-top:20px"><span class="u">perfectpan</span><span class="at">@</span><span class="h">blog</span> <span class="p">~ %</span> <span class="cmd">cat motd.txt</span></div>
+        <p class="out comment fade d2"># 是个什么都不会的废物.jpg —— 但还在写。</p>
+        <div class="home-links fade d3">
+          <a href="#" onclick="return false"><span class="k">open blog/</span><small>16 篇文章 · 算法 / TypeScript / 随笔</small></a>
+          <a href="#" onclick="return false"><span class="k">open projects/</span><small>5 个开源项目 · Rust / TS / Moonbit</small></a>
+        </div>
+        <div class="pl fade d4" style="margin-top:26px"><span class="u">perfectpan</span><span class="at">@</span><span class="h">blog</span> <span class="p">~ %</span> <span class="cursor"></span></div>
+      </section>
+
+      <!-- ================= BLOG LIST ================= -->
+      <section class="page" data-page="blog" hidden>
+        <div class="pl"><span class="u">perfectpan</span><span class="at">@</span><span class="h">blog</span> <span class="p">~/posts %</span> <span class="cmd">ls -la --group-directories-first</span></div>
+
+        <div class="ls">
+          <div class="row head"><span>perms</span><span>date</span><span>read</span><span class="vis">vis</span><span>title</span><span class="size">tags</span></div>
+
+          <div class="year">2023</div>
+          <a class="row" href="#" onclick="return false">
+            <span class="perms"><span class="perm-guest">-r--r--r--</span></span><span class="date">02-18</span><span class="size">6m</span><span class="vis comment">public</span><span class="title">初探 Github Blocks</span><span class="tags">Misc</span>
+          </a>
+
+          <div class="year">2021</div>
+          <a class="row" href="#" onclick="return false">
+            <span class="perms"><span class="perm-guest">-r--r--r--</span></span><span class="date">05-08</span><span class="size">9m</span><span class="vis comment">public</span><span class="title">Type Challenge - 冒泡排序</span><span class="tags">TypeScript</span>
+          </a>
+          <a class="row" href="#" onclick="return false">
+            <span class="perms"><span class="perm-mem">-r--r-----</span></span><span class="date">02-28</span><span class="size">11m</span><span class="vis comment">member</span><span class="title">回顾 2020</span><span class="tags">Life</span>
+          </a>
+
+          <div class="year">2020</div>
+          <a class="row" href="#" onclick="return false">
+            <span class="perms"><span class="perm-guest">-r--r--r--</span></span><span class="date">08-26</span><span class="size">7m</span><span class="vis comment">public</span><span class="title">一些随想</span><span class="tags">随笔</span>
+          </a>
+          <a class="row" href="#" onclick="return false">
+            <span class="perms"><span class="perm-guest">-r--r--r--</span></span><span class="date">04-13</span><span class="size">32m</span><span class="vis comment">public</span><span class="title">LeetCode 中国区 TypeScript 面试题题解</span><span class="tags">TypeScript</span>
+          </a>
+          <a class="row" href="#" onclick="return false">
+            <span class="perms"><span class="perm-guest">-r--r--r--</span></span><span class="date">03-30</span><span class="size">21m</span><span class="vis comment">public</span><span class="title">那些年邂逅的 LeetCode 趣/难题</span><span class="tags">LeetCode</span>
+          </a>
+          <a class="row" href="#" onclick="return false">
+            <span class="perms"><span class="perm-pw">-r--------</span></span><span class="date">03-01</span><span class="size">8m</span><span class="vis comment">password</span><span class="title">文档书写要点整理</span><span class="tags">—</span>
+          </a>
+
+          <div class="year">2019</div>
+          <a class="row" href="#" onclick="return false">
+            <span class="perms"><span class="perm-vip">-r----r---</span></span><span class="date">12-31</span><span class="size">12m</span><span class="vis comment">vip</span><span class="title">回顾 2019</span><span class="tags">Life</span>
+          </a>
+          <a class="row" href="#" onclick="return false">
+            <span class="perms"><span class="perm-guest">-r--r--r--</span></span><span class="date">12-14</span><span class="size">15m</span><span class="vis comment">public</span><span class="title">Codeforces Round#605(Div. 3) D/E/F 题解</span><span class="tags">DP · BFS</span>
+          </a>
+          <a class="row" href="#" onclick="return false">
+            <span class="perms"><span class="perm-guest">-r--r--r--</span></span><span class="date">12-01</span><span class="size">13m</span><span class="vis comment">public</span><span class="title">Codeforces Round#603(Div. 2) E/F 题解</span><span class="tags">DP · Stack</span>
+          </a>
+          <a class="row" href="#" onclick="return false">
+            <span class="perms"><span class="perm-guest">-r--r--r--</span></span><span class="date">09-17</span><span class="size">10m</span><span class="vis comment">public</span><span class="title">银联极客高校挑战赛复赛 D 多项式</span><span class="tags">DP</span>
+          </a>
+          <a class="row" href="#" onclick="return false">
+            <span class="perms"><span class="perm-guest">-r--r--r--</span></span><span class="date">04-30</span><span class="size">18m</span><span class="vis comment">public</span><span class="title">Codeforces 1149B Three Religions</span><span class="tags">DP · String</span>
+          </a>
+          <a class="row" href="#" onclick="return false">
+            <span class="perms"><span class="perm-guest">-r--r--r--</span></span><span class="date">04-22</span><span class="size">9m</span><span class="vis comment">public</span><span class="title">2019 ICPC 南昌邀请赛网络赛 G. tsy's number</span><span class="tags">Number Theory</span>
+          </a>
+        </div>
+
+        <div class="pager">
+          <a href="#" onclick="return false">← prev</a>
+          <span>page 1 / 2</span>
+          <a href="#" onclick="return false">next →</a>
+        </div>
+
+        <p class="legend"># perms = 可见性：owner / member / guest 三组读权限<br># <span class="perm-guest">-r--r--r--</span> 公开 · <span class="perm-mem">-r--r-----</span> 登录可见 · <span class="perm-vip">-r----r---</span> VIP · <span class="perm-pw">-r--------</span> 需密码</p>
+
+        <hr class="hr">
+        <div class="pl"><span class="u">perfectpan</span><span class="at">@</span><span class="h">blog</span> <span class="p">~/posts %</span> <span class="cmd" style="color:var(--dim)">cd ..</span> <span class="cursor"></span></div>
+      </section>
+
+      <!-- ================= ARTICLE ================= -->
+      <section class="page" data-page="post" hidden>
+        <div class="pl"><span class="u">perfectpan</span><span class="at">@</span><span class="h">blog</span> <span class="p">~/posts %</span> <span class="cmd">cat 2021/type-challenge-bubble-sort.md</span></div>
+
+        <div class="art-head">
+          <h1>Type Challenge - 冒泡排序</h1>
+          <div class="meta"><span>2021-05-08</span><span>·</span><span>9 min read</span><span>·</span><span class="perm-guest">public</span><span>·</span><span>#TypeScript</span></div>
+        </div>
+
+        <div class="md">
+          <p>这题要求在类型系统里实现冒泡排序：给定一个元组 <code class="inline">T extends number[]</code>，返回排序后的元组。类型层面上没有循环，所以核心思路是把「一趟冒泡」展开成递归。</p>
+
+          <h2>一趟冒泡：两两比较并交换</h2>
+          <p>先写一个 <code class="inline">Pass</code>，从头到尾扫一遍，相邻逆序就交换。它递归地消费元组的头部两个元素：</p>
+
+          <div class="pre-wrap"><span class="fname">bubble.ts</span>
+<pre class="code"><span class="com">// 一趟冒泡：相邻比较，逆序则交换</span>
+<span class="kw">type</span> <span class="ty">Pass</span>&lt;<span class="ty">T</span> <span class="kw">extends</span> <span class="ty">number</span>[]&gt; =
+  <span class="ty">T</span> <span class="kw">extends</span> [<span class="ty">infer</span> <span class="ty">A</span> <span class="kw">extends</span> <span class="ty">number</span>, <span class="ty">infer</span> <span class="ty">B</span> <span class="kw">extends</span> <span class="ty">number</span>, ...<span class="ty">infer</span> <span class="ty">R</span> <span class="kw">extends</span> <span class="ty">number</span>[]]
+    ? <span class="ty">A</span> <span class="kw">extends</span> <span class="str">`${B}`</span> <span class="kw">?</span> <span class="ty">Pass</span>&lt;[<span class="ty">B</span>, ...<span class="ty">R</span>]&gt; <span class="kw">extends</span> <span class="ty">infer</span> <span class="ty">X</span> <span class="kw">extends</span> <span class="ty">number</span>[]
+        ? [<span class="ty">A</span>, ...<span class="ty">X</span>]
+        : <span class="kw">never</span>
+    : [<span class="ty">B</span>, ...<span class="ty">Pass</span>&lt;[<span class="ty">A</span>, ...<span class="ty">R</span>]&gt;]
+    : <span class="ty">T</span>;
+
+<span class="kw">type</span> <span class="fn">BubbleSort</span>&lt;<span class="ty">T</span> <span class="kw">extends</span> <span class="ty">number</span>[]&gt; =
+  <span class="ty">Pass</span>&lt;<span class="ty">T</span>&gt; <span class="kw">extends</span> <span class="ty">infer</span> <span class="ty">P</span> <span class="kw">extends</span> <span class="ty">number</span>[]
+    ? <span class="ty">Equal</span>&lt;<span class="ty">P</span>, <span class="ty">T</span>&gt; <span class="kw">extends</span> <span class="kw">true</span>
+      ? <span class="ty">P</span>                       <span class="com">// 一趟下来没交换 → 有序</span>
+      : <span class="fn">BubbleSort</span>&lt;<span class="ty">P</span>&gt;           <span class="com">// 还有逆序对 → 再来一趟</span>
+    : <span class="kw">never</span>;</pre>
+          </div>
+
+          <blockquote>数字比较不能直接用 <code class="inline">&lt;</code>，得转成字符串长度或逐位比较 —— 类型体操的老朋友了。</blockquote>
+
+          <h2>几个细节</h2>
+          <ul>
+            <li><code class="inline">infer A extends number</code> 收窄推断结果，省掉一层 <code class="inline">A extends number ? ... : never</code>；</li>
+            <li>终止条件是「这一趟没有发生任何交换」，用 <code class="inline">Equal</code> 做深度相等判断；</li>
+            <li>元组很长时记得给 TS 配置足够的递归深度，或者拆成小测试。</li>
+          </ul>
+          <p>完整题解在仓库 <code class="inline">type-challenges</code> 里，配合 type-challenge 的测试用例食用更佳。</p>
+        </div>
+
+        <hr class="hr">
+        <div class="pl"><span class="u">perfectpan</span><span class="at">@</span><span class="h">blog</span> <span class="p">~ %</span> <span class="cmd">comments --on type-challenge-bubble-sort</span></div>
+
+        <div class="cmt">
+          <div class="cmt-h"><span class="who">alice@example.com</span><span>2021-05-09</span></div>
+          <div class="cmt-b"><p>Equal 判终止这个思路太优雅了，比数长度 hack 干净。</p></div>
+          <div class="cmt reply">
+            <div class="cmt-h"><span class="who">bob@example.com</span><span>2021-05-10</span></div>
+            <div class="cmt-b"><p>数长度在负数场景直接爆炸，还是深度相等稳。</p></div>
+          </div>
+        </div>
+
+        <form class="cmt-form" onsubmit="return false">
+          <input type="text" placeholder="写下评论…（markdown 支持）" aria-label="新评论">
+          <button class="btn primary" type="submit">reply</button>
+        </form>
+
+        <hr class="hr">
+        <div class="pl"><span class="u">perfectpan</span><span class="at">@</span><span class="h">blog</span> <span class="p">~ %</span> <span class="cmd" style="color:var(--dim)">cd ..</span> <span class="cursor"></span></div>
+      </section>
+
+      <!-- ================= PROJECTS ================= -->
+      <section class="page" data-page="projects" hidden>
+        <div class="pl"><span class="u">perfectpan</span><span class="at">@</span><span class="h">blog</span> <span class="p">~ %</span> <span class="cmd">ls -la ~/projects</span></div>
+        <div class="ls" style="margin-top:10px">
+          <div class="row head" style="grid-template-columns:7ch 1fr 16ch"><span>star</span><span>project</span><span class="size">stack</span></div>
+          <a class="row" href="#" onclick="return false" style="grid-template-columns:7ch 1fr 16ch">
+            <span class="perms">★</span><span class="title">blog <span class="comment">— 本博客：TanStack Start 全量跑在 Cloudflare Workers + D1，$0/月</span></span><span class="tags">TanStack · CF · TS</span>
+          </a>
+          <a class="row" href="#" onclick="return false" style="grid-template-columns:7ch 1fr 16ch">
+            <span class="perms">★</span><span class="title">logseq-plugin-code-formatter <span class="comment">— 用 Prettier 一键格式化代码块</span></span><span class="tags">TS · Logseq</span>
+          </a>
+          <a class="row" href="#" onclick="return false" style="grid-template-columns:7ch 1fr 16ch">
+            <span class="perms"> </span><span class="title">ocvm <span class="comment">— nvm 风格的 Rust 版本管理器</span></span><span class="tags">Rust · CLI</span>
+          </a>
+          <a class="row" href="#" onclick="return false" style="grid-template-columns:7ch 1fr 16ch">
+            <span class="perms"> </span><span class="title">agent-presence <span class="comment">— 本地编码 agent 状态同步到飞书签名预览</span></span><span class="tags">TS · Feishu</span>
+          </a>
+          <a class="row" href="#" onclick="return false" style="grid-template-columns:7ch 1fr 16ch">
+            <span class="perms"> </span><span class="title">base64 <span class="comment">— Moonbit 实现的 Base64，遵循 RFC 4648</span></span><span class="tags">Moonbit</span>
+          </a>
+        </div>
+        <div class="pl" style="margin-top:24px"><span class="u">perfectpan</span><span class="at">@</span><span class="h">blog</span> <span class="p">~ %</span> <span class="cmd" style="color:var(--dim)">cd ..</span> <span class="cursor"></span></div>
+      </section>
+
+      <!-- ================= LOGIN ================= -->
+      <section class="page" data-page="login" hidden>
+        <div class="pl"><span class="u">guest</span><span class="at">@</span><span class="h">perfectpan.org</span> <span class="p">~ %</span> <span class="cmd">ssh member@perfectpan.org</span></div>
+        <p class="out comment"># 邮箱密码登录；或者走 GitHub OAuth。</p>
+        <form class="form-panel" onsubmit="return false" style="margin-top:14px">
+          <div class="field">
+            <label for="a-email">email</label>
+            <input id="a-email" type="email" placeholder="you@example.com">
+          </div>
+          <div class="field">
+            <label for="a-pass">password</label>
+            <input id="a-pass" type="password" placeholder="••••••••">
+          </div>
+          <div style="display:flex;gap:12px;margin-top:18px;flex-wrap:wrap">
+            <button class="btn primary" type="submit">sign in</button>
+            <button class="btn" type="button">continue with github</button>
+          </div>
+          <p class="err" hidden>认证失败：邮箱或密码不正确</p>
+        </form>
+        <p class="out" style="margin-top:14px"><span class="comment"># 还没有账号？</span> <a href="#" onclick="return false">signup</a></p>
+      </section>
+
+      <!-- ================= SIGNUP ================= -->
+      <section class="page" data-page="signup" hidden>
+        <div class="pl"><span class="u">guest</span><span class="at">@</span><span class="h">perfectpan.org</span> <span class="p">~ %</span> <span class="cmd">useradd --join</span></div>
+        <p class="out comment"># 注册成为 member，可读 member 可见性的文章。</p>
+        <form class="form-panel" onsubmit="return false" style="margin-top:14px">
+          <div class="field"><label for="a-se">email</label><input id="a-se" type="email" placeholder="you@example.com"></div>
+          <div class="field"><label for="a-sp">password</label><input id="a-sp" type="password" placeholder="至少 8 位"></div>
+          <div class="field"><label for="a-sp2">password (again)</label><input id="a-sp2" type="password" placeholder="再输一遍"></div>
+          <div style="display:flex;gap:12px;margin-top:18px;flex-wrap:wrap">
+            <button class="btn primary" type="submit">create account</button>
+            <button class="btn" type="button">continue with github</button>
+          </div>
+        </form>
+      </section>
+
+      <!-- ================= UNLOCK ================= -->
+      <section class="page" data-page="unlock" hidden>
+        <div class="pl"><span class="u">guest</span><span class="at">@</span><span class="h">perfectpan.org</span> <span class="p">~ %</span> <span class="cmd">cat posts/2020/document-style.md</span></div>
+        <p class="out"><span style="color:var(--red)">cat: posts/2020/document-style.md: Permission denied</span></p>
+        <p class="out comment"># 这篇文章是密码保护的。输入单文密码后 24 小时内免密阅读。</p>
+        <form class="form-panel" onsubmit="return false" style="margin-top:14px">
+          <div class="field"><label for="a-pw">password for this post</label><input id="a-pw" type="password" placeholder="••••••••" autofocus></div>
+          <div style="display:flex;gap:12px;margin-top:16px">
+            <button class="btn primary" type="submit">sudo unlock</button>
+            <a href="#" onclick="return false" style="align-self:center">← 返回文章</a>
+          </div>
+          <p class="err" hidden>密码错误，请重试（连续失败会触发限流）</p>
+        </form>
+      </section>
+
+      <!-- ================= ADMIN ================= -->
+      <section class="page" data-page="admin" hidden>
+        <div class="pl"><span class="u" style="color:var(--red)">root</span><span class="at">@</span><span class="h">blog</span> <span class="p">~ %</span> <span class="cmd">blogctl dashboard</span></div>
+        <div class="tui">
+          <div class="tui-bar">
+            <span class="tname">▚ blogctl</span>
+            <a href="#" onclick="return false">+ new post</a>
+            <a href="#" onclick="return false">comments (23)</a>
+            <span class="thint">j/k 移动 · e 编辑 · d 删除</span>
+          </div>
+          <table class="tui-table">
+            <thead><tr><th>#</th><th>title</th><th>status</th><th>visibility</th><th>updated</th><th>ops</th></tr></thead>
+            <tbody>
+              <tr><td>16</td><td>初探 Github Blocks</td><td><span class="badge pub">published</span></td><td><span class="badge pub">public</span></td><td>2023-02-18</td><td class="ops"><a href="#" onclick="return false">edit</a><a href="#" onclick="return false" style="color:var(--red)">delete</a></td></tr>
+              <tr><td>15</td><td>Type Challenge - 冒泡排序</td><td><span class="badge pub">published</span></td><td><span class="badge pub">public</span></td><td>2021-05-08</td><td class="ops"><a href="#" onclick="return false">edit</a><a href="#" onclick="return false" style="color:var(--red)">delete</a></td></tr>
+              <tr><td>14</td><td>回顾 2020</td><td><span class="badge pub">published</span></td><td><span class="badge mem">member</span></td><td>2021-02-28</td><td class="ops"><a href="#" onclick="return false">edit</a><a href="#" onclick="return false" style="color:var(--red)">delete</a></td></tr>
+              <tr><td>13</td><td>文档书写要点整理</td><td><span class="badge pub">published</span></td><td><span class="badge pw">password</span></td><td>2020-03-01</td><td class="ops"><a href="#" onclick="return false">edit</a><a href="#" onclick="return false" style="color:var(--red)">delete</a></td></tr>
+              <tr><td>17</td><td>Cloudflare 迁移实录（草稿）</td><td><span class="badge draft">draft</span></td><td><span class="badge pub">public</span></td><td>2026-08-12</td><td class="ops"><a href="#" onclick="return false">edit</a><a href="#" onclick="return false" style="color:var(--red)">delete</a></td></tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="pl" style="margin-top:22px"><span class="u" style="color:var(--red)">root</span><span class="at">@</span><span class="h">blog</span> <span class="p">~ %</span> <span class="cursor"></span></div>
+      </section>
+
+      <!-- ================= EDITOR ================= -->
+      <section class="page" data-page="editor" hidden>
+        <div class="pl"><span class="u" style="color:var(--red)">root</span><span class="at">@</span><span class="h">blog</span> <span class="p">~ %</span> <span class="cmd">blogctl edit --new</span></div>
+        <form onsubmit="return false" style="margin-top:14px">
+          <div class="editor-meta">
+            <div class="field"><label>title</label><input type="text" value="Cloudflare 迁移实录"></div>
+            <div class="field"><label>slug</label><input type="text" value="cloudflare-migration"></div>
+            <div class="field"><label>visibility</label>
+              <select><option>public</option><option>member</option><option>vip</option><option>admin</option><option>password</option></select>
+            </div>
+            <div class="field"><label>tags</label><input type="text" value="Cloudflare, D1, Workers"></div>
+          </div>
+          <div class="field" style="max-width:none"><label>content (markdown)</label>
+            <textarea class="md-area" spellcheck="false">## 为什么要迁
+
+Postgres 免费额度撑不住了……
+
+```ts
+export default { fetch } = ...
+```</textarea>
+          </div>
+          <div class="editor-foot">
+            <button class="btn" type="button">[w] 保存草稿</button>
+            <button class="btn primary" type="button">[p] 发布</button>
+            <span class="stat">642 字 · 预计阅读 3 min · 自动保存 12:41</span>
+          </div>
+        </form>
+      </section>
+
+      <!-- ================= 404 ================= -->
+      <section class="page" data-page="404" hidden>
+        <div class="nf">
+          <div class="pl"><span class="u">guest</span><span class="at">@</span><span class="h">perfectpan.org</span> <span class="p">~ %</span> <span class="cmd">cd /blog/nowhere</span></div>
+          <p class="out big">bash: cd: /blog/nowhere: No such file or directory</p>
+          <p class="out comment"># 你闯入了无人之境。</p>
+          <p class="out" style="margin-top:14px"><a href="#" onclick="return false">cd ~/blog</a> <span class="comment">← 回到博客列表</span></p>
+        </div>
+      </section>
+
+    </div>
+
+    <!-- tmux status bar -->
+    <div class="tmux" role="navigation" aria-label="站点窗口">
+      <span class="sess">blog</span>
+      <button class="tmux-win on" data-target="home">0:home</button>
+      <button class="tmux-win" data-target="blog">1:posts</button>
+      <button class="tmux-win" data-target="post">2:post</button>
+      <button class="tmux-win" data-target="projects">3:projects</button>
+      <button class="tmux-win" data-target="admin">4:admin</button>
+      <span class="right"><span>perfectpan.org</span><span>⌘K = grep</span><span id="clock">--:--</span></span>
+    </div>
+  </div>
+</div>
+
+<!-- ⌘K grep palette -->
+<div class="pal-veil" id="pal-veil" hidden>
+  <div class="pal" role="dialog" aria-label="搜索文章">
+    <div class="pal-in"><span class="p">~ %</span><input type="text" id="pal-input" placeholder="grep -ri '题解' ~/posts" aria-label="搜索"></div>
+    <div class="pal-list">
+      <div class="pal-item sel"><span class="d">2021-05</span><span>Type Challenge - 冒泡排序</span></div>
+      <div class="pal-item"><span class="d">2020-04</span><span>LeetCode 中国区 TypeScript 面试题题解</span></div>
+      <div class="pal-item"><span class="d">2019-12</span><span>Codeforces Round#605(Div. 3) D/E/F 题解</span></div>
+      <div class="pal-item"><span class="d">2019-04</span><span>Codeforces 1149B Three Religions</span></div>
+    </div>
+    <div class="pal-foot">↑↓ 选择 · ↵ 打开 · esc 关闭 · 权限过滤按当前身份自动生效</div>
+  </div>
+</div>
+
+<script>
+  // page switching
+  var tabs = document.querySelectorAll('.pt-tab, .tmux-win');
+  var pages = document.querySelectorAll('.page');
+  function go(id) {
+    pages.forEach(function(p){ p.hidden = p.dataset.page !== id; });
+    document.querySelectorAll('.pt-tab').forEach(function(t){ t.classList.toggle('active', t.dataset.target === id); });
+    document.querySelectorAll('.tmux-win').forEach(function(t){ t.classList.toggle('on', t.dataset.target === id); });
+    window.scrollTo(0, 0);
+    history.replaceState(null, '', '#' + id);
+  }
+  tabs.forEach(function(t){ t.addEventListener('click', function(){ go(t.dataset.target); }); });
+  var h = location.hash.slice(1);
+  if (h && document.querySelector('.page[data-page="' + h + '"]')) go(h);
+  window.addEventListener('hashchange', function(){
+    var h = location.hash.slice(1);
+    if (h && document.querySelector('.page[data-page="' + h + '"]')) go(h);
+  });
+
+  // ⌘K palette
+  var veil = document.getElementById('pal-veil');
+  var input = document.getElementById('pal-input');
+  function openPal(){ veil.hidden = false; input.focus(); }
+  function closePal(){ veil.hidden = true; }
+  document.addEventListener('keydown', function(e){
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') { e.preventDefault(); veil.hidden ? openPal() : closePal(); }
+    if (e.key === 'Escape') closePal();
+  });
+  veil.addEventListener('click', function(e){ if (e.target === veil) closePal(); });
+
+  // fake clock
+  function tick(){ document.getElementById('clock').textContent = new Date().toTimeString().slice(0,5); }
+  tick(); setInterval(tick, 30000);
+</script>
+</body>
+</html>

--- a/prototypes/b-journal.html
+++ b/prototypes/b-journal.html
@@ -1,0 +1,690 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>方向 B · 文学集刊《废墨集》· PerfectPan's Blog 原型</title>
+<style>
+  /* ============ tokens ============ */
+  :root {
+    --paper: #F6F3EC;      /* 纸 */
+    --paper2: #EFEAE0;     /* 深一度纸（面板） */
+    --ink: #262523;        /* 墨 */
+    --faded: #6E6A60;      /* 淡墨 */
+    --faint: #A29C8E;      /* 更淡 */
+    --red: #A63A2B;        /* 印泥朱 */
+    --indigo: #2E4A68;     /* 靛青（meta） */
+    --rule: #DAD4C6;       /* 界线 */
+    --serif: "Songti SC", "Noto Serif SC", "Source Han Serif SC", "SimSun", serif;
+    --sans: "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", system-ui, sans-serif;
+    --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: var(--paper);
+    color: var(--ink);
+    font-family: var(--serif);
+    font-size: 16.5px;
+    line-height: 2;
+    min-height: 100vh;
+  }
+  ::selection { background: rgba(166,58,43,0.16); }
+  a { color: var(--ink); text-decoration: none; }
+  a:hover { color: var(--red); }
+  :focus-visible { outline: 2px solid var(--red); outline-offset: 3px; }
+
+  /* ============ prototype chrome ============ */
+  .pt-bar {
+    background: #1E1C1A; color: #B9B2A5;
+    font-family: var(--sans); font-size: 12.5px;
+    padding: 0 16px; display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
+    position: sticky; top: 0; z-index: 50;
+  }
+  .pt-bar .pt-title { color: #E0B04A; font-weight: 700; letter-spacing: 0.06em; }
+  .pt-tab {
+    font-family: inherit; font-size: 12.5px; color: #B9B2A5; background: none;
+    border: 0; padding: 9px 10px; cursor: pointer;
+  }
+  .pt-tab:hover { color: #F6F3EC; }
+  .pt-tab.active { color: #1E1C1A; background: #E0B04A; font-weight: 700; }
+  .pt-links { margin-left: auto; display: flex; gap: 12px; }
+  .pt-links a { color: #6B665C; }
+  .pt-links a:hover { color: #E0B04A; }
+
+  /* ============ 刊头 ============ */
+  .masthead {
+    max-width: 960px; margin: 0 auto; padding: 34px 24px 0;
+    display: flex; align-items: flex-end; gap: 24px;
+  }
+  .masthead .brand {
+    font-size: 30px; font-weight: 900; letter-spacing: 0.22em; white-space: nowrap;
+  }
+  .masthead .brand a:hover { color: var(--ink); }
+  .masthead .brand .dot { color: var(--red); }
+  .masthead nav { display: flex; gap: 26px; font-family: var(--sans); font-size: 13.5px; letter-spacing: 0.28em; margin-left: auto; }
+  .masthead nav a { color: var(--faded); }
+  .masthead nav a:hover { color: var(--red); }
+  .headrule { max-width: 960px; margin: 14px auto 0; padding: 0 24px; }
+  .headrule hr { border: 0; border-top: 2.5px solid var(--ink); position: relative; }
+  .headrule hr::after {
+    content: ""; position: absolute; left: 0; right: 0; top: 3px;
+    border-top: 1px solid var(--ink);
+  }
+
+  /* ============ layout ============ */
+  .sheet { max-width: 960px; margin: 0 auto; padding: 44px 24px 90px; position: relative; min-height: 55vh; }
+  .page[hidden] { display: none; }
+
+  /* 竖排卷标（签名元素） */
+  .spine {
+    position: absolute; left: -52px; top: 8px;
+    writing-mode: vertical-rl; letter-spacing: 0.5em;
+    font-size: 13px; color: var(--faint);
+    border-right: 1px solid var(--rule); padding-right: 10px; height: 300px;
+    user-select: none;
+  }
+  .spine b { color: var(--red); font-weight: 400; }
+
+  /* 印章 */
+  .seal {
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 46px; height: 46px; background: var(--red); color: #F8F4EA;
+    font-size: 24px; font-weight: 900; border-radius: 7px;
+    box-shadow: inset 0 0 0 2px rgba(248,244,234,0.55), inset 0 0 0 4px var(--red);
+    transform: rotate(-4deg);
+  }
+
+  /* 小注（visibility 标记） */
+  .note {
+    font-family: var(--sans); font-size: 11px; letter-spacing: 0.12em;
+    color: var(--faded); border: 1px solid var(--rule); border-radius: 2px;
+    padding: 0 6px; margin-left: 10px; white-space: nowrap; vertical-align: 2px;
+  }
+  .note.vip, .note.mem { color: var(--indigo); border-color: #C9D4DF; }
+  .note.pw { color: var(--red); border-color: #DFC0BA; }
+
+  h1.entry-title { font-size: 34px; font-weight: 900; line-height: 1.55; letter-spacing: 0.04em; }
+  .entry-meta { font-family: var(--sans); font-size: 13px; color: var(--indigo); letter-spacing: 0.06em; margin-top: 10px; }
+  .entry-meta span { margin-right: 18px; }
+
+  /* ============ 扉页 home ============ */
+  .frontispiece { display: grid; grid-template-columns: auto 1fr; gap: 48px; align-items: start; }
+  .fp-vertical {
+    writing-mode: vertical-rl; font-size: 84px; font-weight: 900; letter-spacing: 0.18em;
+    line-height: 1.15; border-left: 3px solid var(--ink); padding-left: 26px; height: 480px;
+    user-select: none;
+  }
+  .fp-vertical small { font-size: 15px; font-weight: 400; color: var(--faded); letter-spacing: 0.4em; margin-top: 18px; }
+  .fp-right { padding-top: 8px; }
+  .fp-tagline { font-size: 19px; line-height: 2.1; max-width: 34ch; }
+  .fp-facts {
+    margin-top: 26px; font-family: var(--sans); font-size: 13px; color: var(--faded);
+    display: flex; gap: 22px; flex-wrap: wrap; letter-spacing: 0.1em;
+  }
+  .fp-facts b { color: var(--ink); font-weight: 600; }
+  .fp-latest { margin-top: 34px; }
+  .fp-latest h3, .blockhead {
+    font-family: var(--sans); font-size: 12.5px; letter-spacing: 0.42em; color: var(--red);
+    margin-bottom: 8px; font-weight: 600;
+  }
+  .toc-line { display: flex; align-items: baseline; gap: 10px; padding: 7px 0; }
+  .toc-line .t { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .toc-line .dots { flex: 1; border-bottom: 2px dotted var(--faint); transform: translateY(-5px); min-width: 24px; }
+  .toc-line .n { font-family: var(--mono); font-size: 12.5px; color: var(--faded); white-space: nowrap; }
+  .toc-line a:hover .t { color: var(--red); }
+  .fp-actions { margin-top: 36px; display: flex; gap: 14px; align-items: center; flex-wrap: wrap; }
+  .btn {
+    font-family: var(--sans); font-size: 13.5px; letter-spacing: 0.2em; cursor: pointer;
+    padding: 10px 26px; border-radius: 2px; border: 1.5px solid var(--ink);
+    background: transparent; color: var(--ink); transition: all .15s;
+  }
+  .btn:hover { background: var(--ink); color: var(--paper); }
+  .btn.red { border-color: var(--red); color: var(--red); }
+  .btn.red:hover { background: var(--red); color: var(--paper); }
+  .fp-seal { margin-top: 44px; display: flex; align-items: center; gap: 14px; }
+  .fp-seal .sign { font-family: var(--sans); font-size: 12px; color: var(--faint); letter-spacing: 0.2em; line-height: 1.9; }
+
+  /* ============ 目次 blog ============ */
+  .juan {
+    display: flex; align-items: baseline; gap: 18px; margin: 40px 0 8px;
+  }
+  .juan h2 { font-size: 24px; font-weight: 900; letter-spacing: 0.3em; }
+  .juan .sub { font-family: var(--sans); font-size: 12px; color: var(--faint); letter-spacing: 0.2em; }
+  .juan::after { content: ""; flex: 1; border-bottom: 1px solid var(--rule); transform: translateY(-6px); }
+  .toc-list { padding: 4px 0; }
+  .toc-list .toc-line { font-size: 17px; padding: 9px 0; }
+  .toc-list .toc-line a { display: flex; flex: 1; align-items: baseline; gap: 10px; }
+  .pager {
+    display: flex; justify-content: center; gap: 30px; margin-top: 50px;
+    font-family: var(--sans); font-size: 13px; letter-spacing: 0.15em; color: var(--faded);
+  }
+  .pager a { color: var(--red); }
+
+  /* ============ 正文 article ============ */
+  .article { max-width: 46em; margin: 0 auto; }
+  .running-head {
+    font-family: var(--sans); font-size: 11.5px; color: var(--faint); letter-spacing: 0.3em;
+    text-align: center; margin-bottom: 26px; padding-bottom: 12px; border-bottom: 1px solid var(--rule);
+  }
+  .article h1 { text-align: center; }
+  .article .entry-meta { text-align: center; margin: 14px 0 34px; }
+  .article .entry-meta span { margin: 0 9px; }
+  .prose p { margin: 18px 0; text-align: justify; }
+  .prose > p:first-of-type::first-letter {
+    font-size: 3.1em; font-weight: 900; float: left; line-height: 1;
+    margin: 8px 12px 0 0; color: var(--red);
+  }
+  .prose h2 {
+    font-size: 21px; font-weight: 900; margin: 40px 0 14px; letter-spacing: 0.08em;
+    display: flex; align-items: center; gap: 16px;
+  }
+  .prose h2::before, .prose h2::after { content: ""; height: 1px; background: var(--rule); flex: 1; }
+  .prose ul { padding-left: 0; list-style: none; margin: 16px 0; }
+  .prose ul li { padding-left: 1.6em; position: relative; margin: 8px 0; }
+  .prose ul li::before { content: "—"; position: absolute; left: 0; color: var(--red); }
+  .prose blockquote {
+    margin: 26px 0; padding: 14px 22px; background: var(--paper2);
+    border-left: 3px solid var(--red); color: var(--faded); font-size: 15.5px;
+  }
+  .prose blockquote .who { display: block; font-family: var(--sans); font-size: 12px; color: var(--faint); margin-top: 6px; letter-spacing: 0.15em; }
+  .prose code {
+    font-family: var(--mono); font-size: 0.84em; background: var(--paper2);
+    border: 1px solid var(--rule); border-radius: 2px; padding: 1px 6px; color: var(--red);
+  }
+  .prose pre {
+    font-family: var(--mono); font-size: 13px; line-height: 1.8; background: #2B2926; color: #E8E2D5;
+    border-radius: 4px; padding: 20px 22px; overflow-x: auto; margin: 24px 0;
+  }
+  .prose pre .c { color: #8A8477; } .prose pre .k { color: #D8A5A0; } .prose pre .f { color: #A8C0D8; }
+  .prose pre .s { color: #B5C9A8; } .prose pre .t { color: #E0C088; }
+  .backlink { text-align: center; margin-top: 54px; font-family: var(--sans); font-size: 13px; letter-spacing: 0.3em; }
+  .backlink a { color: var(--faded); }
+  .backlink a:hover { color: var(--red); }
+
+  /* 读者来函 comments */
+  .letters { max-width: 46em; margin: 60px auto 0; }
+  .letter {
+    border: 1px solid var(--rule); border-radius: 3px; padding: 18px 22px; margin: 14px 0;
+    background: rgba(255,255,255,0.45);
+  }
+  .letter .lhead { font-family: var(--sans); font-size: 12.5px; color: var(--indigo); letter-spacing: 0.08em; margin-bottom: 6px; }
+  .letter .lhead .when { color: var(--faint); margin-left: 12px; }
+  .letter p { font-size: 15.5px; line-height: 1.95; margin: 0; }
+  .letter.reply { margin-left: 44px; background: var(--paper2); }
+  .letter-form { display: flex; gap: 12px; margin-top: 20px; }
+  .letter-form input[type=text] { flex: 1; }
+
+  /* ============ 器物谱 projects ============ */
+  .ware { display: grid; grid-template-columns: 64px 1fr; gap: 0 26px; padding: 26px 0; border-bottom: 1px solid var(--rule); }
+  .ware .no { font-size: 26px; font-weight: 900; color: var(--faint); font-family: var(--serif); }
+  .ware .no small { display: block; font-size: 11px; font-family: var(--sans); letter-spacing: 0.2em; margin-top: 4px; }
+  .ware h2 { font-size: 21px; font-weight: 900; letter-spacing: 0.04em; }
+  .ware h2 .feat { color: var(--red); font-size: 13px; margin-left: 10px; letter-spacing: 0.2em; font-family: var(--sans); }
+  .ware p { color: var(--faded); font-size: 15.5px; margin-top: 6px; }
+  .ware .wlinks { margin-top: 10px; font-family: var(--sans); font-size: 13px; display: flex; gap: 20px; }
+  .ware .wlinks a { color: var(--indigo); border-bottom: 1px solid #C9D4DF; }
+  .ware .tags { margin-top: 8px; font-family: var(--sans); font-size: 12px; color: var(--faint); letter-spacing: 0.1em; }
+  .ware .tags i { font-style: normal; margin-right: 12px; }
+
+  /* ============ forms ============ */
+  .gate { max-width: 460px; margin: 30px auto 0; }
+  .gate .card {
+    border: 1.5px solid var(--ink); border-radius: 4px; background: rgba(255,255,255,0.5);
+    padding: 38px 40px 40px; position: relative;
+    box-shadow: 6px 6px 0 rgba(38,37,35,0.08);
+  }
+  .gate .card .seal { position: absolute; right: 26px; top: -23px; }
+  .gate h1 { font-size: 26px; font-weight: 900; letter-spacing: 0.14em; }
+  .gate .sub { font-family: var(--sans); font-size: 13px; color: var(--faded); margin: 8px 0 26px; letter-spacing: 0.08em; }
+  .field { margin: 16px 0; }
+  .field label { display: block; font-family: var(--sans); font-size: 12.5px; letter-spacing: 0.24em; color: var(--faded); margin-bottom: 6px; }
+  input[type=text], input[type=email], input[type=password], textarea, select {
+    width: 100%; font-family: var(--serif); font-size: 15.5px; color: var(--ink);
+    background: var(--paper); border: 1px solid var(--rule); border-radius: 2px; padding: 10px 14px;
+  }
+  input:focus, textarea:focus, select:focus { outline: none; border-color: var(--red); box-shadow: 0 0 0 2px rgba(166,58,43,0.12); }
+  .gate .actions { display: flex; gap: 12px; margin-top: 26px; flex-wrap: wrap; }
+  .gate .aside { text-align: center; margin-top: 22px; font-family: var(--sans); font-size: 13px; color: var(--faded); }
+  .err { font-family: var(--sans); font-size: 13px; color: var(--red); margin-top: 10px; }
+  .lockmark {
+    width: 54px; height: 54px; border: 2px solid var(--red); border-radius: 4px; color: var(--red);
+    display: flex; align-items: center; justify-content: center; font-size: 26px; font-weight: 900;
+    margin: 0 auto 20px; transform: rotate(3deg);
+  }
+
+  /* ============ 编辑部 admin ============ */
+  .desk-table { width: 100%; border-collapse: collapse; font-family: var(--sans); font-size: 13.5px; margin-top: 26px; }
+  .desk-table th {
+    text-align: left; font-weight: 600; color: var(--faded); letter-spacing: 0.15em; font-size: 12px;
+    padding: 10px 12px; border-bottom: 2px solid var(--ink);
+  }
+  .desk-table td { padding: 12px; border-bottom: 1px solid var(--rule); }
+  .desk-table tr:hover td { background: rgba(166,58,43,0.04); }
+  .desk-table td.t { font-family: var(--serif); font-size: 15.5px; }
+  .desk-table a.op { color: var(--indigo); margin-right: 14px; font-size: 12.5px; }
+  .desk-table a.op.del { color: var(--red); }
+  .editor-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 0 22px; }
+  textarea.draft { min-height: 320px; line-height: 2; font-size: 15px; }
+  .editor-foot { display: flex; gap: 12px; margin-top: 18px; align-items: center; flex-wrap: wrap; }
+  .editor-foot .stat { font-family: var(--sans); font-size: 12px; color: var(--faint); margin-left: auto; letter-spacing: 0.1em; }
+
+  /* ============ 404 ============ */
+  .nf404 { text-align: center; padding: 90px 0 40px; }
+  .nf404 .zh { font-size: 40px; font-weight: 900; letter-spacing: 0.3em; }
+  .nf404 p { font-family: var(--sans); font-size: 14px; color: var(--faded); margin-top: 18px; letter-spacing: 0.15em; }
+
+  /* ============ 检索 palette ============ */
+  .pal-veil { position: fixed; inset: 0; background: rgba(38,37,35,0.35); backdrop-filter: blur(1.5px); display: flex; justify-content: center; padding-top: 14vh; z-index: 100; }
+  .pal-veil[hidden] { display: none; }
+  .pal {
+    width: min(600px, calc(100vw - 32px)); height: fit-content;
+    background: var(--paper); border: 1.5px solid var(--ink); border-radius: 5px;
+    box-shadow: 8px 8px 0 rgba(38,37,35,0.15); overflow: hidden;
+  }
+  .pal-in { display: flex; gap: 12px; align-items: center; padding: 14px 18px; border-bottom: 1px solid var(--rule); }
+  .pal-in .mark { color: var(--red); font-weight: 900; }
+  .pal-in input { background: none; border: 0; padding: 0; font-size: 15.5px; }
+  .pal-in input:focus { box-shadow: none; }
+  .pal-list { max-height: 300px; overflow-y: auto; }
+  .pal-item { display: flex; gap: 14px; padding: 11px 18px; align-items: baseline; font-size: 15px; }
+  .pal-item .d { font-family: var(--mono); font-size: 11.5px; color: var(--faint); min-width: 6ch; }
+  .pal-item.sel { background: rgba(166,58,43,0.07); }
+  .pal-item.sel .t::after { content: "　※"; color: var(--red); font-size: 12px; }
+  .pal-foot { border-top: 1px solid var(--rule); padding: 8px 18px; font-family: var(--sans); font-size: 11.5px; color: var(--faint); letter-spacing: 0.1em; }
+
+  /* 刊脚 */
+  .colophon {
+    border-top: 2.5px solid var(--ink); position: relative; margin-top: 40px; padding-top: 18px;
+    text-align: center; font-family: var(--sans); font-size: 12px; color: var(--faint); letter-spacing: 0.2em;
+  }
+  .colophon::before { content: ""; position: absolute; left: 0; right: 0; top: 3px; border-top: 1px solid var(--ink); }
+  .colophon a { color: var(--indigo); }
+
+  @media (max-width: 760px) {
+    .spine { display: none; }
+    .frontispiece { grid-template-columns: 1fr; }
+    .fp-vertical { height: auto; writing-mode: horizontal-tb; font-size: 46px; border-left: 0; border-bottom: 3px solid var(--ink); padding: 0 0 16px; }
+    .fp-vertical small { margin-top: 8px; margin-left: 8px; }
+    .masthead { flex-wrap: wrap; align-items: center; }
+    .sheet { padding: 30px 18px 70px; }
+    .prose > p:first-of-type::first-letter { font-size: 2.6em; }
+  }
+</style>
+</head>
+<body>
+
+<!-- prototype chrome -->
+<div class="pt-bar">
+  <span class="pt-title">原型 · 方向 B 文学集刊</span>
+  <nav aria-label="原型页面" style="display:flex;gap:2px;flex-wrap:wrap">
+    <button class="pt-tab active" data-target="home">扉页</button>
+    <button class="pt-tab" data-target="blog">目次</button>
+    <button class="pt-tab" data-target="post">正文</button>
+    <button class="pt-tab" data-target="projects">器物谱</button>
+    <button class="pt-tab" data-target="login">入会</button>
+    <button class="pt-tab" data-target="signup">注册</button>
+    <button class="pt-tab" data-target="unlock">密函</button>
+    <button class="pt-tab" data-target="admin">编辑部</button>
+    <button class="pt-tab" data-target="editor">拟稿</button>
+    <button class="pt-tab" data-target="404">阙页</button>
+  </nav>
+  <div class="pt-links"><a href="index.html">总览</a><a href="a-terminal.html">方向 A</a><a href="c-swiss.html">方向 C</a></div>
+</div>
+
+<header class="masthead">
+  <div class="brand"><a href="#" onclick="return false">废墨集<span class="dot">。</span></a></div>
+  <nav>
+    <a href="#" onclick="return false">目次</a>
+    <a href="#" onclick="return false">器物</a>
+    <a href="#" onclick="return false">入会</a>
+    <button class="pt-tab" style="color:var(--red);padding:9px 0" onclick="document.dispatchEvent(new KeyboardEvent('keydown',{key:'k',metaKey:true}))">检索 ⌘K</button>
+  </nav>
+</header>
+<div class="headrule"><hr></div>
+
+<main class="sheet">
+  <aside class="spine" aria-hidden="true">废墨集 · <b>卷四</b> · 二〇二六年 第八期 · perfectpan.org</aside>
+
+  <!-- ================= 扉页 ================= -->
+  <section class="page" data-page="home">
+    <div class="frontispiece">
+      <div class="fp-vertical" aria-hidden="true">废墨集<small>FEI MO JI · 创刊于二〇一九</small></div>
+      <div class="fp-right">
+        <p class="fp-tagline">是个什么都不会的废物.jpg —— 但笔没停过。算法竞赛的旧题解、TypeScript 的类型体操、把整站跑在 Cloudflare 免费额度上的工程笔记，以及一些不成体统的随想，都收在这本集子里。</p>
+        <div class="fp-facts">
+          <span>收文 <b>十六</b> 篇</span>
+          <span>历时 <b>二〇一九 — 二〇二三</b></span>
+          <span>栏目 <b>算法 · 类型 · 随笔 · 工程</b></span>
+        </div>
+        <div class="fp-latest">
+          <h3>近日新篇</h3>
+          <div class="toc-line"><a href="#" onclick="return false"><span class="t">初探 Github Blocks</span><span class="dots"></span></a><span class="n">二〇二三 · 二月</span></div>
+          <div class="toc-line"><a href="#" onclick="return false"><span class="t">Type Challenge - 冒泡排序</span><span class="dots"></span></a><span class="n">二〇二一 · 五月</span></div>
+          <div class="toc-line"><a href="#" onclick="return false"><span class="t">回顾 2020</span><span class="dots"></span></a><span class="n">二〇二一 · 二月</span></div>
+        </div>
+        <div class="fp-actions">
+          <a class="btn red" href="#" onclick="return false">读 目 次</a>
+          <a class="btn" href="#" onclick="return false">观 器 物 谱</a>
+        </div>
+        <div class="fp-seal">
+          <span class="seal">潘</span>
+          <div class="sign">PerfectPan 手订<br>全刊运行于 Cloudflare · 每月费用为零</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= 目次 ================= -->
+  <section class="page" data-page="blog" hidden>
+    <h1 class="entry-title" style="text-align:center">目　次</h1>
+    <p class="entry-meta" style="text-align:center">全刊总目 · 按年分卷 · 自新迄旧</p>
+
+    <div class="juan"><h2>卷四 · 二〇二三</h2><span class="sub">一篇</span></div>
+    <div class="toc-list">
+      <div class="toc-line"><a href="#" onclick="return false"><span class="t">初探 Github Blocks</span><span class="dots"></span></a><span class="n">〇一六</span></div>
+    </div>
+
+    <div class="juan"><h2>卷三 · 二〇二一</h2><span class="sub">两篇</span></div>
+    <div class="toc-list">
+      <div class="toc-line"><a href="#" onclick="return false"><span class="t">Type Challenge - 冒泡排序</span><span class="dots"></span></a><span class="n">〇一五</span></div>
+      <div class="toc-line"><a href="#" onclick="return false"><span class="t">回顾 2020<span class="note mem">会员可读</span></span><span class="dots"></span></a><span class="n">〇一四</span></div>
+    </div>
+
+    <div class="juan"><h2>卷二 · 二〇二〇</h2><span class="sub">四篇</span></div>
+    <div class="toc-list">
+      <div class="toc-line"><a href="#" onclick="return false"><span class="t">一些随想</span><span class="dots"></span></a><span class="n">〇一三</span></div>
+      <div class="toc-line"><a href="#" onclick="return false"><span class="t">LeetCode 中国区 TypeScript 面试题题解</span><span class="dots"></span></a><span class="n">〇一二</span></div>
+      <div class="toc-line"><a href="#" onclick="return false"><span class="t">那些年邂逅的 LeetCode 趣/难题</span><span class="dots"></span></a><span class="n">〇一一</span></div>
+      <div class="toc-line"><a href="#" onclick="return false"><span class="t">文档书写要点整理<span class="note pw">密笈</span></span><span class="dots"></span></a><span class="n">〇一〇</span></div>
+    </div>
+
+    <div class="juan"><h2>卷一 · 二〇一九</h2><span class="sub">八篇 · 摘录六篇</span></div>
+    <div class="toc-list">
+      <div class="toc-line"><a href="#" onclick="return false"><span class="t">回顾 2019<span class="note vip">VIP</span></span><span class="dots"></span></a><span class="n">〇〇九</span></div>
+      <div class="toc-line"><a href="#" onclick="return false"><span class="t">Codeforces Round#605(Div. 3) D/E/F 题解</span><span class="dots"></span></a><span class="n">〇〇八</span></div>
+      <div class="toc-line"><a href="#" onclick="return false"><span class="t">Codeforces Round#603(Div. 2) E/F 题解</span><span class="dots"></span></a><span class="n">〇〇七</span></div>
+      <div class="toc-line"><a href="#" onclick="return false"><span class="t">银联极客高校挑战赛复赛 D 多项式</span><span class="dots"></span></a><span class="n">〇〇六</span></div>
+      <div class="toc-line"><a href="#" onclick="return false"><span class="t">Codeforces 1149B Three Religions</span><span class="dots"></span></a><span class="n">〇〇五</span></div>
+      <div class="toc-line"><a href="#" onclick="return false"><span class="t">2019 ICPC 南昌邀请赛网络赛 G. tsy's number</span><span class="dots"></span></a><span class="n">〇〇四</span></div>
+    </div>
+
+    <nav class="pager" aria-label="翻页">
+      <span>上页</span><span>· 一 / 二 ·</span><a href="#" onclick="return false">下页</a>
+    </nav>
+  </section>
+
+  <!-- ================= 正文 ================= -->
+  <section class="page" data-page="post" hidden>
+    <article class="article">
+      <div class="running-head">废墨集 · 卷三 · 第一五篇 · 栏目：类型体操</div>
+      <h1 class="entry-title">Type Challenge · 冒泡排序</h1>
+      <p class="entry-meta"><span>二〇二一年五月八日</span><span>·</span><span>约九分钟</span><span>·</span><span>TypeScript</span></p>
+
+      <div class="prose">
+        <p>这题要求在类型系统里实现冒泡排序：给定一个元组 <code>T extends number[]</code>，返回排序后的元组。类型层面上没有循环，所以核心思路是把「一趟冒泡」展开成递归。</p>
+
+        <h2>一趟冒泡：两两比较并交换</h2>
+        <p>先写一个 <code>Pass</code>，从头到尾扫一遍，相邻逆序就交换。它递归地消费元组的头部两个元素：</p>
+
+<pre><span class="c">// 一趟冒泡：相邻比较，逆序则交换</span>
+<span class="k">type</span> <span class="t">Pass</span>&lt;<span class="t">T</span> <span class="k">extends</span> <span class="t">number</span>[]&gt; =
+  <span class="t">T</span> <span class="k">extends</span> [<span class="k">infer</span> <span class="t">A</span> <span class="k">extends</span> <span class="t">number</span>, <span class="k">infer</span> <span class="t">B</span> <span class="k">extends</span> <span class="t">number</span>, ...<span class="k">infer</span> <span class="t">R</span> <span class="k">extends</span> <span class="t">number</span>[]]
+    ? <span class="t">A</span> <span class="k">extends</span> <span class="s">`${B}`</span>
+      ? [<span class="t">A</span>, ...<span class="t">Pass</span>&lt;[<span class="t">B</span>, ...<span class="t">R</span>]&gt;]
+      : [<span class="t">B</span>, ...<span class="t">Pass</span>&lt;[<span class="t">A</span>, ...<span class="t">R</span>]&gt;]
+    : <span class="t">T</span>;
+
+<span class="k">type</span> <span class="f">BubbleSort</span>&lt;<span class="t">T</span>&gt; = ...<span class="c">// 一趟没交换 → 有序；否则再来一趟</span></pre>
+
+        <blockquote>
+          数字比较不能直接用 <code>&lt;</code>，得转成字符串长度或逐位比较——类型体操的老朋友了。
+          <span class="who">—— 按语</span>
+        </blockquote>
+
+        <h2>几个细节</h2>
+        <ul>
+          <li><code>infer A extends number</code> 收窄推断结果，省掉一层条件判断；</li>
+          <li>终止条件是「这一趟没有发生任何交换」，用深度相等判断；</li>
+          <li>元组很长时记得给 TS 足够的递归深度，或者拆成小测试。</li>
+        </ul>
+        <p>完整题解在仓库 <code>type-challenges</code> 里，配合测试用例食用更佳。</p>
+      </div>
+
+      <div class="backlink"><a href="#" onclick="return false">— 返 目 次 —</a></div>
+    </article>
+
+    <div class="letters">
+      <h3 class="blockhead">读者来函</h3>
+      <div class="letter">
+        <div class="lhead">alice@example.com<span class="when">五月九日</span></div>
+        <p>Equal 判终止这个思路太优雅了，比数长度 hack 干净。</p>
+      </div>
+      <div class="letter reply">
+        <div class="lhead">bob@example.com<span class="when">五月十日</span></div>
+        <p>数长度在负数场景直接爆炸，还是深度相等稳。</p>
+      </div>
+      <form class="letter-form" onsubmit="return false">
+        <input type="text" placeholder="来函一句（支持 markdown）……" aria-label="新评论">
+        <button class="btn red" type="submit">投 函</button>
+      </form>
+    </div>
+  </section>
+
+  <!-- ================= 器物谱 ================= -->
+  <section class="page" data-page="projects" hidden>
+    <h1 class="entry-title" style="text-align:center">器物谱</h1>
+    <p class="entry-meta" style="text-align:center">所制之器 · 自兹编次 · 以志不忘</p>
+
+    <div class="ware">
+      <div class="no">壹<small>FEATURED</small></div>
+      <div>
+        <h2>blog<span class="feat">本集所在</span></h2>
+        <p>本博客——TanStack Start 前台，全量部署在 Cloudflare Workers + D1 上。</p>
+        <div class="tags"><i>TanStack Start</i><i>Cloudflare</i><i>TypeScript</i></div>
+        <div class="wlinks"><a href="#" onclick="return false">源码</a><a href="#" onclick="return false">在线</a></div>
+      </div>
+    </div>
+    <div class="ware">
+      <div class="no">贰<small>FEATURED</small></div>
+      <div>
+        <h2>logseq-plugin-code-formatter</h2>
+        <p>Logseq 插件——用 Prettier 一键格式化代码块，支持 JS / TS / HTML / CSS / Markdown / JSON。</p>
+        <div class="tags"><i>TypeScript</i><i>Logseq</i><i>Prettier</i></div>
+        <div class="wlinks"><a href="#" onclick="return false">源码</a></div>
+      </div>
+    </div>
+    <div class="ware">
+      <div class="no">叁</div>
+      <div>
+        <h2>ocvm</h2>
+        <p>OpenClaw 版本管理器——nvm 风格的 Rust CLI，按项目安装、切换、锁定与回滚版本。</p>
+        <div class="tags"><i>Rust</i><i>CLI</i></div>
+        <div class="wlinks"><a href="#" onclick="return false">源码</a><a href="#" onclick="return false">在线</a></div>
+      </div>
+    </div>
+    <div class="ware">
+      <div class="no">肆</div>
+      <div>
+        <h2>agent-presence</h2>
+        <p>把本地编码 agent 的在线状态与 token 用量同步到飞书签名链接预览。</p>
+        <div class="tags"><i>TypeScript</i><i>CLI</i><i>Feishu</i></div>
+        <div class="wlinks"><a href="#" onclick="return false">源码</a><a href="#" onclick="return false">在线</a></div>
+      </div>
+    </div>
+    <div class="ware" style="border-bottom:0">
+      <div class="no">伍</div>
+      <div>
+        <h2>base64</h2>
+        <p>Moonbit 语言实现的 Base64 编解码库，遵循 RFC 4648。</p>
+        <div class="tags"><i>Moonbit</i></div>
+        <div class="wlinks"><a href="#" onclick="return false">源码</a></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= 入会 login ================= -->
+  <section class="page" data-page="login" hidden>
+    <div class="gate">
+      <div class="card">
+        <span class="seal" aria-hidden="true">潘</span>
+        <h1>入　会</h1>
+        <p class="sub">会友可读「会员可读」篇目 · 亦支持 GitHub 介绍入会</p>
+        <form onsubmit="return false">
+          <div class="field"><label for="b-em">邮　箱</label><input id="b-em" type="email" placeholder="you@example.com"></div>
+          <div class="field"><label for="b-pw">口　令</label><input id="b-pw" type="password" placeholder="••••••••"></div>
+          <div class="actions">
+            <button class="btn red" type="submit">登 入</button>
+            <button class="btn" type="button">GitHub 入会</button>
+          </div>
+          <p class="err" hidden>邮箱或口令不正确</p>
+        </form>
+        <p class="aside">尚未入会？<a href="#" onclick="return false" style="color:var(--red)">注册</a></p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= 注册 ================= -->
+  <section class="page" data-page="signup" hidden>
+    <div class="gate">
+      <div class="card">
+        <span class="seal" aria-hidden="true">潘</span>
+        <h1>注　册</h1>
+        <p class="sub">注册即成为会友（member）</p>
+        <form onsubmit="return false">
+          <div class="field"><label for="b-sem">邮　箱</label><input id="b-sem" type="email" placeholder="you@example.com"></div>
+          <div class="field"><label for="b-spw">口　令</label><input id="b-spw" type="password" placeholder="至少八位"></div>
+          <div class="field"><label for="b-spw2">再录一遍</label><input id="b-spw2" type="password" placeholder="••••••••"></div>
+          <div class="actions">
+            <button class="btn red" type="submit">立 会 籍</button>
+            <button class="btn" type="button">GitHub 注册</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= 密函 unlock ================= -->
+  <section class="page" data-page="unlock" hidden>
+    <div class="gate">
+      <div class="card" style="text-align:center">
+        <div class="lockmark" aria-hidden="true">密</div>
+        <h1>密　笈</h1>
+        <p class="sub">此篇以单文口令封缄 · 验后廿四小时内免复输入</p>
+        <form onsubmit="return false" style="text-align:left">
+          <div class="field"><label for="b-upw">篇目口令</label><input id="b-upw" type="password" placeholder="••••••••" autofocus></div>
+          <div class="actions" style="justify-content:center">
+            <button class="btn red" type="submit">启 封</button>
+          </div>
+          <p class="err" style="text-align:center" hidden>口令有误，请再试</p>
+        </form>
+        <p class="aside"><a href="#" onclick="return false" style="color:var(--indigo)">← 返回篇目</a></p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= 编辑部 admin ================= -->
+  <section class="page" data-page="admin" hidden>
+    <h1 class="entry-title" style="text-align:center">编 辑 部</h1>
+    <p class="entry-meta" style="text-align:center">案卷总理 · 仅编者可见</p>
+    <table class="desk-table">
+      <thead><tr><th>编号</th><th>篇目</th><th>状态</th><th>可见</th><th>更新</th><th>理事</th></tr></thead>
+      <tbody>
+        <tr><td>〇一六</td><td class="t">初探 Github Blocks</td><td>已刊</td><td>公开</td><td>2023-02-18</td><td><a class="op" href="#" onclick="return false">改</a><a class="op del" href="#" onclick="return false">删</a></td></tr>
+        <tr><td>〇一五</td><td class="t">Type Challenge - 冒泡排序</td><td>已刊</td><td>公开</td><td>2021-05-08</td><td><a class="op" href="#" onclick="return false">改</a><a class="op del" href="#" onclick="return false">删</a></td></tr>
+        <tr><td>〇一四</td><td class="t">回顾 2020</td><td>已刊</td><td>会员</td><td>2021-02-28</td><td><a class="op" href="#" onclick="return false">改</a><a class="op del" href="#" onclick="return false">删</a></td></tr>
+        <tr><td>〇一〇</td><td class="t">文档书写要点整理</td><td>已刊</td><td>密笈</td><td>2020-03-01</td><td><a class="op" href="#" onclick="return false">改</a><a class="op del" href="#" onclick="return false">删</a></td></tr>
+        <tr><td>〇一七</td><td class="t">Cloudflare 迁移实录</td><td>草稿</td><td>公开</td><td>2026-08-12</td><td><a class="op" href="#" onclick="return false">改</a><a class="op del" href="#" onclick="return false">删</a></td></tr>
+      </tbody>
+    </table>
+    <div style="display:flex;gap:12px;margin-top:26px">
+      <a class="btn red" href="#" onclick="return false">＋ 新拟一篇</a>
+      <a class="btn" href="#" onclick="return false">读者来函（廿三）</a>
+    </div>
+  </section>
+
+  <!-- ================= 拟稿 editor ================= -->
+  <section class="page" data-page="editor" hidden>
+    <h1 class="entry-title" style="text-align:center;font-size:28px">拟　稿</h1>
+    <p class="entry-meta" style="text-align:center">新篇草拟 · 每 thirty 秒自动存档</p>
+    <form onsubmit="return false" style="max-width:720px;margin:26px auto 0">
+      <div class="editor-grid">
+        <div class="field"><label>篇　目</label><input type="text" value="Cloudflare 迁移实录"></div>
+        <div class="field"><label>档　名</label><input type="text" value="cloudflare-migration"></div>
+        <div class="field"><label>可见性</label>
+          <select><option>公开</option><option>会员</option><option>VIP</option><option>编者</option><option>密笈</option></select>
+        </div>
+        <div class="field"><label>栏　目</label><input type="text" value="工程, Cloudflare, D1"></div>
+      </div>
+      <div class="field"><label>正文（markdown）</label>
+        <textarea class="draft" spellcheck="false">## 为什么要迁
+
+Postgres 免费额度撑不住了……
+
+```ts
+export default { fetch } = ...
+```</textarea>
+      </div>
+      <div class="editor-foot">
+        <button class="btn" type="button">存 草 稿</button>
+        <button class="btn red" type="button">刊 发</button>
+        <span class="stat">六百四十二字 · 约三分钟 · 存档于 12:41</span>
+      </div>
+    </form>
+  </section>
+
+  <!-- ================= 404 ================= -->
+  <section class="page" data-page="404" hidden>
+    <div class="nf404">
+      <div class="seal" style="margin:0 auto 30px">阙</div>
+      <div class="zh">此页未收</div>
+      <p>本刊并无此篇 · 或已散佚</p>
+      <p style="margin-top:26px"><a class="btn" href="#" onclick="return false" style="text-decoration:none">返 目 次</a></p>
+    </div>
+  </section>
+
+  <footer class="colophon">
+    废墨集 · 二〇二六年 · <a href="#" onclick="return false">RSS 订阅</a> · 全刊运行于 <a href="#" onclick="return false">Cloudflare</a> 之上
+  </footer>
+</main>
+
+<!-- 检索 palette -->
+<div class="pal-veil" id="pal-veil" hidden>
+  <div class="pal" role="dialog" aria-label="检索篇目">
+    <div class="pal-in"><span class="mark">按</span><input type="text" id="pal-input" placeholder="检一篇目……" aria-label="检索"></div>
+    <div class="pal-list">
+      <div class="pal-item sel"><span class="d">2021-05</span><span class="t">Type Challenge - 冒泡排序</span></div>
+      <div class="pal-item"><span class="d">2020-04</span><span class="t">LeetCode 中国区 TypeScript 面试题题解</span></div>
+      <div class="pal-item"><span class="d">2019-12</span><span class="t">Codeforces Round#605(Div. 3) D/E/F 题解</span></div>
+      <div class="pal-item"><span class="d">2019-04</span><span class="t">Codeforces 1149B Three Religions</span></div>
+    </div>
+    <div class="pal-foot">↑↓ 选择 · ↵ 开卷 · esc 合上 · 密笈与会员篇目按身份自动隐去</div>
+  </div>
+</div>
+
+<script>
+  var tabs = document.querySelectorAll('.pt-tab');
+  var pages = document.querySelectorAll('.page');
+  function go(id) {
+    pages.forEach(function(p){ p.hidden = p.dataset.page !== id; });
+    tabs.forEach(function(t){ t.classList.toggle('active', t.dataset.target === id); });
+    window.scrollTo(0, 0);
+    history.replaceState(null, '', '#' + id);
+  }
+  tabs.forEach(function(t){ if (t.dataset.target) t.addEventListener('click', function(){ go(t.dataset.target); }); });
+  var h = location.hash.slice(1);
+  if (h && document.querySelector('.page[data-page="' + h + '"]')) go(h);
+  window.addEventListener('hashchange', function(){
+    var h = location.hash.slice(1);
+    if (h && document.querySelector('.page[data-page="' + h + '"]')) go(h);
+  });
+
+  var veil = document.getElementById('pal-veil');
+  var input = document.getElementById('pal-input');
+  document.addEventListener('keydown', function(e){
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') { e.preventDefault(); veil.hidden = false; input.focus(); }
+    if (e.key === 'Escape') veil.hidden = true;
+  });
+  veil.addEventListener('click', function(e){ if (e.target === veil) veil.hidden = true; });
+</script>
+</body>
+</html>

--- a/prototypes/c-swiss.html
+++ b/prototypes/c-swiss.html
@@ -1,0 +1,823 @@
+<!doctype html>
+<html lang="zh-CN" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>方向 C · 瑞士网格 × 评级色 · PerfectPan's Blog 原型</title>
+<style>
+  /* ============ tokens ============ */
+  :root {
+    --bg: #FFFFFF;
+    --surface: #F5F5F3;
+    --ink: #16181D;
+    --dim: #6D717A;
+    --faint: #A6AAB2;
+    --line: #E4E5E7;
+    --line-strong: #16181D;
+    --accent: #E5484D;
+    --accent-soft: rgba(229,72,77,0.08);
+    /* rating palette（算法评级色系） */
+    --r0: #98A0A6;  /* grey   */
+    --r1: #3F9E4C;  /* green  */
+    --r2: #2FA8B8;  /* cyan   */
+    --r3: #3D6BE8;  /* blue   */
+    --r4: #8F5AE8;  /* violet */
+    --r5: #E8973D;  /* orange */
+    --r6: #E5484D;  /* red    */
+    --sans: "Helvetica Neue", Helvetica, Inter, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", system-ui, sans-serif;
+    --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  }
+  [data-theme="dark"] {
+    --bg: #0E0F12;
+    --surface: #16181D;
+    --ink: #EDEEF0;
+    --dim: #8B8F98;
+    --faint: #565A63;
+    --line: #24262C;
+    --line-strong: #EDEEF0;
+    --accent-soft: rgba(229,72,77,0.14);
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: var(--bg); color: var(--ink);
+    font-family: var(--sans); font-size: 15px; line-height: 1.75;
+    -webkit-font-smoothing: antialiased;
+  }
+  ::selection { background: var(--accent); color: #fff; }
+  a { color: inherit; text-decoration: none; }
+  a:hover { color: var(--accent); }
+  :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .mono { font-family: var(--mono); }
+
+  /* ============ prototype chrome ============ */
+  .pt-bar {
+    background: #101114; color: #9A9FA6; font-size: 12.5px;
+    padding: 0 16px; display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
+    position: sticky; top: 0; z-index: 50;
+  }
+  .pt-bar .pt-title { color: #E5484D; font-weight: 700; letter-spacing: 0.06em; }
+  .pt-tab {
+    font-family: inherit; font-size: 12.5px; color: #9A9FA6; background: none;
+    border: 0; padding: 9px 10px; cursor: pointer;
+  }
+  .pt-tab:hover { color: #EDEEF0; }
+  .pt-tab.active { color: #101114; background: #E5484D; font-weight: 700; }
+  .pt-links { margin-left: auto; display: flex; gap: 12px; }
+  .pt-links a { color: #63686F; }
+  .pt-links a:hover { color: #E5484D; }
+
+  /* ============ site header ============ */
+  .site-head {
+    border-bottom: 2px solid var(--line-strong);
+    position: sticky; top: 40px; z-index: 40; background: var(--bg);
+  }
+  .site-head-in {
+    max-width: 1160px; margin: 0 auto; padding: 0 28px;
+    display: flex; align-items: stretch; gap: 0; height: 58px;
+  }
+  .logo {
+    display: flex; align-items: center; font-weight: 800; letter-spacing: -0.02em;
+    font-size: 15.5px; border-right: 1px solid var(--line); padding-right: 22px;
+  }
+  .logo .cursor { display:inline-block; width: 9px; height: 1.05em; background: var(--accent); margin-left: 4px; animation: blink 1.1s steps(1) infinite; }
+  @keyframes blink { 50% { opacity: 0; } }
+  .site-head nav { display: flex; }
+  .site-head nav a {
+    display: flex; align-items: center; padding: 0 16px; font-size: 13.5px;
+    color: var(--dim); letter-spacing: 0.04em; border-right: 1px solid var(--line);
+    position: relative;
+  }
+  .site-head nav a:hover { color: var(--ink); }
+  .site-head nav a.on { color: var(--ink); font-weight: 700; }
+  .site-head nav a.on::after { content: ""; position: absolute; left: 0; right: 0; bottom: -2px; height: 3px; background: var(--accent); }
+  .site-head .tools { margin-left: auto; display: flex; align-items: center; gap: 4px; }
+  .tool-btn {
+    font: inherit; font-size: 12.5px; color: var(--dim); background: none; border: 0;
+    padding: 6px 10px; cursor: pointer; letter-spacing: 0.04em;
+  }
+  .tool-btn:hover { color: var(--ink); }
+  .tool-btn kbd {
+    font-family: var(--mono); font-size: 10.5px; border: 1px solid var(--line);
+    border-radius: 3px; padding: 0 4px; margin-left: 4px; color: var(--faint);
+  }
+
+  /* ============ shared ============ */
+  .page[hidden] { display: none; }
+  .frame { max-width: 1160px; margin: 0 auto; padding: 0 28px 90px; }
+  .rule { border: 0; border-top: 1px solid var(--line); }
+  .rule.strong { border-top: 2px solid var(--line-strong); }
+  .sec-label {
+    font-family: var(--mono); font-size: 11px; letter-spacing: 0.22em;
+    color: var(--faint); text-transform: uppercase;
+  }
+  .no-index { font-family: var(--mono); font-size: 12px; color: var(--faint); letter-spacing: 0.05em; }
+  .btn {
+    font: inherit; font-size: 13.5px; font-weight: 600; cursor: pointer;
+    padding: 10px 22px; border: 1px solid var(--ink); background: transparent; color: var(--ink);
+    transition: background .12s, color .12s;
+  }
+  .btn:hover { background: var(--ink); color: var(--bg); }
+  .btn.solid { background: var(--accent); border-color: var(--accent); color: #fff; }
+  .btn.solid:hover { background: #C93A3F; border-color: #C93A3F; color: #fff; }
+  .btn.ghost { border-color: var(--line); }
+  .btn.ghost:hover { border-color: var(--ink); background: var(--surface); color: var(--ink); }
+
+  /* rating chip */
+  .chip {
+    display: inline-flex; align-items: center; gap: 6px;
+    font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em;
+    border: 1px solid var(--line); padding: 1px 8px; color: var(--dim); white-space: nowrap;
+  }
+  .chip::before { content: ""; width: 7px; height: 7px; border-radius: 50%; background: var(--c, var(--r0)); }
+  .chip.c0 { --c: var(--r0); } .chip.c1 { --c: var(--r1); } .chip.c2 { --c: var(--r2); }
+  .chip.c3 { --c: var(--r3); } .chip.c4 { --c: var(--r4); } .chip.c5 { --c: var(--r5); }
+  .chip.c6 { --c: var(--r6); border-color: rgba(229,72,77,0.4); color: var(--accent); }
+
+  /* visibility marker */
+  .vis { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.08em; color: var(--faint); }
+  .vis::before { content: "● "; font-size: 8px; vertical-align: 2px; }
+  .vis.mem { color: var(--r3); } .vis.vip { color: var(--r4); } .vis.pw { color: var(--accent); }
+
+  /* ============ HOME ============ */
+  .hero { padding: 64px 0 44px; }
+  .hero .kicker { display: flex; gap: 14px; align-items: baseline; margin-bottom: 18px; }
+  .hero h1 {
+    font-size: clamp(46px, 9vw, 108px); font-weight: 800; letter-spacing: -0.045em;
+    line-height: 0.98;
+  }
+  .hero h1 .hollow {
+    color: transparent; -webkit-text-stroke: 1.5px var(--ink);
+  }
+  .hero h1 .dot { color: var(--accent); }
+  .hero .sub { color: var(--dim); margin-top: 20px; max-width: 56ch; font-size: 15.5px; }
+  .home-cols {
+    display: grid; grid-template-columns: 1.4fr 1fr 1fr; border: 1px solid var(--line); border-top: 2px solid var(--line-strong);
+  }
+  .home-col { padding: 22px 24px 26px; border-right: 1px solid var(--line); }
+  .home-col:last-child { border-right: 0; }
+  .home-col h3 { font-size: 12px; letter-spacing: 0.2em; font-family: var(--mono); color: var(--faint); font-weight: 500; margin-bottom: 14px; }
+  .latest-item { display: flex; gap: 12px; padding: 9px 0; border-bottom: 1px solid var(--line); align-items: baseline; }
+  .latest-item:last-child { border-bottom: 0; }
+  .latest-item .t { flex: 1; font-weight: 600; font-size: 14.5px; }
+  .latest-item .t:hover { color: var(--accent); }
+  .latest-item .d { font-family: var(--mono); font-size: 11px; color: var(--faint); white-space: nowrap; }
+  .stat-row { display: flex; justify-content: space-between; align-items: baseline; padding: 8px 0; border-bottom: 1px solid var(--line); }
+  .stat-row:last-child { border-bottom: 0; }
+  .stat-row b { font-family: var(--mono); font-size: 22px; font-weight: 600; letter-spacing: -0.02em; }
+  .stat-row b.red { color: var(--accent); }
+  .stat-row span { font-size: 12.5px; color: var(--dim); }
+
+  /* ============ BLOG LIST ============ */
+  .list-head {
+    display: flex; align-items: baseline; gap: 18px; padding: 44px 0 14px;
+  }
+  .list-head h1 { font-size: 40px; font-weight: 800; letter-spacing: -0.03em; }
+  .list-head .count { font-family: var(--mono); font-size: 12px; color: var(--faint); }
+  .list-head .filters { margin-left: auto; display: flex; gap: 6px; flex-wrap: wrap; }
+  .filter {
+    font-family: var(--mono); font-size: 11.5px; padding: 4px 12px; cursor: pointer;
+    border: 1px solid var(--line); background: none; color: var(--dim);
+  }
+  .filter:hover { border-color: var(--ink); color: var(--ink); }
+  .filter.on { background: var(--ink); color: var(--bg); border-color: var(--ink); }
+  .rowlist { border-top: 2px solid var(--line-strong); }
+  .row {
+    display: grid; grid-template-columns: 64px 1fr auto 92px; gap: 20px;
+    padding: 15px 10px; border-bottom: 1px solid var(--line); align-items: center;
+    position: relative; transition: background .1s;
+  }
+  a.row:hover { background: var(--accent-soft); color: inherit; }
+  a.row:hover::before { content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 3px; background: var(--accent); }
+  .row .t { font-weight: 600; font-size: 16px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .row .t .vis { margin-left: 12px; }
+  .row .tags { display: flex; gap: 6px; flex-wrap: wrap; justify-content: flex-end; }
+  .row .d { font-family: var(--mono); font-size: 11.5px; color: var(--faint); text-align: right; }
+  .year-mark {
+    font-family: var(--mono); font-size: 12px; color: var(--faint); letter-spacing: 0.2em;
+    padding: 26px 10px 6px; display: flex; align-items: center; gap: 12px;
+  }
+  .year-mark::after { content: ""; flex: 1; border-top: 1px solid var(--line); }
+  .pager { display: flex; gap: 8px; justify-content: center; padding: 36px 0 0; }
+  .pager button, .pager .cur { font-family: var(--mono); font-size: 12px; padding: 6px 14px; border: 1px solid var(--line); background: none; color: var(--dim); cursor: pointer; }
+  .pager .cur { background: var(--ink); color: var(--bg); border-color: var(--ink); }
+
+  /* ============ ARTICLE ============ */
+  .art-grid { display: grid; grid-template-columns: 220px 1fr; gap: 48px; padding-top: 44px; }
+  .meta-rail { position: sticky; top: 138px; align-self: start; }
+  .meta-rail .bigno { font-family: var(--mono); font-size: 44px; font-weight: 300; color: var(--faint); letter-spacing: -0.02em; }
+  .meta-rail .bigno b { color: var(--accent); font-weight: 300; }
+  .meta-rail dl { margin: 18px 0; }
+  .meta-rail dt { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.18em; color: var(--faint); margin-top: 12px; }
+  .meta-rail dd { font-size: 13.5px; color: var(--ink); }
+  .meta-rail .toc a { display: block; font-size: 13px; color: var(--dim); padding: 3px 0; border-left: 2px solid var(--line); padding-left: 10px; }
+  .meta-rail .toc a:hover { color: var(--accent); border-color: var(--accent); }
+  .art-title h1 { font-size: clamp(28px, 4.4vw, 42px); font-weight: 800; letter-spacing: -0.03em; line-height: 1.25; }
+  .art-title .bar { height: 4px; background: linear-gradient(90deg, var(--accent) 0 64px, var(--line) 64px); margin: 18px 0 8px; }
+  .prose { max-width: 68ch; font-size: 16px; }
+  .prose p { margin: 18px 0; color: var(--ink); }
+  .prose h2 { font-size: 22px; font-weight: 800; letter-spacing: -0.02em; margin: 40px 0 12px; padding-top: 18px; border-top: 1px solid var(--line); }
+  .prose h2 .no { font-family: var(--mono); font-size: 12px; color: var(--accent); font-weight: 400; margin-right: 12px; }
+  .prose ul { margin: 14px 0; list-style: none; }
+  .prose li { padding: 6px 0 6px 24px; position: relative; }
+  .prose li::before { content: "→"; position: absolute; left: 0; color: var(--accent); font-family: var(--mono); }
+  .prose blockquote { border-left: 3px solid var(--accent); padding: 10px 20px; margin: 20px 0; background: var(--surface); color: var(--dim); }
+  .prose code.inline { font-family: var(--mono); font-size: 0.85em; background: var(--surface); border: 1px solid var(--line); padding: 1px 6px; }
+  .prose pre {
+    font-family: var(--mono); font-size: 13px; line-height: 1.75; background: var(--surface);
+    border: 1px solid var(--line); border-left: 3px solid var(--ink);
+    padding: 18px 20px; overflow-x: auto; margin: 22px 0;
+  }
+  [data-theme="light"] .prose pre { background: #14161A; border-color: #14161A; color: #DDE1E8; }
+  .pre-wrap { position: relative; }
+  .pre-wrap .fname { position: absolute; top: 0; right: 0; font-family: var(--mono); font-size: 10.5px; color: var(--faint); background: var(--bg); border: 1px solid var(--line); border-top: 0; border-right: 0; padding: 1px 10px; }
+  .tk-c { color: #7A828E; } .tk-k { color: #C792EA; } .tk-f { color: #82AAFF; }
+  .tk-s { color: #C3E88D; } .tk-t { color: #FFCB6B; }
+
+  /* comments */
+  .cmt-head { display: flex; align-items: baseline; gap: 14px; margin: 56px 0 6px; }
+  .cmt-head h2 { font-size: 14px; letter-spacing: 0.16em; font-family: var(--mono); font-weight: 600; }
+  .cmt-head .n { font-family: var(--mono); font-size: 11px; color: var(--accent); }
+  .cmt { border: 1px solid var(--line); margin-top: -1px; }
+  .cmt-in { padding: 14px 18px; }
+  .cmt-h { display: flex; gap: 12px; font-size: 12px; color: var(--dim); margin-bottom: 6px; font-family: var(--mono); }
+  .cmt-h .who { color: var(--ink); font-weight: 600; }
+  .cmt.reply { margin: 0 0 -1px 44px; border-left: 3px solid var(--line); background: var(--surface); }
+  .cmt-form { display: flex; gap: 0; margin-top: 18px; border: 1px solid var(--ink); }
+  .cmt-form input { flex: 1; border: 0; padding: 12px 16px; font: inherit; background: var(--bg); color: var(--ink); }
+  .cmt-form input:focus { outline: none; }
+  .cmt-form button { border: 0; border-left: 1px solid var(--ink); background: var(--ink); color: var(--bg); font: inherit; font-size: 13px; font-weight: 600; padding: 0 24px; cursor: pointer; }
+  .cmt-form button:hover { background: var(--accent); border-color: var(--accent); color: #fff; }
+
+  /* ============ PROJECTS ============ */
+  .proj { border-top: 2px solid var(--line-strong); }
+  .proj-row {
+    display: grid; grid-template-columns: 130px 1.2fr 1fr auto; gap: 24px;
+    padding: 24px 10px; border-bottom: 1px solid var(--line); align-items: start;
+  }
+  .proj-row:hover { background: var(--surface); }
+  .proj-row .idx { font-family: var(--mono); font-size: 26px; font-weight: 300; color: var(--faint); }
+  .proj-row .idx .feat { display: block; font-size: 9.5px; letter-spacing: 0.24em; color: var(--accent); margin-top: 2px; }
+  .proj-row h2 { font-size: 18px; font-weight: 800; letter-spacing: -0.01em; }
+  .proj-row p { font-size: 13.5px; color: var(--dim); margin-top: 6px; }
+  .proj-row .tags { display: flex; gap: 6px; flex-wrap: wrap; padding-top: 4px; }
+  .proj-row .links { display: flex; flex-direction: column; gap: 8px; font-family: var(--mono); font-size: 12px; text-align: right; }
+  .proj-row .links a { color: var(--dim); border-bottom: 1px solid var(--line); padding-bottom: 1px; }
+  .proj-row .links a:hover { color: var(--accent); border-color: var(--accent); }
+
+  /* ============ AUTH / UNLOCK ============ */
+  .auth-wrap { max-width: 440px; margin: 60px auto 0; }
+  .auth-head { display: flex; align-items: baseline; justify-content: space-between; padding-bottom: 10px; }
+  .auth-head h1 { font-size: 24px; font-weight: 800; letter-spacing: -0.02em; }
+  .auth-card { border: 1px solid var(--ink); padding: 30px 30px 34px; }
+  .auth-card::before { content: ""; display: block; height: 4px; background: var(--accent); margin: -30px -30px 26px; }
+  .field { margin: 16px 0; }
+  .field label { display: block; font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.2em; color: var(--faint); margin-bottom: 6px; text-transform: uppercase; }
+  input[type=text], input[type=email], input[type=password], textarea, select {
+    width: 100%; font: inherit; font-size: 14.5px; color: var(--ink);
+    background: var(--bg); border: 1px solid var(--line); padding: 10px 13px;
+  }
+  input:focus, textarea:focus, select:focus { outline: none; border-color: var(--ink); }
+  .auth-actions { display: flex; gap: 10px; margin-top: 24px; flex-wrap: wrap; }
+  .auth-aside { margin-top: 18px; font-size: 13px; color: var(--dim); }
+  .auth-aside a { color: var(--accent); }
+  .err { margin-top: 12px; font-size: 13px; color: var(--accent); border: 1px solid rgba(229,72,77,0.35); background: var(--accent-soft); padding: 8px 12px; }
+  .lockline { display: flex; align-items: center; gap: 10px; font-family: var(--mono); font-size: 11px; letter-spacing: 0.16em; color: var(--accent); margin-bottom: 14px; }
+  .lockline::after { content: ""; flex: 1; border-top: 1px solid rgba(229,72,77,0.4); }
+
+  /* ============ ADMIN ============ */
+  .adm-head { display: flex; align-items: baseline; gap: 16px; padding: 40px 0 14px; }
+  .adm-head h1 { font-size: 26px; font-weight: 800; }
+  .adm-head .spacer { flex: 1; }
+  table.adm { width: 100%; border-collapse: collapse; border-top: 2px solid var(--line-strong); font-size: 13.5px; }
+  .adm th { text-align: left; font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.16em; color: var(--faint); font-weight: 500; padding: 10px 10px; border-bottom: 1px solid var(--line); }
+  .adm td { padding: 11px 10px; border-bottom: 1px solid var(--line); }
+  .adm tbody tr:hover td { background: var(--surface); }
+  .adm td.tt { font-weight: 600; }
+  .adm .st { font-family: var(--mono); font-size: 11px; }
+  .adm .st.pub { color: var(--r1); } .adm .st.draft { color: var(--faint); }
+  .adm .ops { display: flex; gap: 12px; font-family: var(--mono); font-size: 11.5px; }
+  .adm .ops a:hover { color: var(--accent); }
+  .ed-grid { display: grid; grid-template-columns: 260px 1fr; gap: 36px; padding-top: 40px; }
+  .ed-side { border-left: 3px solid var(--ink); padding-left: 18px; }
+  .ed-main textarea { min-height: 380px; font-family: var(--mono); font-size: 13.5px; line-height: 1.8; }
+  .ed-foot { display: flex; gap: 10px; margin-top: 16px; align-items: center; flex-wrap: wrap; }
+  .ed-foot .stat { margin-left: auto; font-family: var(--mono); font-size: 11px; color: var(--faint); }
+
+  /* ============ 404 ============ */
+  .nf { text-align: left; padding: 70px 0 30px; }
+  .nf .code { font-family: var(--mono); font-size: clamp(90px, 18vw, 190px); font-weight: 300; letter-spacing: -0.05em; line-height: 1; }
+  .nf .code b { color: var(--accent); font-weight: 300; }
+  .nf p { color: var(--dim); margin-top: 14px; }
+
+  /* ============ palette ============ */
+  .pal-veil { position: fixed; inset: 0; background: rgba(10,11,14,0.42); display: flex; justify-content: center; padding-top: 13vh; z-index: 100; }
+  .pal-veil[hidden] { display: none; }
+  .pal {
+    width: min(620px, calc(100vw - 32px)); height: fit-content;
+    background: var(--bg); border: 1px solid var(--ink); overflow: hidden;
+    box-shadow: 0 24px 70px rgba(0,0,0,0.28);
+  }
+  .pal::before { content: ""; display: block; height: 4px; background: var(--accent); }
+  .pal-in { display: flex; gap: 12px; align-items: center; padding: 14px 18px; border-bottom: 1px solid var(--line); }
+  .pal-in input { border: 0; padding: 0; font-size: 15px; background: none; }
+  .pal-in input:focus { box-shadow: none; }
+  .pal-list { max-height: 310px; overflow-y: auto; }
+  .pal-item { display: grid; grid-template-columns: 64px 1fr auto; gap: 14px; padding: 11px 18px; align-items: baseline; }
+  .pal-item .d { font-family: var(--mono); font-size: 11px; color: var(--faint); }
+  .pal-item .t { font-weight: 600; font-size: 14px; }
+  .pal-item.sel { background: var(--accent-soft); box-shadow: inset 3px 0 0 var(--accent); }
+  .pal-foot { border-top: 1px solid var(--line); padding: 8px 18px; font-family: var(--mono); font-size: 10.5px; color: var(--faint); letter-spacing: 0.08em; }
+
+  @media (max-width: 900px) {
+    .home-cols { grid-template-columns: 1fr; }
+    .home-col { border-right: 0; border-bottom: 1px solid var(--line); }
+    .art-grid { grid-template-columns: 1fr; }
+    .meta-rail { position: static; display: flex; gap: 28px; flex-wrap: wrap; }
+    .meta-rail .bigno { font-size: 30px; }
+    .row { grid-template-columns: 48px 1fr; }
+    .row .tags, .row .d { display: none; }
+    .proj-row { grid-template-columns: 70px 1fr; }
+    .proj-row .links { flex-direction: row; gap: 18px; grid-column: 2; text-align: left; }
+    .site-head nav a { padding: 0 10px; }
+  }
+</style>
+</head>
+<body>
+
+<!-- prototype chrome -->
+<div class="pt-bar">
+  <span class="pt-title">原型 · 方向 C 瑞士网格</span>
+  <nav aria-label="原型页面" style="display:flex;gap:2px;flex-wrap:wrap">
+    <button class="pt-tab active" data-target="home">首页</button>
+    <button class="pt-tab" data-target="blog">博客</button>
+    <button class="pt-tab" data-target="post">文章</button>
+    <button class="pt-tab" data-target="projects">项目</button>
+    <button class="pt-tab" data-target="login">登录</button>
+    <button class="pt-tab" data-target="signup">注册</button>
+    <button class="pt-tab" data-target="unlock">解锁</button>
+    <button class="pt-tab" data-target="admin">后台</button>
+    <button class="pt-tab" data-target="editor">编辑器</button>
+    <button class="pt-tab" data-target="404">404</button>
+  </nav>
+  <div class="pt-links"><a href="index.html">总览</a><a href="a-terminal.html">方向 A</a><a href="b-journal.html">方向 B</a></div>
+</div>
+
+<!-- site header -->
+<header class="site-head">
+  <div class="site-head-in">
+    <a class="logo" href="#" onclick="return false">PERFECTPAN<span class="cursor"></span></a>
+    <nav>
+      <a href="#" onclick="return false">Home</a>
+      <a href="#" onclick="return false" class="on">Blog</a>
+      <a href="#" onclick="return false">Projects</a>
+      <a href="#" onclick="return false">Admin</a>
+    </nav>
+    <div class="tools">
+      <button class="tool-btn" id="pal-open">Search<kbd>⌘K</kbd></button>
+      <button class="tool-btn" id="theme-toggle">◐ Dark</button>
+      <a class="tool-btn" href="#" onclick="return false">RSS</a>
+      <a class="tool-btn" href="#" onclick="return false">GitHub</a>
+    </div>
+  </div>
+</header>
+
+<div class="frame">
+
+  <!-- ================= HOME ================= -->
+  <section class="page" data-page="home">
+    <div class="hero">
+      <div class="kicker"><span class="sec-label">Personal Index — Since 2019</span><span class="no-index">/ perfectpan.org</span></div>
+      <h1><span class="hollow">PERFECT</span>PAN<span class="dot">.</span></h1>
+      <p class="sub">算法竞赛退役选手、前端工程师。写类型体操、Cloudflare 上的 $0 工程实践，以及一些随想。是个什么都不会的废物.jpg —— 但文档还在更新。</p>
+    </div>
+    <div class="home-cols">
+      <div class="home-col">
+        <h3>最新文章 / LATEST</h3>
+        <div class="latest-item"><span class="no-index">016</span><a class="t" href="#" onclick="return false">初探 Github Blocks</a><span class="d">2023-02</span></div>
+        <div class="latest-item"><span class="no-index">015</span><a class="t" href="#" onclick="return false">Type Challenge - 冒泡排序</a><span class="d">2021-05</span></div>
+        <div class="latest-item"><span class="no-index">014</span><a class="t" href="#" onclick="return false">回顾 2020</a><span class="d">2021-02</span></div>
+        <div class="latest-item"><span class="no-index">013</span><a class="t" href="#" onclick="return false">一些随想</a><span class="d">2020-08</span></div>
+      </div>
+      <div class="home-col">
+        <h3>项目 / WORK</h3>
+        <div class="latest-item"><a class="t" href="#" onclick="return false">blog</a><span class="d">★</span></div>
+        <div class="latest-item"><a class="t" href="#" onclick="return false">logseq-plugin-code-formatter</a><span class="d">★</span></div>
+        <div class="latest-item"><a class="t" href="#" onclick="return false">ocvm</a><span class="d"></span></div>
+        <div class="latest-item"><a class="t" href="#" onclick="return false">agent-presence</a><span class="d"></span></div>
+      </div>
+      <div class="home-col">
+        <h3>数据 / INDEX</h3>
+        <div class="stat-row"><b class="red">16</b><span>篇文章</span></div>
+        <div class="stat-row"><b>5</b><span>个开源项目</span></div>
+        <div class="stat-row"><b>4</b><span>个年份卷宗</span></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= BLOG ================= -->
+  <section class="page" data-page="blog" hidden>
+    <div class="list-head">
+      <h1>Blog</h1>
+      <span class="count mono">— 16 entries / 2 pages</span>
+      <div class="filters">
+        <button class="filter on">全部</button>
+        <button class="filter">算法</button>
+        <button class="filter">TypeScript</button>
+        <button class="filter">随笔</button>
+        <button class="filter">工程</button>
+      </div>
+    </div>
+    <div class="rowlist">
+      <div class="year-mark">2023</div>
+      <a class="row" href="#" onclick="return false">
+        <span class="no-index">016</span>
+        <span class="t">初探 Github Blocks</span>
+        <span class="tags"><span class="chip c0">Misc</span></span>
+        <span class="d">02-18</span>
+      </a>
+      <div class="year-mark">2021</div>
+      <a class="row" href="#" onclick="return false">
+        <span class="no-index">015</span>
+        <span class="t">Type Challenge - 冒泡排序</span>
+        <span class="tags"><span class="chip c3">TypeScript</span></span>
+        <span class="d">05-08</span>
+      </a>
+      <a class="row" href="#" onclick="return false">
+        <span class="no-index">014</span>
+        <span class="t">回顾 2020<span class="vis mem">MEMBER</span></span>
+        <span class="tags"><span class="chip c0">Life</span></span>
+        <span class="d">02-28</span>
+      </a>
+      <div class="year-mark">2020</div>
+      <a class="row" href="#" onclick="return false">
+        <span class="no-index">013</span>
+        <span class="t">一些随想</span>
+        <span class="tags"><span class="chip c0">随笔</span></span>
+        <span class="d">08-26</span>
+      </a>
+      <a class="row" href="#" onclick="return false">
+        <span class="no-index">012</span>
+        <span class="t">LeetCode 中国区 TypeScript 面试题题解</span>
+        <span class="tags"><span class="chip c3">TypeScript</span></span>
+        <span class="d">04-13</span>
+      </a>
+      <a class="row" href="#" onclick="return false">
+        <span class="no-index">011</span>
+        <span class="t">那些年邂逅的 LeetCode 趣/难题</span>
+        <span class="tags"><span class="chip c5">LeetCode</span></span>
+        <span class="d">03-30</span>
+      </a>
+      <a class="row" href="#" onclick="return false">
+        <span class="no-index">010</span>
+        <span class="t">文档书写要点整理<span class="vis pw">PASSWORD</span></span>
+        <span class="tags"><span class="chip c6">LOCKED</span></span>
+        <span class="d">03-01</span>
+      </a>
+      <div class="year-mark">2019</div>
+      <a class="row" href="#" onclick="return false">
+        <span class="no-index">009</span>
+        <span class="t">回顾 2019<span class="vis vip">VIP</span></span>
+        <span class="tags"><span class="chip c0">Life</span></span>
+        <span class="d">12-31</span>
+      </a>
+      <a class="row" href="#" onclick="return false">
+        <span class="no-index">008</span>
+        <span class="t">Codeforces Round#605(Div. 3) D/E/F 题解</span>
+        <span class="tags"><span class="chip c4">DP</span><span class="chip c2">BFS</span></span>
+        <span class="d">12-14</span>
+      </a>
+      <a class="row" href="#" onclick="return false">
+        <span class="no-index">007</span>
+        <span class="t">Codeforces Round#603(Div. 2) E/F 题解</span>
+        <span class="tags"><span class="chip c4">DP</span><span class="chip c2">Stack</span></span>
+        <span class="d">12-01</span>
+      </a>
+      <a class="row" href="#" onclick="return false">
+        <span class="no-index">006</span>
+        <span class="t">银联极客高校挑战赛复赛 D 多项式</span>
+        <span class="tags"><span class="chip c4">DP</span></span>
+        <span class="d">09-17</span>
+      </a>
+      <a class="row" href="#" onclick="return false">
+        <span class="no-index">005</span>
+        <span class="t">Codeforces 1149B Three Religions</span>
+        <span class="tags"><span class="chip c4">DP</span><span class="chip c3">String</span></span>
+        <span class="d">04-30</span>
+      </a>
+      <a class="row" href="#" onclick="return false">
+        <span class="no-index">004</span>
+        <span class="t">2019 ICPC 南昌邀请赛网络赛 G. tsy's number</span>
+        <span class="tags"><span class="chip c1">Number Theory</span></span>
+        <span class="d">04-22</span>
+      </a>
+    </div>
+    <div class="pager">
+      <button class="cur">1</button><button>2</button>
+      <button>next →</button>
+    </div>
+  </section>
+
+  <!-- ================= ARTICLE ================= -->
+  <section class="page" data-page="post" hidden>
+    <div class="art-grid">
+      <aside class="meta-rail">
+        <div class="bigno">№<b>015</b></div>
+        <dl>
+          <dt>DATE</dt><dd>2021-05-08</dd>
+          <dt>READING</dt><dd>9 min</dd>
+          <dt>TAGS</dt><dd><span class="chip c3">TypeScript</span></dd>
+          <dt>VISIBILITY</dt><dd><span class="vis">PUBLIC</span></dd>
+        </dl>
+        <div class="toc">
+          <dt style="font-family:var(--mono);font-size:10.5px;letter-spacing:0.18em;color:var(--faint);margin-bottom:6px">ON THIS PAGE</dt>
+          <a href="#" onclick="return false">一趟冒泡</a>
+          <a href="#" onclick="return false">几个细节</a>
+        </div>
+      </aside>
+      <article>
+        <div class="art-title">
+          <h1>Type Challenge - 冒泡排序</h1>
+          <div class="bar"></div>
+        </div>
+        <div class="prose">
+          <p>这题要求在类型系统里实现冒泡排序：给定一个元组 <code class="inline">T extends number[]</code>，返回排序后的元组。类型层面上没有循环，所以核心思路是把「一趟冒泡」展开成递归。</p>
+
+          <h2><span class="no">01</span>一趟冒泡：两两比较并交换</h2>
+          <p>先写一个 <code class="inline">Pass</code>，从头到尾扫一遍，相邻逆序就交换。它递归地消费元组的头部两个元素：</p>
+
+          <div class="pre-wrap"><span class="fname">bubble.ts</span>
+<pre><span class="tk-c">// 一趟冒泡：相邻比较，逆序则交换</span>
+<span class="tk-k">type</span> <span class="tk-t">Pass</span>&lt;<span class="tk-t">T</span> <span class="tk-k">extends</span> <span class="tk-t">number</span>[]&gt; =
+  <span class="tk-t">T</span> <span class="tk-k">extends</span> [<span class="tk-k">infer</span> <span class="tk-t">A</span> <span class="tk-k">extends</span> <span class="tk-t">number</span>, <span class="tk-k">infer</span> <span class="tk-t">B</span> <span class="tk-k">extends</span> <span class="tk-t">number</span>, ...<span class="tk-k">infer</span> <span class="tk-t">R</span> <span class="tk-k">extends</span> <span class="tk-t">number</span>[]]
+    ? <span class="tk-t">A</span> <span class="tk-k">extends</span> <span class="tk-s">`${B}`</span>
+      ? [<span class="tk-t">A</span>, ...<span class="tk-t">Pass</span>&lt;[<span class="tk-t">B</span>, ...<span class="tk-t">R</span>]&gt;]
+      : [<span class="tk-t">B</span>, ...<span class="tk-t">Pass</span>&lt;[<span class="tk-t">A</span>, ...<span class="tk-t">R</span>]&gt;]
+    : <span class="tk-t">T</span>;
+
+<span class="tk-k">type</span> <span class="tk-f">BubbleSort</span>&lt;<span class="tk-t">T</span>&gt; = ...<span class="tk-c">// 一趟没交换 → 有序；否则再来一趟</span></pre>
+          </div>
+
+          <blockquote>数字比较不能直接用 <code class="inline">&lt;</code>，得转成字符串长度或逐位比较——类型体操的老朋友了。</blockquote>
+
+          <h2><span class="no">02</span>几个细节</h2>
+          <ul>
+            <li><code class="inline">infer A extends number</code> 收窄推断结果，省掉一层条件判断；</li>
+            <li>终止条件是「这一趟没有发生任何交换」，用深度相等判断；</li>
+            <li>元组很长时记得给 TS 足够的递归深度，或者拆成小测试。</li>
+          </ul>
+          <p>完整题解在仓库 <code class="inline">type-challenges</code> 里，配合测试用例食用更佳。</p>
+        </div>
+
+        <div class="cmt-head"><h2>COMMENTS</h2><span class="n mono">2</span></div>
+        <div class="cmt">
+          <div class="cmt-in">
+            <div class="cmt-h"><span class="who">alice@example.com</span><span>2021-05-09</span></div>
+            <p>Equal 判终止这个思路太优雅了，比数长度 hack 干净。</p>
+          </div>
+        </div>
+        <div class="cmt reply">
+          <div class="cmt-in">
+            <div class="cmt-h"><span class="who">bob@example.com</span><span>2021-05-10</span></div>
+            <p>数长度在负数场景直接爆炸，还是深度相等稳。</p>
+          </div>
+        </div>
+        <form class="cmt-form" onsubmit="return false">
+          <input type="text" placeholder="写下评论…（支持 markdown）" aria-label="新评论">
+          <button type="submit">评论 →</button>
+        </form>
+      </article>
+    </div>
+  </section>
+
+  <!-- ================= PROJECTS ================= -->
+  <section class="page" data-page="projects" hidden>
+    <div class="list-head">
+      <h1>Projects</h1>
+      <span class="count mono">— 5 works / 2 featured</span>
+    </div>
+    <div class="proj">
+      <div class="proj-row">
+        <div class="idx">01<span class="feat">FEATURED</span></div>
+        <div>
+          <h2>blog</h2>
+          <p>本博客——TanStack Start 前台，全量部署在 Cloudflare Workers + D1 上。</p>
+        </div>
+        <div class="tags"><span class="chip c3">TanStack Start</span><span class="chip c2">Cloudflare</span><span class="chip c0">TypeScript</span></div>
+        <div class="links"><a href="#" onclick="return false">CODE ↗</a><a href="#" onclick="return false">DEMO ↗</a></div>
+      </div>
+      <div class="proj-row">
+        <div class="idx">02<span class="feat">FEATURED</span></div>
+        <div>
+          <h2>logseq-plugin-code-formatter</h2>
+          <p>Logseq 插件——用 Prettier 一键格式化代码块，支持 JS / TS / HTML / CSS / Markdown / JSON。</p>
+        </div>
+        <div class="tags"><span class="chip c3">TypeScript</span><span class="chip c0">Logseq</span><span class="chip c2">Prettier</span></div>
+        <div class="links"><a href="#" onclick="return false">CODE ↗</a></div>
+      </div>
+      <div class="proj-row">
+        <div class="idx">03</div>
+        <div>
+          <h2>ocvm</h2>
+          <p>OpenClaw 版本管理器——nvm 风格的 Rust CLI，按项目安装、切换、锁定与回滚版本。</p>
+        </div>
+        <div class="tags"><span class="chip c4">Rust</span><span class="chip c0">CLI</span></div>
+        <div class="links"><a href="#" onclick="return false">CODE ↗</a><a href="#" onclick="return false">DEMO ↗</a></div>
+      </div>
+      <div class="proj-row">
+        <div class="idx">04</div>
+        <div>
+          <h2>agent-presence</h2>
+          <p>把本地编码 agent 的在线状态与 token 用量同步到飞书签名链接预览。</p>
+        </div>
+        <div class="tags"><span class="chip c3">TypeScript</span><span class="chip c0">CLI</span><span class="chip c5">Feishu</span></div>
+        <div class="links"><a href="#" onclick="return false">CODE ↗</a><a href="#" onclick="return false">DEMO ↗</a></div>
+      </div>
+      <div class="proj-row">
+        <div class="idx">05</div>
+        <div>
+          <h2>base64</h2>
+          <p>Moonbit 语言实现的 Base64 编解码库，遵循 RFC 4648。</p>
+        </div>
+        <div class="tags"><span class="chip c1">Moonbit</span></div>
+        <div class="links"><a href="#" onclick="return false">CODE ↗</a></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= LOGIN ================= -->
+  <section class="page" data-page="login" hidden>
+    <div class="auth-wrap">
+      <div class="auth-head"><h1>登录</h1><span class="no-index">AUTH / 01</span></div>
+      <div class="auth-card">
+        <form onsubmit="return false">
+          <div class="field"><label for="c-em">Email</label><input id="c-em" type="email" placeholder="you@example.com"></div>
+          <div class="field"><label for="c-pw">Password</label><input id="c-pw" type="password" placeholder="••••••••"></div>
+          <div class="auth-actions">
+            <button class="btn solid" type="submit">登录</button>
+            <button class="btn ghost" type="button">GitHub 登录</button>
+          </div>
+          <p class="err" hidden>邮箱或密码不正确</p>
+        </form>
+        <p class="auth-aside">登录后可读 member 篇目 · <a href="#" onclick="return false">没有账号？注册</a></p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= SIGNUP ================= -->
+  <section class="page" data-page="signup" hidden>
+    <div class="auth-wrap">
+      <div class="auth-head"><h1>注册</h1><span class="no-index">AUTH / 02</span></div>
+      <div class="auth-card">
+        <form onsubmit="return false">
+          <div class="field"><label for="c-sem">Email</label><input id="c-sem" type="email" placeholder="you@example.com"></div>
+          <div class="field"><label for="c-spw">Password</label><input id="c-spw" type="password" placeholder="至少 8 位"></div>
+          <div class="field"><label for="c-spw2">Confirm</label><input id="c-spw2" type="password" placeholder="再输一遍"></div>
+          <div class="auth-actions">
+            <button class="btn solid" type="submit">创建账号</button>
+            <button class="btn ghost" type="button">GitHub 注册</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= UNLOCK ================= -->
+  <section class="page" data-page="unlock" hidden>
+    <div class="auth-wrap">
+      <div class="auth-head"><h1>解锁文章</h1><span class="no-index">AUTH / 03</span></div>
+      <div class="auth-card">
+        <div class="lockline">LOCKED ENTRY · №010</div>
+        <form onsubmit="return false">
+          <div class="field"><label for="c-upw">单文密码</label><input id="c-upw" type="password" placeholder="••••••••" autofocus></div>
+          <p class="err">密码错误，请重试（连续失败会触发限流）</p>
+          <div class="auth-actions">
+            <button class="btn solid" type="submit">解锁</button>
+            <a class="btn ghost" href="#" onclick="return false">← 返回文章</a>
+          </div>
+        </form>
+        <p class="auth-aside">验证后 24 小时内免密阅读本篇。</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= ADMIN ================= -->
+  <section class="page" data-page="admin" hidden>
+    <div class="adm-head">
+      <h1>后台</h1><span class="no-index">ADMIN / DASHBOARD</span>
+      <span class="spacer"></span>
+      <a class="btn solid" href="#" onclick="return false" style="text-decoration:none">＋ 新文章</a>
+      <a class="btn ghost" href="#" onclick="return false" style="text-decoration:none">评论管理</a>
+    </div>
+    <table class="adm">
+      <thead><tr><th>№</th><th>标题</th><th>状态</th><th>可见性</th><th>更新时间</th><th>操作</th></tr></thead>
+      <tbody>
+        <tr><td class="mono">016</td><td class="tt">初探 Github Blocks</td><td class="st pub">● published</td><td class="mono">public</td><td class="mono">2023-02-18</td><td class="ops"><a href="#" onclick="return false">编辑</a><a href="#" onclick="return false">删除</a></td></tr>
+        <tr><td class="mono">015</td><td class="tt">Type Challenge - 冒泡排序</td><td class="st pub">● published</td><td class="mono">public</td><td class="mono">2021-05-08</td><td class="ops"><a href="#" onclick="return false">编辑</a><a href="#" onclick="return false">删除</a></td></tr>
+        <tr><td class="mono">014</td><td class="tt">回顾 2020</td><td class="st pub">● published</td><td class="mono">member</td><td class="mono">2021-02-28</td><td class="ops"><a href="#" onclick="return false">编辑</a><a href="#" onclick="return false">删除</a></td></tr>
+        <tr><td class="mono">010</td><td class="tt">文档书写要点整理</td><td class="st pub">● published</td><td class="mono">password</td><td class="mono">2020-03-01</td><td class="ops"><a href="#" onclick="return false">编辑</a><a href="#" onclick="return false">删除</a></td></tr>
+        <tr><td class="mono">017</td><td class="tt">Cloudflare 迁移实录</td><td class="st draft">○ draft</td><td class="mono">public</td><td class="mono">2026-08-12</td><td class="ops"><a href="#" onclick="return false">编辑</a><a href="#" onclick="return false">删除</a></td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- ================= EDITOR ================= -->
+  <section class="page" data-page="editor" hidden>
+    <div class="adm-head">
+      <h1>编辑器</h1><span class="no-index">ADMIN / EDITOR · NEW</span>
+    </div>
+    <div class="ed-grid">
+      <aside class="ed-side">
+        <div class="field"><label>Title</label><input type="text" value="Cloudflare 迁移实录"></div>
+        <div class="field"><label>Slug</label><input type="text" value="cloudflare-migration"></div>
+        <div class="field"><label>Visibility</label>
+          <select><option>public</option><option>member</option><option>vip</option><option>admin</option><option>password</option></select>
+        </div>
+        <div class="field"><label>Tags</label><input type="text" value="Cloudflare, D1, Workers"></div>
+      </aside>
+      <div class="ed-main">
+        <div class="field"><label>Content — Markdown</label>
+          <textarea spellcheck="false">## 为什么要迁
+
+Postgres 免费额度撑不住了……
+
+```ts
+export default { fetch } = ...
+```</textarea>
+        </div>
+        <div class="ed-foot">
+          <button class="btn ghost" type="button">保存草稿</button>
+          <button class="btn solid" type="button">发布</button>
+          <span class="stat">642 chars · 3 min read · autosaved 12:41</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= 404 ================= -->
+  <section class="page" data-page="404" hidden>
+    <div class="nf">
+      <div class="sec-label" style="margin-bottom:10px">ERROR / NOT FOUND</div>
+      <div class="code">4<b>0</b>4</div>
+      <p>你闯入了无人之境。</p>
+      <div style="margin-top:26px"><a class="btn" href="#" onclick="return false" style="text-decoration:none">← 返回博客</a></div>
+    </div>
+  </section>
+
+</div>
+
+<!-- ⌘K palette -->
+<div class="pal-veil" id="pal-veil" hidden>
+  <div class="pal" role="dialog" aria-label="搜索文章">
+    <div class="pal-in">
+      <span class="sec-label" style="margin:0">FIND</span>
+      <input type="text" id="pal-input" placeholder="搜索文章…" aria-label="搜索">
+    </div>
+    <div class="pal-list">
+      <div class="pal-item sel"><span class="d">015</span><span class="t">Type Challenge - 冒泡排序</span><span class="chip c3">TypeScript</span></div>
+      <div class="pal-item"><span class="d">012</span><span class="t">LeetCode 中国区 TypeScript 面试题题解</span><span class="chip c3">TypeScript</span></div>
+      <div class="pal-item"><span class="d">008</span><span class="t">Codeforces Round#605(Div. 3) D/E/F 题解</span><span class="chip c4">DP</span></div>
+      <div class="pal-item"><span class="d">005</span><span class="t">Codeforces 1149B Three Religions</span><span class="chip c4">DP</span></div>
+    </div>
+    <div class="pal-foot">↑↓ navigate · ↵ open · esc close — 权限按当前身份过滤</div>
+  </div>
+</div>
+
+<script>
+  // page switching
+  var tabs = document.querySelectorAll('.pt-tab');
+  var pages = document.querySelectorAll('.page');
+  function go(id) {
+    pages.forEach(function(p){ p.hidden = p.dataset.page !== id; });
+    tabs.forEach(function(t){ t.classList.toggle('active', t.dataset.target === id); });
+    window.scrollTo(0, 0);
+    history.replaceState(null, '', '#' + id);
+  }
+  tabs.forEach(function(t){ if (t.dataset.target) t.addEventListener('click', function(){ go(t.dataset.target); }); });
+  var h = location.hash.slice(1);
+  if (h && document.querySelector('.page[data-page="' + h + '"]')) go(h);
+  window.addEventListener('hashchange', function(){
+    var h = location.hash.slice(1);
+    if (h && document.querySelector('.page[data-page="' + h + '"]')) go(h);
+  });
+
+  // theme
+  var tbtn = document.getElementById('theme-toggle');
+  tbtn.addEventListener('click', function(){
+    var el = document.documentElement;
+    var dark = el.getAttribute('data-theme') === 'dark';
+    el.setAttribute('data-theme', dark ? 'light' : 'dark');
+    tbtn.textContent = dark ? '◐ Dark' : '◑ Light';
+  });
+
+  // palette
+  var veil = document.getElementById('pal-veil');
+  var input = document.getElementById('pal-input');
+  document.getElementById('pal-open').addEventListener('click', function(){ veil.hidden = false; input.focus(); });
+  document.addEventListener('keydown', function(e){
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') { e.preventDefault(); veil.hidden = false; input.focus(); }
+    if (e.key === 'Escape') veil.hidden = true;
+  });
+  veil.addEventListener('click', function(e){ if (e.target === veil) veil.hidden = true; });
+</script>
+</body>
+</html>

--- a/prototypes/d-zen.html
+++ b/prototypes/d-zen.html
@@ -1,0 +1,532 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>方向 D · 日式余白 · PerfectPan's Blog 原型</title>
+<style>
+  /* ============ tokens ============ */
+  :root {
+    --bg: #F7F8F5;        /* 青白 */
+    --surface: #FFFFFF;
+    --wash: #EFF1EC;      /* 淡青灰 */
+    --ink: #2B302B;       /* 墨绿黑 */
+    --dim: #78816F;       /* 淡墨（偏青） */
+    --faint: #A9B2A3;
+    --bamboo: #557C67;    /* 竹青（唯一强调色） */
+    --bamboo-soft: #E3EAE4;
+    --line: #E1E5DA;
+    --sans: "PingFang SC", "Hiragino Sans Kaku Gothic ProN", "Hiragino Sans GB", "Microsoft YaHei", system-ui, sans-serif;
+    --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    --serif: "Songti SC", "Hiragino Mincho ProN", "SimSun", serif;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: var(--bg); color: var(--ink);
+    font-family: var(--sans); font-weight: 400;
+    font-size: 15px; line-height: 2.05;
+    min-height: 100vh;
+  }
+  ::selection { background: var(--bamboo-soft); }
+  a { color: inherit; text-decoration: none; }
+  :focus-visible { outline: 1.5px solid var(--bamboo); outline-offset: 4px; }
+
+  /* ============ prototype chrome ============ */
+  .pt-bar {
+    background: #20241F; color: #8F988A; font-size: 12.5px;
+    padding: 0 16px; display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
+    position: sticky; top: 0; z-index: 50;
+  }
+  .pt-bar .pt-title { color: #A9C6B4; font-weight: 700; letter-spacing: 0.08em; }
+  .pt-tab {
+    font-family: inherit; font-size: 12.5px; color: #8F988A; background: none;
+    border: 0; padding: 9px 10px; cursor: pointer;
+  }
+  .pt-tab:hover { color: #EDF0E8; }
+  .pt-tab.active { color: #20241F; background: #A9C6B4; font-weight: 700; }
+  .pt-links { margin-left: auto; display: flex; gap: 12px; }
+  .pt-links a { color: #5C6558; }
+  .pt-links a:hover { color: #A9C6B4; }
+
+  /* ============ site frame ============ */
+  .site { max-width: 680px; margin: 0 auto; padding: 0 24px 120px; position: relative; }
+  .page[hidden] { display: none; }
+
+  /* 签名元素：右缘竖排小字 */
+  .margin-note {
+    position: fixed; right: 18px; top: 50%; transform: translateY(-50%);
+    writing-mode: vertical-rl; letter-spacing: 0.6em;
+    font-size: 10.5px; color: var(--faint); user-select: none;
+  }
+  .margin-note::before { content: ""; display: block; width: 1px; height: 46px; background: var(--line); margin: 0 auto 18px; }
+
+  /* 顶栏 */
+  .head { padding: 72px 0 8px; display: flex; align-items: baseline; gap: 18px; }
+  .head .mark { font-family: var(--serif); font-size: 19px; letter-spacing: 0.5em; font-weight: 600; }
+  .head nav { margin-left: auto; display: flex; gap: 22px; font-size: 13px; letter-spacing: 0.22em; }
+  .head nav a { color: var(--dim); }
+  .head nav a:hover { color: var(--bamboo); }
+
+  /* 间（ma）分隔 */
+  .ma { display: flex; justify-content: center; padding: 52px 0; }
+  .ma span { color: var(--faint); font-size: 12px; letter-spacing: 1.2em; padding-left: 1.2em; }
+
+  /* ============ home ============ */
+  .zen-hero { padding: 88px 0 8px; }
+  .zen-hero .since { font-size: 12px; letter-spacing: 0.5em; color: var(--faint); }
+  .zen-hero h1 {
+    font-family: var(--serif); font-weight: 600; font-size: 34px; line-height: 1.9;
+    letter-spacing: 0.12em; margin-top: 18px;
+  }
+  .zen-hero p { color: var(--dim); margin-top: 18px; max-width: 38ch; }
+  .zen-links { display: flex; gap: 56px; padding: 40px 0 0; }
+  .zen-links a { font-size: 14px; letter-spacing: 0.3em; color: var(--ink); border-bottom: 1px solid var(--line); padding-bottom: 6px; }
+  .zen-links a:hover { color: var(--bamboo); border-color: var(--bamboo); }
+  .zen-latest { padding: 8px 0 0; }
+  .zen-latest .label, .label {
+    font-size: 11px; letter-spacing: 0.42em; color: var(--faint); margin-bottom: 10px;
+  }
+
+  /* 清单（无边界列表） */
+  .plainlist .item {
+    display: flex; align-items: baseline; gap: 20px; padding: 15px 2px;
+  }
+  .plainlist .item .t { flex: 1; font-size: 15.5px; }
+  .plainlist .item .d { font-family: var(--mono); font-size: 11.5px; color: var(--faint); white-space: nowrap; }
+  .plainlist a.item:hover .t { color: var(--bamboo); }
+  .year-quiet { font-family: var(--mono); font-size: 12px; color: var(--faint); letter-spacing: 0.3em; padding: 44px 2px 6px; }
+  .vis-quiet { font-size: 10px; letter-spacing: 0.28em; color: var(--faint); margin-left: 12px; }
+  .vis-quiet.mem { color: var(--bamboo); }
+  .vis-quiet.vip { color: #8A7BB0; }
+  .vis-quiet.pw { color: #B0705F; }
+
+  /* ============ article ============ */
+  .art h1 { font-family: var(--serif); font-size: 29px; font-weight: 600; letter-spacing: 0.06em; line-height: 1.8; }
+  .art .meta { font-family: var(--mono); font-size: 11.5px; color: var(--faint); margin-top: 12px; letter-spacing: 0.1em; }
+  .prose { margin-top: 46px; font-size: 16px; }
+  .prose p { margin: 26px 0; color: #3A403A; }
+  .prose h2 {
+    font-size: 16px; font-weight: 600; letter-spacing: 0.16em; margin: 64px 0 8px;
+    display: flex; align-items: center; gap: 12px;
+  }
+  .prose h2::before { content: ""; width: 5px; height: 5px; border-radius: 50%; background: var(--bamboo); }
+  .prose ul { list-style: none; margin: 20px 0; }
+  .prose li { padding: 8px 0 8px 20px; position: relative; color: #3A403A; }
+  .prose li::before { content: "・"; position: absolute; left: 0; color: var(--bamboo); }
+  .prose blockquote { margin: 34px 0; padding: 4px 0 4px 24px; border-left: 1px solid var(--bamboo); color: var(--dim); font-size: 15px; }
+  .prose code { font-family: var(--mono); font-size: 0.84em; color: var(--bamboo); background: var(--wash); padding: 1px 7px; border-radius: 10px; }
+  .prose pre {
+    font-family: var(--mono); font-size: 13px; line-height: 1.9; color: #39413B;
+    background: var(--surface); border: 1px solid var(--line); border-radius: 2px;
+    padding: 24px 26px; overflow-x: auto; margin: 30px 0;
+  }
+  .pre-wrap { position: relative; }
+  .pre-wrap .fname { position: absolute; top: -9px; left: 18px; font-family: var(--mono); font-size: 10.5px; color: var(--faint); background: var(--bg); padding: 0 8px; }
+  .tk-c { color: #9AA595; } .tk-k { color: #6E8F7C; } .tk-t { color: #4C6B5B; }
+  .tk-s { color: #8F9E6E; } .tk-f { color: #557C67; }
+
+  /* comments */
+  .cmt { padding: 22px 0; border-top: 1px solid var(--line); }
+  .cmt:first-of-type { border-top: 0; }
+  .cmt .ch { font-family: var(--mono); font-size: 11px; color: var(--faint); margin-bottom: 6px; }
+  .cmt .ch .who { color: var(--ink); }
+  .cmt.reply { margin-left: 40px; }
+  .cmt-form { display: flex; gap: 18px; border-top: 1px solid var(--line); padding-top: 26px; margin-top: 4px; }
+  .cmt-form input { flex: 1; }
+
+  /* ============ projects ============ */
+  .ware { padding: 26px 2px; }
+  .ware .name { font-size: 16px; letter-spacing: 0.06em; }
+  .ware .name .feat { font-size: 10px; letter-spacing: 0.3em; color: var(--bamboo); margin-left: 14px; }
+  .ware p { color: var(--dim); font-size: 14px; margin-top: 6px; max-width: 46ch; }
+  .ware .wlinks { margin-top: 10px; font-family: var(--mono); font-size: 12px; display: flex; gap: 20px; }
+  .ware .wlinks a { color: var(--faint); }
+  .ware .wlinks a:hover { color: var(--bamboo); }
+
+  /* ============ forms ============ */
+  .gate { max-width: 400px; margin: 40px auto 0; padding: 30px 0; }
+  .gate h1 { font-family: var(--serif); font-size: 24px; font-weight: 600; letter-spacing: 0.3em; text-align: center; }
+  .gate .sub { text-align: center; color: var(--faint); font-size: 12.5px; letter-spacing: 0.14em; margin-top: 8px; }
+  .field { margin: 34px 0; }
+  .field label { display: block; font-size: 11px; letter-spacing: 0.4em; color: var(--faint); margin-bottom: 4px; }
+  input[type=text], input[type=email], input[type=password], textarea, select {
+    width: 100%; font-family: var(--sans); font-size: 15px; color: var(--ink);
+    background: transparent; border: 0; border-bottom: 1px solid var(--line);
+    padding: 8px 2px; border-radius: 0;
+  }
+  input:focus, textarea:focus, select:focus { outline: none; border-bottom-color: var(--bamboo); }
+  .field-line { position: relative; }
+  .gate .actions { display: flex; gap: 40px; justify-content: center; margin-top: 44px; }
+  .btn {
+    font: inherit; font-size: 13px; letter-spacing: 0.34em; cursor: pointer;
+    background: none; border: 0; color: var(--ink);
+    padding: 12px 10px; border-bottom: 1px solid var(--ink);
+  }
+  .btn:hover { color: var(--bamboo); border-color: var(--bamboo); }
+  .btn.fill { background: var(--bamboo); color: #F4F7F3; border-bottom-color: var(--bamboo); padding: 12px 30px; }
+  .btn.fill:hover { background: #476856; }
+  .gate .aside { text-align: center; margin-top: 34px; font-size: 12.5px; color: var(--faint); }
+  .err { text-align: center; color: #B0705F; font-size: 13px; margin-top: 18px; letter-spacing: 0.1em; }
+  .lock-mark { text-align: center; font-family: var(--serif); font-size: 30px; color: var(--bamboo); padding: 6px 0 0; }
+
+  /* ============ admin ============ */
+  .adm-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  .adm-table th { text-align: left; font-weight: 400; font-size: 10.5px; letter-spacing: 0.3em; color: var(--faint); padding: 14px 8px; border-bottom: 1px solid var(--line); }
+  .adm-table td { padding: 13px 8px; border-bottom: 1px solid var(--line); }
+  .adm-table tr:hover td { background: rgba(85,124,101,0.05); }
+  .adm-table .ops a { color: var(--faint); margin-right: 14px; font-size: 12px; }
+  .adm-table .ops a:hover { color: var(--bamboo); }
+  .st { font-size: 11px; letter-spacing: 0.2em; }
+  .st.pub { color: var(--bamboo); } .st.draft { color: var(--faint); }
+  .ed-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0 40px; }
+  textarea.draft { min-height: 300px; font-size: 14px; line-height: 2.1; border-bottom: 1px solid var(--line); }
+  .ed-foot { display: flex; gap: 40px; align-items: center; margin-top: 30px; }
+  .ed-foot .stat { font-family: var(--mono); font-size: 10.5px; color: var(--faint); }
+
+  /* ============ 404 ============ */
+  .nf { text-align: center; padding: 80px 0 30px; }
+  .nf .k { font-family: var(--serif); font-size: 64px; color: var(--faint); }
+  .nf p { color: var(--dim); font-size: 13.5px; letter-spacing: 0.2em; margin-top: 18px; }
+
+  /* ============ palette ============ */
+  .pal-veil { position: fixed; inset: 0; background: rgba(43,48,43,0.18); display: flex; justify-content: center; padding-top: 16vh; z-index: 100; }
+  .pal-veil[hidden] { display: none; }
+  .pal { width: min(560px, calc(100vw - 32px)); height: fit-content; background: var(--surface); border: 1px solid var(--line); padding: 8px 0 2px; }
+  .pal-in { display: flex; gap: 14px; align-items: center; padding: 14px 22px; }
+  .pal-in input { border-bottom: 0; padding: 0; font-size: 15px; }
+  .pal-in input:focus { border-bottom: 0; }
+  .pal-list { max-height: 300px; overflow-y: auto; }
+  .pal-item { display: flex; gap: 16px; padding: 12px 22px; align-items: baseline; font-size: 14.5px; }
+  .pal-item .d { font-family: var(--mono); font-size: 11px; color: var(--faint); min-width: 6ch; }
+  .pal-item.sel .t { color: var(--bamboo); }
+  .pal-item.sel .t::after { content: " ・"; color: var(--faint); }
+  .pal-foot { border-top: 1px solid var(--line); margin-top: 6px; padding: 9px 22px; font-size: 10.5px; color: var(--faint); letter-spacing: 0.2em; }
+
+  footer.kicker { text-align: center; font-size: 11px; letter-spacing: 0.34em; color: var(--faint); padding-top: 60px; }
+
+  @media (max-width: 760px) {
+    .margin-note { display: none; }
+    .zen-links { gap: 34px; }
+    .ed-grid { grid-template-columns: 1fr; }
+    .head { padding-top: 48px; flex-wrap: wrap; }
+  }
+</style>
+</head>
+<body>
+
+<div class="pt-bar">
+  <span class="pt-title">原型 · 方向 D 日式余白</span>
+  <nav aria-label="原型页面" style="display:flex;gap:2px;flex-wrap:wrap">
+    <button class="pt-tab active" data-target="home">首页</button>
+    <button class="pt-tab" data-target="blog">博客</button>
+    <button class="pt-tab" data-target="post">文章</button>
+    <button class="pt-tab" data-target="projects">项目</button>
+    <button class="pt-tab" data-target="login">登录</button>
+    <button class="pt-tab" data-target="signup">注册</button>
+    <button class="pt-tab" data-target="unlock">解锁</button>
+    <button class="pt-tab" data-target="admin">后台</button>
+    <button class="pt-tab" data-target="editor">编辑器</button>
+    <button class="pt-tab" data-target="404">404</button>
+  </nav>
+  <div class="pt-links"><a href="index.html">总览</a></div>
+</div>
+
+<aside class="margin-note" aria-hidden="true">余白 · PERFECTPAN · 二〇二六</aside>
+
+<main class="site">
+  <header class="head">
+    <span class="mark">字纸篓</span>
+    <nav>
+      <a href="#" onclick="return false">读</a>
+      <a href="#" onclick="return false">物</a>
+      <button class="pt-tab" style="color:var(--bamboo);padding:0;letter-spacing:0.22em" onclick="document.dispatchEvent(new KeyboardEvent('keydown',{key:'k',metaKey:true}))">检</button>
+    </nav>
+  </header>
+
+  <!-- ================= HOME ================= -->
+  <section class="page" data-page="home">
+    <div class="zen-hero">
+      <div class="since">二〇一九年以来</div>
+      <h1>是个什么都不会的<br>废物.jpg</h1>
+      <p>算法竞赛退役，如今写 TypeScript 与类型体操，把整站跑在 Cloudflare 的免费额度上。这里收着题解、笔记和一些不成体统的随想。</p>
+    </div>
+    <div class="ma"><span>間</span></div>
+    <div class="zen-links">
+      <a href="#" onclick="return false">读文章</a>
+      <a href="#" onclick="return false">看器物</a>
+    </div>
+    <div class="ma"><span>間</span></div>
+    <div class="zen-latest">
+      <div class="label">近 稿 三 篇</div>
+      <div class="plainlist">
+        <a class="item" href="#" onclick="return false"><span class="t">初探 Github Blocks</span><span class="d">2023 / 02</span></a>
+        <a class="item" href="#" onclick="return false"><span class="t">Type Challenge · 冒泡排序</span><span class="d">2021 / 05</span></a>
+        <a class="item" href="#" onclick="return false"><span class="t">回顾 2020</span><span class="d">2021 / 02</span></a>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= BLOG ================= -->
+  <section class="page" data-page="blog" hidden>
+    <div class="ma" style="padding-top:56px"><span>間</span></div>
+    <div class="plainlist">
+      <div class="year-quiet">2023</div>
+      <a class="item" href="#" onclick="return false"><span class="t">初探 Github Blocks</span><span class="d">02 / 18</span></a>
+
+      <div class="year-quiet">2021</div>
+      <a class="item" href="#" onclick="return false"><span class="t">Type Challenge · 冒泡排序</span><span class="d">05 / 08</span></a>
+      <a class="item" href="#" onclick="return false"><span class="t">回顾 2020<span class="vis-quiet mem">会 员</span></span><span class="d">02 / 28</span></a>
+
+      <div class="year-quiet">2020</div>
+      <a class="item" href="#" onclick="return false"><span class="t">一些随想</span><span class="d">08 / 26</span></a>
+      <a class="item" href="#" onclick="return false"><span class="t">LeetCode 中国区 TypeScript 面试题题解</span><span class="d">04 / 13</span></a>
+      <a class="item" href="#" onclick="return false"><span class="t">那些年邂逅的 LeetCode 趣/难题</span><span class="d">03 / 30</span></a>
+      <a class="item" href="#" onclick="return false"><span class="t">文档书写要点整理<span class="vis-quiet pw">密</span></span><span class="d">03 / 01</span></a>
+
+      <div class="year-quiet">2019</div>
+      <a class="item" href="#" onclick="return false"><span class="t">回顾 2019<span class="vis-quiet vip">VIP</span></span><span class="d">12 / 31</span></a>
+      <a class="item" href="#" onclick="return false"><span class="t">Codeforces Round#605(Div. 3) D/E/F 题解</span><span class="d">12 / 14</span></a>
+      <a class="item" href="#" onclick="return false"><span class="t">Codeforces Round#603(Div. 2) E/F 题解</span><span class="d">12 / 01</span></a>
+      <a class="item" href="#" onclick="return false"><span class="t">银联极客高校挑战赛复赛 D 多项式</span><span class="d">09 / 17</span></a>
+      <a class="item" href="#" onclick="return false"><span class="t">Codeforces 1149B Three Religions</span><span class="d">04 / 30</span></a>
+      <a class="item" href="#" onclick="return false"><span class="t">2019 ICPC 南昌邀请赛网络赛 G. tsy's number</span><span class="d">04 / 22</span></a>
+    </div>
+    <div class="ma"><span>次 页 へ ・ ・ ・</span></div>
+  </section>
+
+  <!-- ================= ARTICLE ================= -->
+  <section class="page" data-page="post" hidden>
+    <div class="ma" style="padding-top:56px"><span>間</span></div>
+    <article class="art">
+      <h1>Type Challenge · 冒泡排序</h1>
+      <div class="meta">2021 / 05 / 08 ・ 九分 ・ TypeScript ・ 公開</div>
+      <div class="prose">
+        <p>这题要求在类型系统里实现冒泡排序：给定一个元组 <code>T extends number[]</code>，返回排序后的元组。类型层面上没有循环，所以核心思路是把「一趟冒泡」展开成递归。</p>
+
+        <h2>一趟冒泡</h2>
+        <p>先写一个 <code>Pass</code>，从头到尾扫一遍，相邻逆序就交换：</p>
+
+        <div class="pre-wrap"><span class="fname">bubble.ts</span>
+<pre><span class="tk-c">// 一趟冒泡：相邻比较，逆序则交换</span>
+<span class="tk-k">type</span> <span class="tk-t">Pass</span>&lt;<span class="tk-t">T</span> <span class="tk-k">extends</span> <span class="tk-t">number</span>[]&gt; =
+  <span class="tk-t">T</span> <span class="tk-k">extends</span> [<span class="tk-k">infer</span> <span class="tk-t">A</span> <span class="tk-k">extends</span> <span class="tk-t">number</span>, <span class="tk-k">infer</span> <span class="tk-t">B</span> <span class="tk-k">extends</span> <span class="tk-t">number</span>, ...<span class="tk-k">infer</span> <span class="tk-t">R</span> <span class="tk-k">extends</span> <span class="tk-t">number</span>[]]
+    ? <span class="tk-t">A</span> <span class="tk-k">extends</span> <span class="tk-s">`${B}`</span>
+      ? [<span class="tk-t">A</span>, ...<span class="tk-t">Pass</span>&lt;[<span class="tk-t">B</span>, ...<span class="tk-t">R</span>]&gt;]
+      : [<span class="tk-t">B</span>, ...<span class="tk-t">Pass</span>&lt;[<span class="tk-t">A</span>, ...<span class="tk-t">R</span>]&gt;]
+    : <span class="tk-t">T</span>;
+
+<span class="tk-k">type</span> <span class="tk-f">BubbleSort</span>&lt;<span class="tk-t">T</span>&gt; = ...<span class="tk-c">// 没交换 → 有序</span></pre>
+        </div>
+
+        <blockquote>数字比较不能直接用 <code>&lt;</code>，得转成字符串长度或逐位比较——类型体操的老朋友了。</blockquote>
+
+        <h2>几个细节</h2>
+        <ul>
+          <li><code>infer A extends number</code> 收窄推断结果，省掉一层条件判断；</li>
+          <li>终止条件是「这一趟没有发生任何交换」，用深度相等判断；</li>
+          <li>元组很长时记得给 TS 足够的递归深度，或者拆成小测试。</li>
+        </ul>
+        <p>完整题解在仓库 <code>type-challenges</code> 里，配合测试用例食用更佳。</p>
+      </div>
+    </article>
+
+    <div class="ma"><span>読 者 の 声</span></div>
+    <div class="cmt">
+      <div class="ch"><span class="who">alice@example.com</span> ・ 2021 / 05 / 09</div>
+      <p>Equal 判终止这个思路太优雅了，比数长度 hack 干净。</p>
+    </div>
+    <div class="cmt reply">
+      <div class="ch"><span class="who">bob@example.com</span> ・ 2021 / 05 / 10</div>
+      <p>数长度在负数场景直接爆炸，还是深度相等稳。</p>
+    </div>
+    <form class="cmt-form" onsubmit="return false">
+      <input type="text" placeholder="静かに一言どうぞ……" aria-label="新评论">
+      <button class="btn" type="submit">投　稿</button>
+    </form>
+  </section>
+
+  <!-- ================= PROJECTS ================= -->
+  <section class="page" data-page="projects" hidden>
+    <div class="ma" style="padding-top:56px"><span>間</span></div>
+    <div class="ware">
+      <div class="name">blog<span class="feat">代表 作</span></div>
+      <p>本博客——TanStack Start 前台，全量部署在 Cloudflare Workers + D1 上。</p>
+      <div class="wlinks"><a href="#" onclick="return false">source</a><a href="#" onclick="return false">live</a></div>
+    </div>
+    <div class="ware">
+      <div class="name">logseq-plugin-code-formatter<span class="feat">代表 作</span></div>
+      <p>Logseq 插件——用 Prettier 一键格式化代码块，支持 JS / TS / HTML / CSS / Markdown / JSON。</p>
+      <div class="wlinks"><a href="#" onclick="return false">source</a></div>
+    </div>
+    <div class="ware">
+      <div class="name">ocvm</div>
+      <p>OpenClaw 版本管理器——nvm 风格的 Rust CLI，按项目安装、切换、锁定与回滚版本。</p>
+      <div class="wlinks"><a href="#" onclick="return false">source</a><a href="#" onclick="return false">live</a></div>
+    </div>
+    <div class="ware">
+      <div class="name">agent-presence</div>
+      <p>把本地编码 agent 的在线状态与 token 用量同步到飞书签名链接预览。</p>
+      <div class="wlinks"><a href="#" onclick="return false">source</a><a href="#" onclick="return false">live</a></div>
+    </div>
+    <div class="ware">
+      <div class="name">base64</div>
+      <p>Moonbit 语言实现的 Base64 编解码库，遵循 RFC 4648。</p>
+      <div class="wlinks"><a href="#" onclick="return false">source</a></div>
+    </div>
+  </section>
+
+  <!-- ================= LOGIN ================= -->
+  <section class="page" data-page="login" hidden>
+    <div class="gate">
+      <h1>登　録</h1>
+      <p class="sub">会員は「会員可読」の記事を読める</p>
+      <form onsubmit="return false">
+        <div class="field"><label for="d-em">邮 箱</label><input id="d-em" type="email" placeholder="you@example.com"></div>
+        <div class="field"><label for="d-pw">口 令</label><input id="d-pw" type="password" placeholder="・・・・・・・・"></div>
+        <div class="actions">
+          <button class="btn fill" type="submit">登　入</button>
+          <button class="btn" type="button">GitHub</button>
+        </div>
+        <p class="err" hidden>邮箱或口令不正确</p>
+      </form>
+      <p class="aside">尚未注册？<a href="#" onclick="return false" style="color:var(--bamboo)">注册</a></p>
+    </div>
+  </section>
+
+  <!-- ================= SIGNUP ================= -->
+  <section class="page" data-page="signup" hidden>
+    <div class="gate">
+      <h1>注　冊</h1>
+      <p class="sub">登録すると member になる</p>
+      <form onsubmit="return false">
+        <div class="field"><label for="d-sem">邮 箱</label><input id="d-sem" type="email" placeholder="you@example.com"></div>
+        <div class="field"><label for="d-spw">口 令</label><input id="d-spw" type="password" placeholder="至少八位"></div>
+        <div class="field"><label for="d-spw2">确 认</label><input id="d-spw2" type="password" placeholder="・・・・・・・・"></div>
+        <div class="actions">
+          <button class="btn fill" type="submit">建立账号</button>
+          <button class="btn" type="button">GitHub</button>
+        </div>
+      </form>
+    </div>
+  </section>
+
+  <!-- ================= UNLOCK ================= -->
+  <section class="page" data-page="unlock" hidden>
+    <div class="gate">
+      <div class="lock-mark">鍵</div>
+      <h1>解　鎖</h1>
+      <p class="sub">この記事は一言パスワードで封をされている ・ 24 時間有効</p>
+      <form onsubmit="return false">
+        <div class="field"><label for="d-upw">篇 目 口 令</label><input id="d-upw" type="password" placeholder="・・・・・・・・" autofocus></div>
+        <p class="err">口令有误，请再试</p>
+        <div class="actions">
+          <button class="btn fill" type="submit">启 封</button>
+          <a class="btn" href="#" onclick="return false">返 回</a>
+        </div>
+      </form>
+    </div>
+  </section>
+
+  <!-- ================= ADMIN ================= -->
+  <section class="page" data-page="admin" hidden>
+    <div class="ma" style="padding-top:56px"><span>間</span></div>
+    <table class="adm-table">
+      <thead><tr><th>编号</th><th>篇目</th><th>状态</th><th>可见</th><th>更新</th><th></th></tr></thead>
+      <tbody>
+        <tr><td class="d" style="font-family:var(--mono);font-size:11px;color:var(--faint)">016</td><td>初探 Github Blocks</td><td class="st pub">已刊</td><td style="font-size:12px;color:var(--dim)">公开</td><td style="font-family:var(--mono);font-size:11px;color:var(--faint)">2023-02-18</td><td class="ops"><a href="#" onclick="return false">改</a><a href="#" onclick="return false">删</a></td></tr>
+        <tr><td style="font-family:var(--mono);font-size:11px;color:var(--faint)">015</td><td>Type Challenge · 冒泡排序</td><td class="st pub">已刊</td><td style="font-size:12px;color:var(--dim)">公开</td><td style="font-family:var(--mono);font-size:11px;color:var(--faint)">2021-05-08</td><td class="ops"><a href="#" onclick="return false">改</a><a href="#" onclick="return false">删</a></td></tr>
+        <tr><td style="font-family:var(--mono);font-size:11px;color:var(--faint)">014</td><td>回顾 2020</td><td class="st pub">已刊</td><td style="font-size:12px;color:var(--dim)">会员</td><td style="font-family:var(--mono);font-size:11px;color:var(--faint)">2021-02-28</td><td class="ops"><a href="#" onclick="return false">改</a><a href="#" onclick="return false">删</a></td></tr>
+        <tr><td style="font-family:var(--mono);font-size:11px;color:var(--faint)">010</td><td>文档书写要点整理</td><td class="st pub">已刊</td><td style="font-size:12px;color:var(--dim)">密笈</td><td style="font-family:var(--mono);font-size:11px;color:var(--faint)">2020-03-01</td><td class="ops"><a href="#" onclick="return false">改</a><a href="#" onclick="return false">删</a></td></tr>
+        <tr><td style="font-family:var(--mono);font-size:11px;color:var(--faint)">017</td><td>Cloudflare 迁移实录</td><td class="st draft">草稿</td><td style="font-size:12px;color:var(--dim)">公开</td><td style="font-family:var(--mono);font-size:11px;color:var(--faint)">2026-08-12</td><td class="ops"><a href="#" onclick="return false">改</a><a href="#" onclick="return false">删</a></td></tr>
+      </tbody>
+    </table>
+    <div class="ed-foot">
+      <a class="btn" href="#" onclick="return false">新拟一篇</a>
+      <a class="btn" href="#" onclick="return false">来函（23）</a>
+    </div>
+  </section>
+
+  <!-- ================= EDITOR ================= -->
+  <section class="page" data-page="editor" hidden>
+    <div class="ma" style="padding-top:56px"><span>間</span></div>
+    <form onsubmit="return false">
+      <div class="ed-grid">
+        <div class="field"><label>篇 目</label><input type="text" value="Cloudflare 迁移实录"></div>
+        <div class="field"><label>档 名</label><input type="text" value="cloudflare-migration"></div>
+        <div class="field"><label>可 见</label>
+          <select><option>公开</option><option>会员</option><option>VIP</option><option>编者</option><option>密笈</option></select>
+        </div>
+        <div class="field"><label>栏 目</label><input type="text" value="工程, Cloudflare, D1"></div>
+      </div>
+      <div class="field"><label>正 文</label>
+        <textarea class="draft" spellcheck="false">## 为什么要迁
+
+Postgres 免费额度撑不住了……
+
+```ts
+export default { fetch } = ...
+```</textarea>
+      </div>
+      <div class="ed-foot">
+        <button class="btn" type="button">存 草 稿</button>
+        <button class="btn fill" type="button">刊 发</button>
+        <span class="stat">642 字 ・ 约 3 分 ・ 存档 12:41</span>
+      </div>
+    </form>
+  </section>
+
+  <!-- ================= 404 ================= -->
+  <section class="page" data-page="404" hidden>
+    <div class="nf">
+      <div class="k">空</div>
+      <p>此处无文 ・ <a href="#" onclick="return false" style="color:var(--bamboo)">回到目次</a></p>
+    </div>
+  </section>
+
+  <footer class="kicker">PERFECTPAN ・ 静々と更新中</footer>
+</main>
+
+<!-- 检索 palette -->
+<div class="pal-veil" id="pal-veil" hidden>
+  <div class="pal" role="dialog" aria-label="检索篇目">
+    <div class="pal-in">
+      <span style="color:var(--faint);font-size:11px;letter-spacing:0.4em">検 索</span>
+      <input type="text" id="pal-input" placeholder="静かに入力……" aria-label="检索">
+    </div>
+    <div class="pal-list">
+      <div class="pal-item sel"><span class="d">2021/05</span><span class="t">Type Challenge · 冒泡排序</span></div>
+      <div class="pal-item"><span class="d">2020/04</span><span class="t">LeetCode 中国区 TypeScript 面试题题解</span></div>
+      <div class="pal-item"><span class="d">2019/12</span><span class="t">Codeforces Round#605(Div. 3) D/E/F 题解</span></div>
+      <div class="pal-item"><span class="d">2019/04</span><span class="t">Codeforces 1149B Three Religions</span></div>
+    </div>
+    <div class="pal-foot">↑↓ 選択 ・ ↵ 開く ・ esc 閉じる</div>
+  </div>
+</div>
+
+<script>
+  var tabs = document.querySelectorAll('.pt-tab');
+  var pages = document.querySelectorAll('.page');
+  function go(id) {
+    pages.forEach(function(p){ p.hidden = p.dataset.page !== id; });
+    tabs.forEach(function(t){ t.classList.toggle('active', t.dataset.target === id); });
+    window.scrollTo(0, 0);
+    history.replaceState(null, '', '#' + id);
+  }
+  tabs.forEach(function(t){ if (t.dataset.target) t.addEventListener('click', function(){ go(t.dataset.target); }); });
+  var h = location.hash.slice(1);
+  if (h && document.querySelector('.page[data-page="' + h + '"]')) go(h);
+  window.addEventListener('hashchange', function(){
+    var h = location.hash.slice(1);
+    if (h && document.querySelector('.page[data-page="' + h + '"]')) go(h);
+  });
+
+  var veil = document.getElementById('pal-veil');
+  var input = document.getElementById('pal-input');
+  document.addEventListener('keydown', function(e){
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') { e.preventDefault(); veil.hidden = false; input.focus(); }
+    if (e.key === 'Escape') veil.hidden = true;
+  });
+  veil.addEventListener('click', function(e){ if (e.target === veil) veil.hidden = true; });
+</script>
+</body>
+</html>

--- a/prototypes/e-blueprint.html
+++ b/prototypes/e-blueprint.html
@@ -1,0 +1,719 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>方向 E · 工程蓝图 · PerfectPan's Blog 原型</title>
+<style>
+  /* ============ tokens ============ */
+  :root {
+    --bp: #173E62;         /* 蓝图纸 */
+    --bp-deep: #113149;
+    --sheet: rgba(233,242,252,0.045);
+    --ink: #E8F1FA;        /* 白墨线 */
+    --dim: #9FB9D6;
+    --faint: #6D89AB;
+    --grid: rgba(232,241,250,0.07);
+    --line: rgba(232,241,250,0.28);
+    --line-soft: rgba(232,241,250,0.14);
+    --yellow: #FFC957;     /* 图纸标注黄 */
+    --cyan: #8FDCFF;       /* 链接/交互 */
+    --red: #FF8E7A;        /* 红铅笔 */
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, "PingFang SC", monospace;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background-color: var(--bp);
+    background-image:
+      linear-gradient(var(--grid) 1px, transparent 1px),
+      linear-gradient(90deg, var(--grid) 1px, transparent 1px),
+      linear-gradient(rgba(232,241,250,0.035) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(232,241,250,0.035) 1px, transparent 1px);
+    background-size: 120px 120px, 120px 120px, 24px 24px, 24px 24px;
+    color: var(--ink);
+    font-family: var(--mono);
+    font-size: 14px; line-height: 1.8;
+    min-height: 100vh;
+  }
+  ::selection { background: rgba(255,201,87,0.28); }
+  a { color: var(--cyan); text-decoration: none; }
+  a:hover { text-decoration: underline; text-underline-offset: 3px; }
+  :focus-visible { outline: 1.5px dashed var(--yellow); outline-offset: 3px; }
+
+  /* ============ prototype chrome ============ */
+  .pt-bar {
+    background: #0C2237; color: #7C97B5; font-size: 12.5px;
+    padding: 0 16px; display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
+    position: sticky; top: 0; z-index: 50; border-bottom: 1px solid rgba(232,241,250,0.15);
+  }
+  .pt-bar .pt-title { color: var(--yellow); font-weight: 700; letter-spacing: 0.08em; }
+  .pt-tab {
+    font-family: inherit; font-size: 12.5px; color: #7C97B5; background: none;
+    border: 0; padding: 9px 10px; cursor: pointer;
+  }
+  .pt-tab:hover { color: var(--ink); }
+  .pt-tab.active { color: #0C2237; background: var(--yellow); font-weight: 700; }
+  .pt-links { margin-left: auto; display: flex; gap: 12px; }
+  .pt-links a { color: #586F8C; }
+  .pt-links a:hover { color: var(--yellow); }
+
+  /* ============ 图纸 sheet ============ */
+  .board { max-width: 1100px; margin: 0 auto; padding: 34px 22px 70px; }
+  .sheet {
+    position: relative;
+    border: 1.6px solid var(--line);
+    background: var(--sheet);
+    padding: 34px 38px 96px;
+    min-height: 60vh;
+  }
+  .sheet::before {
+    content: ""; position: absolute; inset: 5px;
+    border: 1px solid var(--line-soft); pointer-events: none;
+  }
+  /* 角标记 */
+  .tick { position: absolute; width: 14px; height: 14px; pointer-events: none; }
+  .tick::before, .tick::after { content: ""; position: absolute; background: var(--yellow); }
+  .tick::before { width: 14px; height: 2px; } .tick::after { width: 2px; height: 14px; }
+  .tick.tl { top: -1px; left: -1px; } .tick.tr { top: -1px; right: -1px; transform: scaleX(-1); }
+  .tick.bl { bottom: -1px; left: -1px; transform: scaleY(-1); } .tick.br { bottom: -1px; right: -1px; transform: scale(-1); }
+
+  .page[hidden] { display: none; }
+
+  /* 标题栏（图签） */
+  .titleblock {
+    position: absolute; right: -1.6px; bottom: -1.6px;
+    display: grid; grid-template-columns: auto auto auto;
+    border: 1.6px solid var(--line); border-right: 0; border-bottom: 0;
+    background: rgba(12,34,55,0.88);
+    font-size: 10.5px; letter-spacing: 0.14em; color: var(--dim);
+  }
+  .titleblock .cell { padding: 7px 14px; border-left: 1px solid var(--line-soft); }
+  .titleblock .cell:first-child { border-left: 0; }
+  .titleblock b { display: block; color: var(--yellow); font-weight: 600; font-size: 13px; letter-spacing: 0.06em; }
+  .titleblock .cell.wide { grid-row: span 2; display: flex; align-items: center; }
+  .titleblock .cell.wide b { font-size: 16px; }
+
+  .sheet-head {
+    display: flex; align-items: baseline; gap: 18px; flex-wrap: wrap;
+    padding-bottom: 18px; border-bottom: 1px dashed var(--line); margin-bottom: 26px;
+  }
+  .sheet-head .dwg { font-size: 11px; letter-spacing: 0.3em; color: var(--faint); }
+  .sheet-head h1 { font-size: 25px; font-weight: 700; letter-spacing: 0.04em; }
+  .sheet-head .tools { margin-left: auto; display: flex; gap: 10px; }
+  .tool { font: inherit; font-size: 11px; letter-spacing: 0.16em; color: var(--dim); background: none; border: 1px solid var(--line-soft); padding: 4px 12px; cursor: pointer; }
+  .tool:hover { color: var(--yellow); border-color: var(--yellow); }
+
+  .lbl { font-size: 10.5px; letter-spacing: 0.3em; color: var(--faint); }
+  .rev { color: var(--yellow); }
+
+  /* ============ home ============ */
+  .cover { display: grid; grid-template-columns: 1.3fr 1fr; gap: 50px; }
+  .cover .big {
+    font-size: clamp(38px, 6vw, 62px); font-weight: 700; letter-spacing: 0.02em; line-height: 1.15;
+  }
+  .cover .big span { color: var(--yellow); }
+  .cover .sub { margin-top: 20px; color: var(--dim); max-width: 48ch; }
+  .cover .specs { margin-top: 30px; }
+  .spec-line { display: flex; gap: 16px; padding: 9px 0; border-bottom: 1px solid var(--line-soft); font-size: 12.5px; }
+  .spec-line .k { color: var(--faint); letter-spacing: 0.2em; min-width: 13ch; }
+  .spec-line .v { color: var(--ink); }
+  .cover-right { border-left: 1px dashed var(--line); padding-left: 40px; }
+  .cover-right h3 { font-size: 11px; letter-spacing: 0.3em; color: var(--yellow); margin-bottom: 12px; font-weight: 600; }
+  .idx-row { display: flex; gap: 12px; padding: 8px 0; border-bottom: 1px solid var(--line-soft); align-items: baseline; }
+  .idx-row .no { color: var(--faint); font-size: 11px; min-width: 4ch; }
+  .idx-row .t { flex: 1; color: var(--ink); }
+  .idx-row .t:hover { color: var(--cyan); }
+  .open-ports { margin-top: 30px; display: flex; gap: 12px; flex-wrap: wrap; }
+  .btn {
+    font: inherit; font-size: 12px; letter-spacing: 0.22em; cursor: pointer;
+    background: none; color: var(--ink); border: 1.4px solid var(--line);
+    padding: 10px 22px; transition: all .12s;
+  }
+  .btn:hover { border-color: var(--yellow); color: var(--yellow); text-decoration: none; }
+  .btn.fill { background: var(--yellow); border-color: var(--yellow); color: #123049; font-weight: 700; }
+  .btn.fill:hover { background: #FFD57A; }
+
+  /* ============ BOM 表（blog） ============ */
+  table.bom { width: 100%; border-collapse: collapse; font-size: 13px; }
+  .bom th {
+    text-align: left; font-weight: 400; font-size: 10px; letter-spacing: 0.26em; color: var(--yellow);
+    padding: 10px 12px; border-bottom: 1.4px solid var(--line);
+  }
+  .bom td { padding: 10px 12px; border-bottom: 1px solid var(--line-soft); }
+  .bom tbody tr:hover td { background: rgba(143,220,255,0.06); }
+  .bom td.item { color: var(--faint); font-size: 11px; }
+  .bom td.tt a { color: var(--ink); }
+  .bom td.tt a:hover { color: var(--cyan); }
+  .bom .yr { display: flex; align-items: center; gap: 14px; padding: 24px 12px 8px; color: var(--dim); letter-spacing: 0.3em; font-size: 11px; }
+  .bom .yr::after { content: ""; flex: 1; border-top: 1px dashed var(--line-soft); }
+  .perm { font-size: 11px; letter-spacing: 0.06em; }
+  .perm.pub { color: #9BE3B4; } .perm.mem { color: var(--cyan); }
+  .perm.vip { color: #C7A6F2; } .perm.pw { color: var(--red); }
+  .bom-pager { display: flex; justify-content: center; gap: 22px; padding-top: 30px; font-size: 12px; color: var(--dim); }
+
+  /* ============ article ============ */
+  .art-head { border-bottom: 1.4px solid var(--line); padding-bottom: 20px; margin-bottom: 30px; }
+  .art-head h1 { font-size: 27px; font-weight: 700; }
+  .art-head .meta { margin-top: 10px; display: flex; gap: 22px; flex-wrap: wrap; font-size: 11px; letter-spacing: 0.2em; color: var(--dim); }
+  .prose { max-width: 72ch; }
+  .prose p { margin: 16px 0; color: #D9E6F4; }
+  .prose h2 {
+    font-size: 16px; margin: 36px 0 10px; letter-spacing: 0.08em;
+    display: flex; align-items: center; gap: 12px;
+  }
+  .prose h2 .no { color: var(--yellow); font-size: 11px; letter-spacing: 0.24em; }
+  .prose h2::after { content: ""; flex: 1; border-top: 1px dashed var(--line-soft); }
+  .prose ul { margin: 14px 0; list-style: none; }
+  .prose li { padding: 6px 0 6px 26px; position: relative; color: #D9E6F4; }
+  .prose li::before { content: "—"; position: absolute; left: 0; color: var(--yellow); }
+  .prose blockquote { border-left: 2px solid var(--yellow); background: rgba(255,201,87,0.06); padding: 12px 20px; margin: 20px 0; color: var(--dim); }
+  .prose blockquote .who { display: block; margin-top: 6px; font-size: 10.5px; letter-spacing: 0.24em; color: var(--faint); }
+  .prose code { font-size: 0.85em; color: var(--yellow); border: 1px solid var(--line-soft); padding: 1px 6px; background: rgba(232,241,250,0.05); }
+  .prose pre {
+    position: relative; font-size: 13px; line-height: 1.8; color: #D9E6F4;
+    background: var(--bp-deep); border: 1px solid var(--line);
+    padding: 20px 22px; overflow-x: auto; margin: 22px 0;
+  }
+  .pre-wrap .fname { position: absolute; top: 0; right: 0; font-size: 10.5px; color: var(--faint); background: var(--bp); border-left: 1px solid var(--line-soft); border-bottom: 1px solid var(--line-soft); padding: 1px 12px; }
+  .tk-c { color: #6D89AB; } .tk-k { color: #FFC957; } .tk-t { color: #8FDCFF; }
+  .tk-s { color: #9BE3B4; } .tk-f { color: #C7A6F2; }
+
+  .cmt { border: 1px solid var(--line-soft); background: var(--sheet); margin: 12px 0; }
+  .cmt .ch { display: flex; gap: 14px; padding: 8px 16px; border-bottom: 1px dashed var(--line-soft); font-size: 11px; color: var(--dim); }
+  .cmt .ch .who { color: var(--ink); }
+  .cmt .cb { padding: 10px 16px; }
+  .cmt.reply { margin-left: 44px; border-left: 2px solid var(--yellow); }
+  .cmt-form { display: flex; gap: 12px; margin-top: 18px; }
+  .cmt-form input[type=text] { flex: 1; }
+  input[type=text], input[type=email], input[type=password], textarea, select {
+    font-family: var(--mono); font-size: 13.5px; color: var(--ink);
+    background: var(--bp-deep); border: 1px solid var(--line-soft); padding: 10px 14px; width: 100%;
+  }
+  input::placeholder, textarea::placeholder { color: var(--faint); }
+  input:focus, textarea:focus, select:focus { outline: none; border-color: var(--yellow); }
+
+  /* ============ projects ============ */
+  .dwg-row { display: grid; grid-template-columns: 110px 1fr auto; gap: 28px; padding: 22px 8px; border-bottom: 1px solid var(--line-soft); align-items: start; }
+  .dwg-row .no { font-size: 24px; color: var(--faint); }
+  .dwg-row .no .feat { display: block; font-size: 9px; letter-spacing: 0.3em; color: var(--yellow); margin-top: 3px; }
+  .dwg-row h2 { font-size: 17px; }
+  .dwg-row p { color: var(--dim); font-size: 13px; margin-top: 6px; max-width: 60ch; }
+  .dwg-row .links { display: flex; flex-direction: column; gap: 6px; font-size: 12px; text-align: right; }
+
+  /* ============ forms ============ */
+  .gate { max-width: 440px; margin: 26px auto 0; }
+  .gate h1 { font-size: 20px; letter-spacing: 0.14em; }
+  .gate .sub { font-size: 11px; letter-spacing: 0.2em; color: var(--dim); margin: 8px 0 24px; }
+  .field { margin: 16px 0; }
+  .field label { display: block; font-size: 10px; letter-spacing: 0.3em; color: var(--faint); margin-bottom: 6px; }
+  .gate .actions { display: flex; gap: 12px; margin-top: 24px; }
+  .err { border: 1px dashed var(--red); color: var(--red); padding: 8px 14px; font-size: 12px; margin-top: 16px; }
+
+  /* ============ admin ============ */
+  table.adm { width: 100%; border-collapse: collapse; font-size: 13px; }
+  .adm th { text-align: left; font-size: 10px; letter-spacing: 0.26em; color: var(--yellow); font-weight: 400; padding: 10px 12px; border-bottom: 1.4px solid var(--line); }
+  .adm td { padding: 10px 12px; border-bottom: 1px solid var(--line-soft); }
+  .adm tbody tr:hover td { background: rgba(143,220,255,0.06); }
+  .adm .st { font-size: 11px; } .adm .st.pub { color: #9BE3B4; } .adm .st.draft { color: var(--faint); }
+  .adm .ops a { margin-right: 14px; font-size: 11.5px; }
+  .adm .ops a.del { color: var(--red); }
+  .ed-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 0 26px; }
+  textarea.draft { min-height: 320px; line-height: 1.9; }
+  .ed-foot { display: flex; gap: 12px; margin-top: 18px; align-items: center; flex-wrap: wrap; }
+  .ed-foot .stat { margin-left: auto; font-size: 10.5px; letter-spacing: 0.14em; color: var(--faint); }
+
+  /* ============ 404 ============ */
+  .nf { text-align: center; padding: 70px 0 30px; }
+  .nf .code { font-size: 80px; font-weight: 700; color: var(--faint); letter-spacing: 0.1em; }
+  .nf .code b { color: var(--red); font-weight: 700; }
+  .nf p { color: var(--dim); margin: 14px 0 26px; font-size: 12px; letter-spacing: 0.24em; }
+
+  /* ============ palette ============ */
+  .pal-veil { position: fixed; inset: 0; background: rgba(9,26,42,0.72); display: flex; justify-content: center; padding-top: 14vh; z-index: 100; }
+  .pal-veil[hidden] { display: none; }
+  .pal { width: min(620px, calc(100vw - 32px)); height: fit-content; background: var(--bp-deep); border: 1.4px solid var(--line); }
+  .pal-in { display: flex; gap: 14px; align-items: center; padding: 14px 18px; border-bottom: 1px solid var(--line-soft); }
+  .pal-in .m { color: var(--yellow); font-size: 11px; letter-spacing: 0.3em; }
+  .pal-in input { background: none; border: 0; padding: 0; font-size: 14.5px; }
+  .pal-in input:focus { border: 0; }
+  .pal-list { max-height: 300px; overflow-y: auto; }
+  .pal-item { display: flex; gap: 16px; padding: 11px 18px; align-items: baseline; }
+  .pal-item .d { font-size: 11px; color: var(--faint); min-width: 6ch; }
+  .pal-item.sel { background: rgba(143,220,255,0.08); box-shadow: inset 2px 0 0 var(--yellow); }
+  .pal-foot { border-top: 1px solid var(--line-soft); padding: 8px 18px; font-size: 10.5px; letter-spacing: 0.14em; color: var(--faint); }
+
+  @media (max-width: 820px) {
+    .cover { grid-template-columns: 1fr; }
+    .cover-right { border-left: 0; border-top: 1px dashed var(--line); padding: 26px 0 0; }
+    .sheet { padding: 22px 18px 130px; }
+    .titleblock { grid-template-columns: auto auto; }
+    .dwg-row { grid-template-columns: 60px 1fr; }
+    .dwg-row .links { flex-direction: row; grid-column: 2; text-align: left; gap: 18px; }
+    .bom th:nth-child(3), .bom td:nth-child(3), .bom th:nth-child(4), .bom td:nth-child(4) { display: none; }
+  }
+</style>
+</head>
+<body>
+
+<div class="pt-bar">
+  <span class="pt-title">原型 · 方向 E 工程蓝图</span>
+  <nav aria-label="原型页面" style="display:flex;gap:2px;flex-wrap:wrap">
+    <button class="pt-tab active" data-target="home">首页</button>
+    <button class="pt-tab" data-target="blog">博客</button>
+    <button class="pt-tab" data-target="post">文章</button>
+    <button class="pt-tab" data-target="projects">项目</button>
+    <button class="pt-tab" data-target="login">登录</button>
+    <button class="pt-tab" data-target="signup">注册</button>
+    <button class="pt-tab" data-target="unlock">解锁</button>
+    <button class="pt-tab" data-target="admin">后台</button>
+    <button class="pt-tab" data-target="editor">编辑器</button>
+    <button class="pt-tab" data-target="404">404</button>
+  </nav>
+  <div class="pt-links"><a href="index.html">总览</a></div>
+</div>
+
+<div class="board">
+
+  <!-- ================= HOME ================= -->
+  <section class="page" data-page="home">
+    <div class="sheet">
+      <span class="tick tl"></span><span class="tick tr"></span><span class="tick bl"></span><span class="tick br"></span>
+      <div class="sheet-head">
+        <span class="dwg">DWG NO. PP-HOME-001</span>
+        <span class="dwg">REV <span class="rev">C</span></span>
+        <div class="tools">
+          <button class="tool" onclick="document.dispatchEvent(new KeyboardEvent('keydown',{key:'k',metaKey:true}))">检索 ⌘K</button>
+          <a class="tool" href="#" onclick="return false">RSS</a>
+          <a class="tool" href="#" onclick="return false">GITHUB</a>
+        </div>
+      </div>
+
+      <div class="cover">
+        <div>
+          <div class="lbl">GENERAL ARRANGEMENT — SINCE 2019</div>
+          <div class="big" style="margin-top:14px">PERFECTPAN<span>.</span></div>
+          <p class="sub">个人博客施工图集：算法竞赛旧题解、TypeScript 类型体操、Cloudflare $0/月 工程实践，以及随想。是个什么都不会的废物.jpg —— 图纸仍在更新。</p>
+          <div class="specs">
+            <div class="spec-line"><span class="k">DOCUMENTS</span><span class="v">16 篇（2019 — 2023）</span></div>
+            <div class="spec-line"><span class="k">ASSEMBLIES</span><span class="v">5 个开源项目</span></div>
+            <div class="spec-line"><span class="k">SUBSTRATE</span><span class="v">Cloudflare Workers + D1</span></div>
+            <div class="spec-line"><span class="k">TOLERANCE</span><span class="v">$0.00 / 月</span></div>
+          </div>
+          <div class="open-ports">
+            <a class="btn fill" href="#" onclick="return false">OPEN BLOG/</a>
+            <a class="btn" href="#" onclick="return false">OPEN PROJECTS/</a>
+          </div>
+        </div>
+        <div class="cover-right">
+          <h3>LATEST INDEX</h3>
+          <div class="idx-row"><span class="no">016</span><a class="t" href="#" onclick="return false">初探 Github Blocks</a></div>
+          <div class="idx-row"><span class="no">015</span><a class="t" href="#" onclick="return false">Type Challenge · 冒泡排序</a></div>
+          <div class="idx-row"><span class="no">014</span><a class="t" href="#" onclick="return false">回顾 2020</a></div>
+          <div class="idx-row"><span class="no">013</span><a class="t" href="#" onclick="return false">一些随想</a></div>
+          <div class="idx-row"><span class="no">012</span><a class="t" href="#" onclick="return false">LeetCode 中国区 TypeScript 面试题题解</a></div>
+        </div>
+      </div>
+
+      <div class="titleblock">
+        <div class="cell wide"><b>PERFECTPAN.ORG</b></div>
+        <div class="cell">TITLE<b>总布置图</b></div>
+        <div class="cell">SCALE<b>1 : 1</b></div>
+        <div class="cell">DATE<b>2026-08-15</b></div>
+        <div class="cell">SHEET<b>1 / 1</b></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= BLOG ================= -->
+  <section class="page" data-page="blog" hidden>
+    <div class="sheet">
+      <span class="tick tl"></span><span class="tick tr"></span><span class="tick bl"></span><span class="tick br"></span>
+      <div class="sheet-head">
+        <span class="dwg">DWG NO. PP-BLOG-016</span>
+        <span class="dwg">REV <span class="rev">C</span></span>
+        <h1 style="margin-left:auto">BLOG — 材料清单</h1>
+      </div>
+
+      <table class="bom">
+        <thead><tr><th>ITEM</th><th>TITLE / DESCRIPTION</th><th>ACCESS</th><th>DATE</th><th>MARK</th></tr></thead>
+        <tbody>
+          <tr class="yr"><td colspan="5">— 2023 —</td></tr>
+          <tr><td class="item">016</td><td class="tt"><a href="#" onclick="return false">初探 Github Blocks</a></td><td class="perm pub">PUBLIC</td><td class="item">02-18</td><td class="item">MISC</td></tr>
+          <tr class="yr"><td colspan="5">— 2021 —</td></tr>
+          <tr><td class="item">015</td><td class="tt"><a href="#" onclick="return false">Type Challenge · 冒泡排序</a></td><td class="perm pub">PUBLIC</td><td class="item">05-08</td><td class="item">TS</td></tr>
+          <tr><td class="item">014</td><td class="tt"><a href="#" onclick="return false">回顾 2020</a></td><td class="perm mem">MEMBER</td><td class="item">02-28</td><td class="item">LIFE</td></tr>
+          <tr class="yr"><td colspan="5">— 2020 —</td></tr>
+          <tr><td class="item">013</td><td class="tt"><a href="#" onclick="return false">一些随想</a></td><td class="perm pub">PUBLIC</td><td class="item">08-26</td><td class="item">随笔</td></tr>
+          <tr><td class="item">012</td><td class="tt"><a href="#" onclick="return false">LeetCode 中国区 TypeScript 面试题题解</a></td><td class="perm pub">PUBLIC</td><td class="item">04-13</td><td class="item">TS</td></tr>
+          <tr><td class="item">011</td><td class="tt"><a href="#" onclick="return false">那些年邂逅的 LeetCode 趣/难题</a></td><td class="perm pub">PUBLIC</td><td class="item">03-30</td><td class="item">LC</td></tr>
+          <tr><td class="item">010</td><td class="tt"><a href="#" onclick="return false">文档书写要点整理</a></td><td class="perm pw">PASSWORD</td><td class="item">03-01</td><td class="item">—</td></tr>
+          <tr class="yr"><td colspan="5">— 2019 —</td></tr>
+          <tr><td class="item">009</td><td class="tt"><a href="#" onclick="return false">回顾 2019</a></td><td class="perm vip">VIP</td><td class="item">12-31</td><td class="item">LIFE</td></tr>
+          <tr><td class="item">008</td><td class="tt"><a href="#" onclick="return false">Codeforces Round#605(Div. 3) D/E/F 题解</a></td><td class="perm pub">PUBLIC</td><td class="item">12-14</td><td class="item">DP·BFS</td></tr>
+          <tr><td class="item">007</td><td class="tt"><a href="#" onclick="return false">Codeforces Round#603(Div. 2) E/F 题解</a></td><td class="perm pub">PUBLIC</td><td class="item">12-01</td><td class="item">DP·STK</td></tr>
+          <tr><td class="item">006</td><td class="tt"><a href="#" onclick="return false">银联极客高校挑战赛复赛 D 多项式</a></td><td class="perm pub">PUBLIC</td><td class="item">09-17</td><td class="item">DP</td></tr>
+          <tr><td class="item">005</td><td class="tt"><a href="#" onclick="return false">Codeforces 1149B Three Religions</a></td><td class="perm pub">PUBLIC</td><td class="item">04-30</td><td class="item">DP·STR</td></tr>
+          <tr><td class="item">004</td><td class="tt"><a href="#" onclick="return false">2019 ICPC 南昌邀请赛网络赛 G. tsy's number</a></td><td class="perm pub">PUBLIC</td><td class="item">04-22</td><td class="item">NT</td></tr>
+        </tbody>
+      </table>
+
+      <div class="bom-pager"><span>← PREV</span><span>SHEET 1 / 2</span><a href="#" onclick="return false">NEXT →</a></div>
+
+      <div class="titleblock">
+        <div class="cell wide"><b>PP-BLOG</b></div>
+        <div class="cell">TITLE<b>材料清单</b></div>
+        <div class="cell">SCALE<b>1 : 1</b></div>
+        <div class="cell">DATE<b>2026-08-15</b></div>
+        <div class="cell">SHEET<b>1 / 2</b></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= ARTICLE ================= -->
+  <section class="page" data-page="post" hidden>
+    <div class="sheet">
+      <span class="tick tl"></span><span class="tick tr"></span><span class="tick bl"></span><span class="tick br"></span>
+      <div class="sheet-head">
+        <span class="dwg">DWG NO. PP-POST-015</span>
+        <span class="dwg">REV <span class="rev">B</span></span>
+        <div class="tools"><a class="tool" href="#" onclick="return false">← BACK TO BOM</a></div>
+      </div>
+
+      <div class="art-head">
+        <h1>Type Challenge · 冒泡排序</h1>
+        <div class="meta">
+          <span>DATE: 2021-05-08</span><span>READING: 9 MIN</span><span>MATERIAL: TYPESCRIPT</span><span class="perm pub">ACCESS: PUBLIC</span>
+        </div>
+      </div>
+
+      <div class="prose">
+        <p>这题要求在类型系统里实现冒泡排序：给定一个元组 <code>T extends number[]</code>，返回排序后的元组。类型层面上没有循环，所以核心思路是把「一趟冒泡」展开成递归。</p>
+
+        <h2><span class="no">NOTE 1</span>一趟冒泡：两两比较并交换</h2>
+        <p>先写一个 <code>Pass</code>，从头到尾扫一遍，相邻逆序就交换。它递归地消费元组的头部两个元素：</p>
+
+        <div class="pre-wrap">
+<pre><span class="fname">bubble.ts</span><span class="tk-c">// 一趟冒泡：相邻比较，逆序则交换</span>
+<span class="tk-k">type</span> <span class="tk-t">Pass</span>&lt;<span class="tk-t">T</span> <span class="tk-k">extends</span> <span class="tk-t">number</span>[]&gt; =
+  <span class="tk-t">T</span> <span class="tk-k">extends</span> [<span class="tk-k">infer</span> <span class="tk-t">A</span> <span class="tk-k">extends</span> <span class="tk-t">number</span>, <span class="tk-k">infer</span> <span class="tk-t">B</span> <span class="tk-k">extends</span> <span class="tk-t">number</span>, ...<span class="tk-k">infer</span> <span class="tk-t">R</span> <span class="tk-k">extends</span> <span class="tk-t">number</span>[]]
+    ? <span class="tk-t">A</span> <span class="tk-k">extends</span> <span class="tk-s">`${B}`</span>
+      ? [<span class="tk-t">A</span>, ...<span class="tk-t">Pass</span>&lt;[<span class="tk-t">B</span>, ...<span class="tk-t">R</span>]&gt;]
+      : [<span class="tk-t">B</span>, ...<span class="tk-t">Pass</span>&lt;[<span class="tk-t">A</span>, ...<span class="tk-t">R</span>]&gt;]
+    : <span class="tk-t">T</span>;
+
+<span class="tk-k">type</span> <span class="tk-f">BubbleSort</span>&lt;<span class="tk-t">T</span>&gt; = ...<span class="tk-c">// 一趟没交换 → 有序；否则再来一趟</span></pre>
+        </div>
+
+        <blockquote>数字比较不能直接用 <code>&lt;</code>，得转成字符串长度或逐位比较——类型体操的老朋友了。<span class="who">— NOTE</span></blockquote>
+
+        <h2><span class="no">NOTE 2</span>几个细节</h2>
+        <ul>
+          <li><code>infer A extends number</code> 收窄推断结果，省掉一层条件判断；</li>
+          <li>终止条件是「这一趟没有发生任何交换」，用深度相等判断；</li>
+          <li>元组很长时记得给 TS 足够的递归深度，或者拆成小测试。</li>
+        </ul>
+        <p>完整题解在仓库 <code>type-challenges</code> 里，配合测试用例食用更佳。</p>
+      </div>
+
+      <div class="lbl" style="margin:44px 0 6px">INSPECTION RECORD — 读者来函</div>
+      <div class="cmt">
+        <div class="ch"><span class="who">alice@example.com</span><span>2021-05-09</span></div>
+        <div class="cb"><p>Equal 判终止这个思路太优雅了，比数长度 hack 干净。</p></div>
+      </div>
+      <div class="cmt reply">
+        <div class="ch"><span class="who">bob@example.com</span><span>2021-05-10</span></div>
+        <div class="cb"><p>数长度在负数场景直接爆炸，还是深度相等稳。</p></div>
+      </div>
+      <form class="cmt-form" onsubmit="return false">
+        <input type="text" placeholder="检验意见……（支持 markdown）" aria-label="新评论">
+        <button class="btn fill" type="submit">SUBMIT</button>
+      </form>
+
+      <div class="titleblock">
+        <div class="cell wide"><b>PP-POST-015</b></div>
+        <div class="cell">TITLE<b>冒泡排序</b></div>
+        <div class="cell">SCALE<b>1 : 1</b></div>
+        <div class="cell">DATE<b>2021-05-08</b></div>
+        <div class="cell">SHEET<b>15 / 16</b></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= PROJECTS ================= -->
+  <section class="page" data-page="projects" hidden>
+    <div class="sheet">
+      <span class="tick tl"></span><span class="tick tr"></span><span class="tick bl"></span><span class="tick br"></span>
+      <div class="sheet-head">
+        <span class="dwg">DWG NO. PP-PRJ-005</span>
+        <span class="dwg">REV <span class="rev">A</span></span>
+        <h1 style="margin-left:auto">PROJECTS — 装配图集</h1>
+      </div>
+
+      <div class="dwg-row">
+        <div class="no">05<span class="feat">FEATURED</span></div>
+        <div>
+          <h2>blog</h2>
+          <p>本博客——TanStack Start 前台，全量部署在 Cloudflare Workers + D1 上。</p>
+        </div>
+        <div class="links"><a href="#" onclick="return false">CODE ↗</a><a href="#" onclick="return false">DEMO ↗</a></div>
+      </div>
+      <div class="dwg-row">
+        <div class="no">04<span class="feat">FEATURED</span></div>
+        <div>
+          <h2>logseq-plugin-code-formatter</h2>
+          <p>Logseq 插件——用 Prettier 一键格式化代码块，支持 JS / TS / HTML / CSS / Markdown / JSON。</p>
+        </div>
+        <div class="links"><a href="#" onclick="return false">CODE ↗</a></div>
+      </div>
+      <div class="dwg-row">
+        <div class="no">03</div>
+        <div>
+          <h2>ocvm</h2>
+          <p>OpenClaw 版本管理器——nvm 风格的 Rust CLI，按项目安装、切换、锁定与回滚版本。</p>
+        </div>
+        <div class="links"><a href="#" onclick="return false">CODE ↗</a><a href="#" onclick="return false">DEMO ↗</a></div>
+      </div>
+      <div class="dwg-row">
+        <div class="no">02</div>
+        <div>
+          <h2>agent-presence</h2>
+          <p>把本地编码 agent 的在线状态与 token 用量同步到飞书签名链接预览。</p>
+        </div>
+        <div class="links"><a href="#" onclick="return false">CODE ↗</a><a href="#" onclick="return false">DEMO ↗</a></div>
+      </div>
+      <div class="dwg-row">
+        <div class="no">01</div>
+        <div>
+          <h2>base64</h2>
+          <p>Moonbit 语言实现的 Base64 编解码库，遵循 RFC 4648。</p>
+        </div>
+        <div class="links"><a href="#" onclick="return false">CODE ↗</a></div>
+      </div>
+
+      <div class="titleblock">
+        <div class="cell wide"><b>PP-PRJ</b></div>
+        <div class="cell">TITLE<b>装配图集</b></div>
+        <div class="cell">SCALE<b>1 : 1</b></div>
+        <div class="cell">DATE<b>2026-08-15</b></div>
+        <div class="cell">SHEET<b>5 / 5</b></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= LOGIN ================= -->
+  <section class="page" data-page="login" hidden>
+    <div class="sheet" style="max-width:520px;margin:0 auto">
+      <span class="tick tl"></span><span class="tick tr"></span><span class="tick bl"></span><span class="tick br"></span>
+      <div class="sheet-head"><span class="dwg">DWG NO. PP-AUTH-01</span><span class="dwg">REV <span class="rev">A</span></span></div>
+      <div class="gate" style="margin:0">
+        <h1>登录 / SIGN IN</h1>
+        <p class="sub">会友可读 MEMBER 图纸 · 亦支持 GITHUB OAUTH</p>
+        <form onsubmit="return false">
+          <div class="field"><label for="e-em">EMAIL</label><input id="e-em" type="email" placeholder="you@example.com"></div>
+          <div class="field"><label for="e-pw">PASSWORD</label><input id="e-pw" type="password" placeholder="••••••••"></div>
+          <div class="actions">
+            <button class="btn fill" type="submit">SIGN IN</button>
+            <button class="btn" type="button">GITHUB</button>
+          </div>
+          <p class="err" hidden>认证失败：邮箱或密码不正确</p>
+        </form>
+        <p style="margin-top:18px;font-size:12px;color:var(--dim)">尚未注册？ <a href="#" onclick="return false">SIGN UP</a></p>
+      </div>
+      <div class="titleblock">
+        <div class="cell wide"><b>PP-AUTH-01</b></div>
+        <div class="cell">TITLE<b>登录</b></div>
+        <div class="cell">SHEET<b>—</b></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= SIGNUP ================= -->
+  <section class="page" data-page="signup" hidden>
+    <div class="sheet" style="max-width:520px;margin:0 auto">
+      <span class="tick tl"></span><span class="tick tr"></span><span class="tick bl"></span><span class="tick br"></span>
+      <div class="sheet-head"><span class="dwg">DWG NO. PP-AUTH-02</span><span class="dwg">REV <span class="rev">A</span></span></div>
+      <div class="gate" style="margin:0">
+        <h1>注册 / SIGN UP</h1>
+        <p class="sub">注册即成为 MEMBER</p>
+        <form onsubmit="return false">
+          <div class="field"><label for="e-sem">EMAIL</label><input id="e-sem" type="email" placeholder="you@example.com"></div>
+          <div class="field"><label for="e-spw">PASSWORD</label><input id="e-spw" type="password" placeholder="至少 8 位"></div>
+          <div class="field"><label for="e-spw2">CONFIRM</label><input id="e-spw2" type="password" placeholder="••••••••"></div>
+          <div class="actions">
+            <button class="btn fill" type="submit">CREATE</button>
+            <button class="btn" type="button">GITHUB</button>
+          </div>
+        </form>
+      </div>
+      <div class="titleblock">
+        <div class="cell wide"><b>PP-AUTH-02</b></div>
+        <div class="cell">TITLE<b>注册</b></div>
+        <div class="cell">SHEET<b>—</b></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= UNLOCK ================= -->
+  <section class="page" data-page="unlock" hidden>
+    <div class="sheet" style="max-width:520px;margin:0 auto">
+      <span class="tick tl"></span><span class="tick tr"></span><span class="tick bl"></span><span class="tick br"></span>
+      <div class="sheet-head"><span class="dwg">DWG NO. PP-AUTH-03</span><span class="dwg">REV <span class="rev">A</span></span><span class="dwg" style="color:var(--red)">STATUS: LOCKED</span></div>
+      <div class="gate" style="margin:0">
+        <h1>解锁图纸 №010</h1>
+        <p class="sub">此篇以单文密码封缄 ・ 验后 24 小时免复输入</p>
+        <form onsubmit="return false">
+          <div class="field"><label for="e-upw">POST PASSWORD</label><input id="e-upw" type="password" placeholder="••••••••" autofocus></div>
+          <p class="err">密码错误，请重试（连续失败会触发限流）</p>
+          <div class="actions">
+            <button class="btn fill" type="submit">UNLOCK</button>
+            <a class="btn" href="#" onclick="return false">← BACK</a>
+          </div>
+        </form>
+      </div>
+      <div class="titleblock">
+        <div class="cell wide"><b>PP-AUTH-03</b></div>
+        <div class="cell">TITLE<b>密笈</b></div>
+        <div class="cell">SHEET<b>—</b></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= ADMIN ================= -->
+  <section class="page" data-page="admin" hidden>
+    <div class="sheet">
+      <span class="tick tl"></span><span class="tick tr"></span><span class="tick bl"></span><span class="tick br"></span>
+      <div class="sheet-head">
+        <span class="dwg">DWG NO. PP-ADM-000</span>
+        <span class="dwg">REV <span class="rev">D</span></span>
+        <h1 style="margin-left:auto">后台 · 图档管理</h1>
+      </div>
+
+      <table class="adm">
+        <thead><tr><th>ITEM</th><th>TITLE</th><th>STATUS</th><th>ACCESS</th><th>UPDATED</th><th>OPS</th></tr></thead>
+        <tbody>
+          <tr><td style="color:var(--faint);font-size:11px">016</td><td>初探 Github Blocks</td><td class="st pub">● PUBLISHED</td><td style="font-size:11px">public</td><td style="color:var(--faint);font-size:11px">2023-02-18</td><td class="ops"><a href="#" onclick="return false">EDIT</a><a class="del" href="#" onclick="return false">DEL</a></td></tr>
+          <tr><td style="color:var(--faint);font-size:11px">015</td><td>Type Challenge · 冒泡排序</td><td class="st pub">● PUBLISHED</td><td style="font-size:11px">public</td><td style="color:var(--faint);font-size:11px">2021-05-08</td><td class="ops"><a href="#" onclick="return false">EDIT</a><a class="del" href="#" onclick="return false">DEL</a></td></tr>
+          <tr><td style="color:var(--faint);font-size:11px">014</td><td>回顾 2020</td><td class="st pub">● PUBLISHED</td><td style="font-size:11px">member</td><td style="color:var(--faint);font-size:11px">2021-02-28</td><td class="ops"><a href="#" onclick="return false">EDIT</a><a class="del" href="#" onclick="return false">DEL</a></td></tr>
+          <tr><td style="color:var(--faint);font-size:11px">010</td><td>文档书写要点整理</td><td class="st pub">● PUBLISHED</td><td style="font-size:11px">password</td><td style="color:var(--faint);font-size:11px">2020-03-01</td><td class="ops"><a href="#" onclick="return false">EDIT</a><a class="del" href="#" onclick="return false">DEL</a></td></tr>
+          <tr><td style="color:var(--faint);font-size:11px">017</td><td>Cloudflare 迁移实录</td><td class="st draft">○ DRAFT</td><td style="font-size:11px">public</td><td style="color:var(--faint);font-size:11px">2026-08-12</td><td class="ops"><a href="#" onclick="return false">EDIT</a><a class="del" href="#" onclick="return false">DEL</a></td></tr>
+        </tbody>
+      </table>
+      <div class="ed-foot" style="margin-top:24px">
+        <a class="btn fill" href="#" onclick="return false">＋ NEW DRAWING</a>
+        <a class="btn" href="#" onclick="return false">COMMENTS (23)</a>
+      </div>
+
+      <div class="titleblock">
+        <div class="cell wide"><b>PP-ADM</b></div>
+        <div class="cell">TITLE<b>图档管理</b></div>
+        <div class="cell">DATE<b>2026-08-15</b></div>
+        <div class="cell">SHEET<b>—</b></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= EDITOR ================= -->
+  <section class="page" data-page="editor" hidden>
+    <div class="sheet">
+      <span class="tick tl"></span><span class="tick tr"></span><span class="tick bl"></span><span class="tick br"></span>
+      <div class="sheet-head">
+        <span class="dwg">DWG NO. PP-ADM-017</span>
+        <span class="dwg">REV <span class="rev">—</span></span>
+        <h1 style="margin-left:auto">编辑器 · 制图中</h1>
+      </div>
+
+      <form onsubmit="return false">
+        <div class="ed-grid">
+          <div class="field"><label>TITLE</label><input type="text" value="Cloudflare 迁移实录"></div>
+          <div class="field"><label>SLUG</label><input type="text" value="cloudflare-migration"></div>
+          <div class="field"><label>VISIBILITY</label>
+            <select><option>public</option><option>member</option><option>vip</option><option>admin</option><option>password</option></select>
+          </div>
+          <div class="field"><label>TAGS</label><input type="text" value="Cloudflare, D1, Workers"></div>
+        </div>
+        <div class="field"><label>CONTENT — MARKDOWN</label>
+          <textarea class="draft" spellcheck="false">## 为什么要迁
+
+Postgres 免费额度撑不住了……
+
+```ts
+export default { fetch } = ...
+```</textarea>
+        </div>
+        <div class="ed-foot">
+          <button class="btn" type="button">SAVE DRAFT</button>
+          <button class="btn fill" type="button">PUBLISH</button>
+          <span class="stat">642 CHARS · 3 MIN · AUTOSAVED 12:41</span>
+        </div>
+      </form>
+
+      <div class="titleblock">
+        <div class="cell wide"><b>PP-ADM-017</b></div>
+        <div class="cell">TITLE<b>迁移实录</b></div>
+        <div class="cell">DATE<b>2026-08-12</b></div>
+        <div class="cell">SHEET<b>DRAFT</b></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= 404 ================= -->
+  <section class="page" data-page="404" hidden>
+    <div class="sheet">
+      <span class="tick tl"></span><span class="tick tr"></span><span class="tick bl"></span><span class="tick br"></span>
+      <div class="nf">
+        <div class="lbl">ERROR — NO SUCH DRAWING</div>
+        <div class="code">4<b>0</b>4</div>
+        <p>本图集并无此图号 · 或已作废归档</p>
+        <a class="btn" href="#" onclick="return false">← BACK TO BLOG</a>
+      </div>
+      <div class="titleblock">
+        <div class="cell wide"><b>PP-404</b></div>
+        <div class="cell">TITLE<b>阙图</b></div>
+        <div class="cell">SHEET<b>—</b></div>
+      </div>
+    </div>
+  </section>
+
+</div>
+
+<!-- 检索 palette -->
+<div class="pal-veil" id="pal-veil" hidden>
+  <div class="pal" role="dialog" aria-label="搜索文章">
+    <div class="pal-in"><span class="m">检索</span><input type="text" id="pal-input" placeholder="按图号或关键词查找……" aria-label="搜索"></div>
+    <div class="pal-list">
+      <div class="pal-item sel"><span class="d">015</span><span>Type Challenge · 冒泡排序</span></div>
+      <div class="pal-item"><span class="d">012</span><span>LeetCode 中国区 TypeScript 面试题题解</span></div>
+      <div class="pal-item"><span class="d">008</span><span>Codeforces Round#605(Div. 3) D/E/F 题解</span></div>
+      <div class="pal-item"><span class="d">005</span><span>Codeforces 1149B Three Religions</span></div>
+    </div>
+    <div class="pal-foot">↑↓ SELECT · ↵ OPEN · ESC CLOSE — 权限按当前身份过滤</div>
+  </div>
+</div>
+
+<script>
+  var tabs = document.querySelectorAll('.pt-tab');
+  var pages = document.querySelectorAll('.page');
+  function go(id) {
+    pages.forEach(function(p){ p.hidden = p.dataset.page !== id; });
+    tabs.forEach(function(t){ t.classList.toggle('active', t.dataset.target === id); });
+    window.scrollTo(0, 0);
+    history.replaceState(null, '', '#' + id);
+  }
+  tabs.forEach(function(t){ if (t.dataset.target) t.addEventListener('click', function(){ go(t.dataset.target); }); });
+  var h = location.hash.slice(1);
+  if (h && document.querySelector('.page[data-page="' + h + '"]')) go(h);
+  window.addEventListener('hashchange', function(){
+    var h = location.hash.slice(1);
+    if (h && document.querySelector('.page[data-page="' + h + '"]')) go(h);
+  });
+
+  var veil = document.getElementById('pal-veil');
+  var input = document.getElementById('pal-input');
+  document.addEventListener('keydown', function(e){
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') { e.preventDefault(); veil.hidden = false; input.focus(); }
+    if (e.key === 'Escape') veil.hidden = true;
+  });
+  veil.addEventListener('click', function(e){ if (e.target === veil) veil.hidden = true; });
+</script>
+</body>
+</html>

--- a/prototypes/f-neopop.html
+++ b/prototypes/f-neopop.html
@@ -1,0 +1,648 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>方向 F · 糖果粗野 · PerfectPan's Blog 原型</title>
+<style>
+  /* ============ tokens ============ */
+  :root {
+    --bg: #FFFDF4;        /* 奶白 */
+    --block: #FFDE59;     /* 大黄块 */
+    --ink: #141414;
+    --paper: #FFFFFF;
+    --orange: #FF6B35;
+    --violet: #7C5CFF;
+    --pink: #FF90C2;
+    --mint: #21CBA8;
+    --sky: #57B8FF;
+    --line: #141414;
+    --shadow: 5px 5px 0 #141414;
+    --shadow-sm: 3px 3px 0 #141414;
+    --sans: "Helvetica Neue", Inter, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", system-ui, sans-serif;
+    --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: var(--bg); color: var(--ink);
+    font-family: var(--sans); font-size: 15px; line-height: 1.75;
+    min-height: 100vh;
+    background-image: radial-gradient(rgba(20,20,20,0.06) 1.2px, transparent 1.2px);
+    background-size: 22px 22px;
+  }
+  ::selection { background: var(--block); }
+  a { color: inherit; text-decoration: none; }
+  :focus-visible { outline: 3px solid var(--violet); outline-offset: 2px; }
+
+  /* ============ prototype chrome ============ */
+  .pt-bar {
+    background: #141414; color: #9B9B9B; font-size: 12.5px;
+    padding: 0 16px; display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
+    position: sticky; top: 0; z-index: 50;
+  }
+  .pt-bar .pt-title { color: var(--block); font-weight: 700; letter-spacing: 0.06em; }
+  .pt-tab {
+    font-family: inherit; font-size: 12.5px; color: #9B9B9B; background: none;
+    border: 0; padding: 9px 10px; cursor: pointer;
+  }
+  .pt-tab:hover { color: #fff; }
+  .pt-tab.active { color: #141414; background: var(--block); font-weight: 700; }
+  .pt-links { margin-left: auto; display: flex; gap: 12px; }
+  .pt-links a { color: #6B6B6B; }
+  .pt-links a:hover { color: var(--block); }
+
+  /* ============ 通用部件 ============ */
+  .wrap { max-width: 1080px; margin: 0 auto; padding: 0 22px 90px; }
+  .page[hidden] { display: none; }
+
+  .card {
+    background: var(--paper); border: 2px solid var(--line);
+    box-shadow: var(--shadow); border-radius: 2px;
+    transition: transform .1s, box-shadow .1s;
+  }
+  .card.lift:hover { transform: translate(-2px,-2px); box-shadow: 7px 7px 0 #141414; }
+
+  .sticker {
+    display: inline-block; border: 2px solid var(--line); box-shadow: var(--shadow-sm);
+    font-size: 11px; font-weight: 800; letter-spacing: 0.08em; padding: 1px 9px;
+    background: var(--paper); border-radius: 2px; white-space: nowrap;
+  }
+  .sticker.y { background: var(--block); }
+  .sticker.o { background: var(--orange); color: #fff; }
+  .sticker.v { background: var(--violet); color: #fff; }
+  .sticker.p { background: var(--pink); }
+  .sticker.m { background: var(--mint); }
+  .sticker.s { background: var(--sky); }
+  .tilt-l { transform: rotate(-2.5deg); } .tilt-r { transform: rotate(2deg); }
+
+  .btn {
+    font: inherit; font-size: 14px; font-weight: 800; cursor: pointer;
+    background: var(--paper); color: var(--ink);
+    border: 2px solid var(--line); box-shadow: var(--shadow-sm); border-radius: 2px;
+    padding: 10px 22px; transition: transform .1s, box-shadow .1s;
+  }
+  .btn:hover { transform: translate(-2px,-2px); box-shadow: 5px 5px 0 #141414; }
+  .btn:active { transform: translate(2px,2px); box-shadow: 1px 1px 0 #141414; }
+  .btn.fill { background: var(--block); }
+  .btn.o { background: var(--orange); color: #fff; }
+
+  .h-banner {
+    display: inline-block; background: var(--ink); color: var(--block);
+    font-weight: 900; font-size: 13px; letter-spacing: 0.24em; padding: 4px 16px;
+    transform: rotate(-1.2deg);
+  }
+
+  /* ============ header ============ */
+  .site-head { padding: 30px 0 26px; display: flex; align-items: center; gap: 18px; flex-wrap: wrap; }
+  .logo {
+    background: var(--ink); color: #FFFDF4; font-weight: 900; font-size: 17px;
+    padding: 8px 16px; border-radius: 2px; transform: rotate(-1.5deg);
+    box-shadow: var(--shadow-sm); display: inline-block;
+  }
+  .site-head nav { display: flex; gap: 10px; flex-wrap: wrap; }
+  .nav-chip {
+    font-size: 13px; font-weight: 800; padding: 5px 14px; border: 2px solid var(--line);
+    border-radius: 999px; background: var(--paper); box-shadow: var(--shadow-sm);
+  }
+  .nav-chip:hover { background: var(--block); }
+  .nav-chip.on { background: var(--orange); color: #fff; }
+  .site-head .tools { margin-left: auto; display: flex; gap: 10px; }
+  .tool-btn {
+    font: inherit; font-size: 12px; font-weight: 800; background: var(--paper);
+    border: 2px solid var(--line); border-radius: 2px; box-shadow: var(--shadow-sm);
+    padding: 5px 12px; cursor: pointer;
+  }
+  .tool-btn:hover { background: var(--sky); }
+
+  /* ============ HOME ============ */
+  .hero {
+    background: var(--block); border: 2px solid var(--line); box-shadow: var(--shadow);
+    border-radius: 2px; padding: 54px 44px 50px; position: relative; overflow: hidden;
+  }
+  .hero .sticker.float { position: absolute; top: 20px; right: 26px; }
+  .hero h1 {
+    font-size: clamp(40px, 7vw, 72px); font-weight: 900; line-height: 1.08; letter-spacing: -0.02em;
+    text-transform: uppercase;
+  }
+  .hero h1 .stroke {
+    color: var(--bg); -webkit-text-stroke: 2.5px var(--ink); paint-order: stroke fill;
+  }
+  .hero h1 .dot { color: var(--orange); }
+  .hero p { margin-top: 18px; font-size: 16.5px; max-width: 52ch; font-weight: 500; }
+  .hero .cta { margin-top: 30px; display: flex; gap: 14px; flex-wrap: wrap; }
+  .home-grid { display: grid; grid-template-columns: 1.5fr 1fr; gap: 22px; margin-top: 22px; }
+  .panel { padding: 24px 26px; }
+  .panel h3 {
+    display: inline-block; font-size: 13px; font-weight: 900; letter-spacing: 0.14em;
+    background: var(--violet); color: #fff; padding: 2px 12px; transform: rotate(-1deg); margin-bottom: 16px;
+  }
+  .panel h3.o { background: var(--orange); }
+  .rowitem { display: flex; gap: 12px; align-items: center; padding: 9px 0; border-bottom: 2px dashed rgba(20,20,20,0.16); }
+  .rowitem:last-child { border-bottom: 0; }
+  .rowitem .no { font-family: var(--mono); font-size: 11px; color: rgba(20,20,20,0.5); font-weight: 700; }
+  .rowitem .t { flex: 1; font-weight: 700; font-size: 14.5px; }
+  .rowitem .t:hover { color: var(--violet); }
+  .stat-row { display: flex; justify-content: space-between; align-items: center; padding: 10px 0; border-bottom: 2px dashed rgba(20,20,20,0.16); }
+  .stat-row:last-child { border-bottom: 0; }
+  .stat-row b { font-size: 26px; font-weight: 900; }
+  .stat-row b.vio { color: var(--violet); } .stat-row b.org { color: var(--orange); }
+  .stat-row span { font-size: 12.5px; font-weight: 600; color: rgba(20,20,20,0.6); }
+
+  /* ============ BLOG ============ */
+  .page-head { padding: 34px 0 22px; display: flex; align-items: center; gap: 18px; flex-wrap: wrap; }
+  .page-head h1 { font-size: 38px; font-weight: 900; letter-spacing: -0.02em; }
+  .filters { margin-left: auto; display: flex; gap: 8px; flex-wrap: wrap; }
+  .list-card { padding: 10px 26px 18px; }
+  .yr-band { display: flex; align-items: center; gap: 14px; padding: 22px 0 10px; }
+  .yr-band .pill { background: var(--ink); color: #FFFDF4; font-weight: 900; font-size: 13px; padding: 2px 14px; border-radius: 999px; letter-spacing: 0.1em; }
+  .yr-band::after { content: ""; flex: 1; border-top: 2px dashed rgba(20,20,20,0.2); }
+  .post-row {
+    display: grid; grid-template-columns: 52px 1fr auto auto; gap: 18px; align-items: center;
+    padding: 12px 10px; border-radius: 2px;
+  }
+  .post-row:hover { background: var(--block); outline: 2px solid var(--line); }
+  .post-row .no { font-family: var(--mono); font-size: 12px; font-weight: 700; color: rgba(20,20,20,0.55); }
+  .post-row .t { font-weight: 700; font-size: 16px; }
+  .post-row .tags { display: flex; gap: 6px; flex-wrap: wrap; }
+  .post-row .d { font-family: var(--mono); font-size: 11.5px; font-weight: 700; color: rgba(20,20,20,0.55); }
+  .pager { display: flex; gap: 10px; justify-content: center; margin-top: 24px; }
+  .pager .cur { background: var(--orange); color: #fff; }
+
+  /* ============ ARTICLE ============ */
+  .art-card { padding: 40px 46px 44px; margin-top: 8px; }
+  .art-card h1 { font-size: clamp(26px, 4vw, 38px); font-weight: 900; line-height: 1.3; letter-spacing: -0.01em; }
+  .art-meta { display: flex; gap: 10px; margin: 16px 0 8px; flex-wrap: wrap; }
+  .prose { margin-top: 26px; font-size: 16px; }
+  .prose p { margin: 18px 0; }
+  .prose h2 {
+    font-size: 20px; font-weight: 900; margin: 36px 0 12px; display: flex; gap: 12px; align-items: center;
+  }
+  .prose h2 .chip { background: var(--mint); border: 2px solid var(--line); box-shadow: var(--shadow-sm); font-size: 12px; padding: 0 10px; border-radius: 999px; }
+  .prose ul { margin: 14px 0; list-style: none; }
+  .prose li { padding: 7px 0 7px 30px; position: relative; font-weight: 500; }
+  .prose li::before { content: "★"; position: absolute; left: 2px; color: var(--orange); font-size: 13px; }
+  .prose blockquote {
+    background: var(--pink); border: 2px solid var(--line); box-shadow: var(--shadow-sm);
+    padding: 12px 20px; margin: 22px 0; font-weight: 600; border-radius: 2px; transform: rotate(-0.6deg);
+  }
+  .prose code { font-family: var(--mono); font-size: 0.85em; background: var(--block); border: 1.5px solid var(--line); border-radius: 2px; padding: 1px 6px; font-weight: 700; }
+  .prose pre {
+    font-family: var(--mono); font-size: 13px; line-height: 1.8; color: #F4F1E8;
+    background: #141414; border: 2px solid var(--line); box-shadow: var(--shadow);
+    border-radius: 2px; padding: 20px 22px; overflow-x: auto; margin: 24px 0;
+  }
+  .pre-wrap { position: relative; }
+  .pre-wrap .fname { position: absolute; top: -14px; left: 18px; background: var(--sky); border: 2px solid var(--line); font-size: 11px; font-weight: 800; padding: 0 10px; border-radius: 999px; transform: rotate(-1.5deg); }
+  .tk-c { color: #7C7C7C; } .tk-k { color: #FFDE59; } .tk-t { color: #57B8FF; }
+  .tk-s { color: #21CBA8; } .tk-f { color: #FF90C2; }
+  .cmt-card { padding: 16px 20px; margin: 14px 0; }
+  .cmt-card.reply { margin-left: 48px; background: var(--bg); }
+  .cmt-h { display: flex; gap: 12px; align-items: center; font-size: 12.5px; font-weight: 700; margin-bottom: 6px; }
+  .cmt-h .who { background: var(--violet); color: #fff; padding: 0 10px; border-radius: 999px; border: 2px solid var(--line); font-size: 11.5px; }
+  .cmt-form { display: flex; gap: 12px; margin-top: 20px; }
+  .cmt-form input[type=text] { flex: 1; }
+
+  /* ============ PROJECTS ================= */
+  .proj-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 22px; }
+  .proj-card { padding: 24px 26px; position: relative; }
+  .proj-card h2 { font-size: 19px; font-weight: 900; display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+  .proj-card p { margin-top: 8px; font-size: 14px; color: rgba(20,20,20,0.75); }
+  .proj-card .tags { margin: 14px 0; display: flex; gap: 6px; flex-wrap: wrap; }
+  .proj-card .links { display: flex; gap: 10px; }
+
+  /* ============ forms ============ */
+  .gate { max-width: 460px; margin: 30px auto 0; }
+  .gate .card { padding: 34px 36px 36px; position: relative; }
+  .gate .badge-top { position: absolute; top: -16px; left: 26px; }
+  .gate h1 { font-size: 30px; font-weight: 900; }
+  .gate .sub { font-size: 13.5px; font-weight: 600; color: rgba(20,20,20,0.6); margin: 6px 0 22px; }
+  .field { margin: 15px 0; }
+  .field label { display: block; font-size: 12px; font-weight: 900; letter-spacing: 0.12em; margin-bottom: 5px; }
+  input[type=text], input[type=email], input[type=password], textarea, select {
+    width: 100%; font-family: var(--sans); font-size: 14.5px; font-weight: 500; color: var(--ink);
+    background: var(--bg); border: 2px solid var(--line); border-radius: 2px; padding: 10px 14px;
+    box-shadow: inset 2px 2px 0 rgba(20,20,20,0.08);
+  }
+  input:focus, textarea:focus, select:focus { outline: none; background: #fff; border-color: var(--violet); box-shadow: 3px 3px 0 var(--violet); }
+  .gate .actions { display: flex; gap: 12px; margin-top: 24px; flex-wrap: wrap; }
+  .err {
+    display: inline-block; background: var(--pink); border: 2px solid var(--line); box-shadow: var(--shadow-sm);
+    font-size: 13px; font-weight: 700; padding: 6px 14px; margin-top: 16px; transform: rotate(-1deg);
+  }
+  .gate .aside { margin-top: 20px; font-size: 13.5px; font-weight: 600; }
+  .gate .aside a { color: var(--violet); text-decoration: underline; text-decoration-thickness: 2px; }
+
+  /* ============ admin ============ */
+  table.adm { width: 100%; border-collapse: collapse; font-size: 13.5px; }
+  .adm th { text-align: left; font-size: 11px; font-weight: 900; letter-spacing: 0.14em; padding: 12px 12px; border-bottom: 2.5px solid var(--line); }
+  .adm td { padding: 12px; border-bottom: 2px dashed rgba(20,20,20,0.18); font-weight: 600; }
+  .adm tbody tr:hover td { background: rgba(255,222,89,0.35); }
+  .adm td.tt { font-weight: 800; }
+  .adm .ops a { font-size: 11.5px; font-weight: 800; margin-right: 12px; }
+  .adm .ops a.del { color: var(--orange); }
+  .ed-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 0 22px; }
+  textarea.draft { min-height: 300px; font-family: var(--mono); font-size: 13.5px; line-height: 1.8; }
+  .ed-foot { display: flex; gap: 12px; margin-top: 18px; flex-wrap: wrap; align-items: center; }
+  .ed-foot .stat { margin-left: auto; font-family: var(--mono); font-size: 11px; font-weight: 700; color: rgba(20,20,20,0.55); }
+
+  /* ============ 404 ============ */
+  .nf { text-align: center; padding: 70px 0 40px; }
+  .nf .code { font-size: 100px; font-weight: 900; letter-spacing: -0.03em; line-height: 1; }
+  .nf .code b { color: var(--orange); }
+  .nf p { font-weight: 700; margin: 16px 0 28px; }
+
+  /* ============ palette ============ */
+  .pal-veil { position: fixed; inset: 0; background: rgba(20,20,20,0.5); display: flex; justify-content: center; padding-top: 13vh; z-index: 100; }
+  .pal-veil[hidden] { display: none; }
+  .pal { width: min(620px, calc(100vw - 32px)); height: fit-content; background: var(--bg); border: 2px solid var(--line); box-shadow: 8px 8px 0 #141414; border-radius: 2px; overflow: hidden; }
+  .pal-in { display: flex; gap: 12px; align-items: center; padding: 14px 18px; border-bottom: 2px solid var(--line); background: var(--block); }
+  .pal-in input { background: none; border: 0; box-shadow: none; padding: 0; font-size: 15px; font-weight: 700; }
+  .pal-in input:focus { box-shadow: none; border: 0; }
+  .pal-list { max-height: 300px; overflow-y: auto; }
+  .pal-item { display: flex; gap: 14px; padding: 11px 18px; align-items: center; }
+  .pal-item .d { font-family: var(--mono); font-size: 11px; font-weight: 700; color: rgba(20,20,20,0.5); min-width: 4ch; }
+  .pal-item.sel { background: var(--block); outline: 2px solid var(--line); }
+  .pal-foot { border-top: 2px solid var(--line); padding: 8px 18px; font-size: 11px; font-weight: 700; color: rgba(20,20,20,0.55); }
+
+  @media (max-width: 860px) {
+    .home-grid, .proj-grid { grid-template-columns: 1fr; }
+    .art-card { padding: 26px 20px 30px; }
+    .post-row { grid-template-columns: 44px 1fr; }
+    .post-row .tags, .post-row .d { display: none; }
+    .site-head { padding-top: 20px; }
+  }
+</style>
+</head>
+<body>
+
+<div class="pt-bar">
+  <span class="pt-title">原型 · 方向 F 糖果粗野</span>
+  <nav aria-label="原型页面" style="display:flex;gap:2px;flex-wrap:wrap">
+    <button class="pt-tab active" data-target="home">首页</button>
+    <button class="pt-tab" data-target="blog">博客</button>
+    <button class="pt-tab" data-target="post">文章</button>
+    <button class="pt-tab" data-target="projects">项目</button>
+    <button class="pt-tab" data-target="login">登录</button>
+    <button class="pt-tab" data-target="signup">注册</button>
+    <button class="pt-tab" data-target="unlock">解锁</button>
+    <button class="pt-tab" data-target="admin">后台</button>
+    <button class="pt-tab" data-target="editor">编辑器</button>
+    <button class="pt-tab" data-target="404">404</button>
+  </nav>
+  <div class="pt-links"><a href="index.html">总览</a></div>
+</div>
+
+<div class="wrap">
+  <header class="site-head">
+    <span class="logo">PerfectPan</span>
+    <nav>
+      <a class="nav-chip" href="#" onclick="return false">Home</a>
+      <a class="nav-chip on" href="#" onclick="return false">Blog</a>
+      <a class="nav-chip" href="#" onclick="return false">Projects</a>
+      <a class="nav-chip" href="#" onclick="return false">Admin</a>
+    </nav>
+    <div class="tools">
+      <button class="tool-btn" onclick="document.dispatchEvent(new KeyboardEvent('keydown',{key:'k',metaKey:true}))">⌘K 搜索</button>
+      <a class="tool-btn" href="#" onclick="return false">RSS</a>
+      <a class="tool-btn" href="#" onclick="return false">GitHub</a>
+    </div>
+  </header>
+
+  <!-- ================= HOME ================= -->
+  <section class="page" data-page="home">
+    <div class="hero">
+      <span class="sticker float tilt-r">EST. 2019 ★</span>
+      <h1><span class="stroke">PERFECT</span>PAN<span class="dot">!</span></h1>
+      <p>是个什么都不会的废物.jpg —— 但博客还在更新。算法题解、TypeScript 类型体操、Cloudflare $0/月 工程实践，全在这。</p>
+      <div class="cta">
+        <a class="btn fill" href="#" onclick="return false">读博客 →</a>
+        <a class="btn" href="#" onclick="return false">看项目 →</a>
+      </div>
+    </div>
+    <div class="home-grid">
+      <div class="card lift panel">
+        <h3>LATEST 最新</h3>
+        <div class="rowitem"><span class="no">016</span><a class="t" href="#" onclick="return false">初探 Github Blocks</a><span class="sticker s">Misc</span></div>
+        <div class="rowitem"><span class="no">015</span><a class="t" href="#" onclick="return false">Type Challenge · 冒泡排序</a><span class="sticker v">TS</span></div>
+        <div class="rowitem"><span class="no">014</span><a class="t" href="#" onclick="return false">回顾 2020</a><span class="sticker p">会员</span></div>
+        <div class="rowitem"><span class="no">013</span><a class="t" href="#" onclick="return false">一些随想</a><span class="sticker">随笔</span></div>
+      </div>
+      <div class="card lift panel">
+        <h3 class="o">STATS 数据</h3>
+        <div class="stat-row"><b class="vio">16</b><span>篇文章</span></div>
+        <div class="stat-row"><b class="org">5</b><span>个开源项目</span></div>
+        <div class="stat-row"><b>$0</b><span>每月托管费</span></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= BLOG ================= -->
+  <section class="page" data-page="blog" hidden>
+    <div class="page-head">
+      <span class="h-banner">ALL POSTS</span>
+      <h1>博客</h1>
+      <div class="filters">
+        <span class="sticker y tilt-l">全部</span>
+        <span class="sticker">算法</span>
+        <span class="sticker v">TypeScript</span>
+        <span class="sticker p">随笔</span>
+        <span class="sticker m">工程</span>
+      </div>
+    </div>
+    <div class="card list-card">
+      <div class="yr-band"><span class="pill">2023</span></div>
+      <div class="post-row"><span class="no">016</span><span class="t">初探 Github Blocks</span><span class="tags"><span class="sticker s">Misc</span></span><span class="d">02-18</span></div>
+
+      <div class="yr-band"><span class="pill">2021</span></div>
+      <div class="post-row"><span class="no">015</span><span class="t">Type Challenge · 冒泡排序</span><span class="tags"><span class="sticker v">TS</span></span><span class="d">05-08</span></div>
+      <div class="post-row"><span class="no">014</span><span class="t">回顾 2020</span><span class="tags"><span class="sticker p">MEMBER</span></span><span class="d">02-28</span></div>
+
+      <div class="yr-band"><span class="pill">2020</span></div>
+      <div class="post-row"><span class="no">013</span><span class="t">一些随想</span><span class="tags"><span class="sticker">随笔</span></span><span class="d">08-26</span></div>
+      <div class="post-row"><span class="no">012</span><span class="t">LeetCode 中国区 TypeScript 面试题题解</span><span class="tags"><span class="sticker v">TS</span></span><span class="d">04-13</span></div>
+      <div class="post-row"><span class="no">011</span><span class="t">那些年邂逅的 LeetCode 趣/难题</span><span class="tags"><span class="sticker o">LC</span></span><span class="d">03-30</span></div>
+      <div class="post-row"><span class="no">010</span><span class="t">文档书写要点整理</span><span class="tags"><span class="sticker o">🔒 密码</span></span><span class="d">03-01</span></div>
+
+      <div class="yr-band"><span class="pill">2019</span></div>
+      <div class="post-row"><span class="no">009</span><span class="t">回顾 2019</span><span class="tags"><span class="sticker v">VIP</span></span><span class="d">12-31</span></div>
+      <div class="post-row"><span class="no">008</span><span class="t">Codeforces Round#605(Div. 3) D/E/F 题解</span><span class="tags"><span class="sticker m">DP</span><span class="sticker s">BFS</span></span><span class="d">12-14</span></div>
+      <div class="post-row"><span class="no">007</span><span class="t">Codeforces Round#603(Div. 2) E/F 题解</span><span class="tags"><span class="sticker m">DP</span><span class="sticker s">Stack</span></span><span class="d">12-01</span></div>
+      <div class="post-row"><span class="no">006</span><span class="t">银联极客高校挑战赛复赛 D 多项式</span><span class="tags"><span class="sticker m">DP</span></span><span class="d">09-17</span></div>
+      <div class="post-row"><span class="no">005</span><span class="t">Codeforces 1149B Three Religions</span><span class="tags"><span class="sticker m">DP</span><span class="sticker v">STR</span></span><span class="d">04-30</span></div>
+      <div class="post-row"><span class="no">004</span><span class="t">2019 ICPC 南昌邀请赛网络赛 G. tsy's number</span><span class="tags"><span class="sticker y">NT</span></span><span class="d">04-22</span></div>
+    </div>
+    <div class="pager">
+      <button class="btn cur">1</button><button class="btn">2</button><button class="btn">NEXT →</button>
+    </div>
+  </section>
+
+  <!-- ================= ARTICLE ================= -->
+  <section class="page" data-page="post" hidden>
+    <div class="page-head" style="padding-bottom:14px">
+      <span class="h-banner">POST №015</span>
+      <a class="btn" href="#" onclick="return false" style="margin-left:auto">← BACK</a>
+    </div>
+    <article class="card art-card">
+      <h1>Type Challenge · 冒泡排序</h1>
+      <div class="art-meta">
+        <span class="sticker v">TypeScript</span><span class="sticker">2021-05-08</span><span class="sticker m">9 min</span><span class="sticker y">PUBLIC</span>
+      </div>
+      <div class="prose">
+        <p>这题要求在类型系统里实现冒泡排序：给定一个元组 <code>T extends number[]</code>，返回排序后的元组。类型层面上没有循环，所以核心思路是把「一趟冒泡」展开成递归。</p>
+
+        <h2><span class="chip">01</span>一趟冒泡：两两比较并交换</h2>
+        <p>先写一个 <code>Pass</code>，从头到尾扫一遍，相邻逆序就交换：</p>
+
+        <div class="pre-wrap"><span class="fname">bubble.ts</span>
+<pre><span class="tk-c">// 一趟冒泡：相邻比较，逆序则交换</span>
+<span class="tk-k">type</span> <span class="tk-t">Pass</span>&lt;<span class="tk-t">T</span> <span class="tk-k">extends</span> <span class="tk-t">number</span>[]&gt; =
+  <span class="tk-t">T</span> <span class="tk-k">extends</span> [<span class="tk-k">infer</span> <span class="tk-t">A</span> <span class="tk-k">extends</span> <span class="tk-t">number</span>, <span class="tk-k">infer</span> <span class="tk-t">B</span> <span class="tk-k">extends</span> <span class="tk-t">number</span>, ...<span class="tk-k">infer</span> <span class="tk-t">R</span> <span class="tk-k">extends</span> <span class="tk-t">number</span>[]]
+    ? <span class="tk-t">A</span> <span class="tk-k">extends</span> <span class="tk-s">`${B}`</span>
+      ? [<span class="tk-t">A</span>, ...<span class="tk-t">Pass</span>&lt;[<span class="tk-t">B</span>, ...<span class="tk-t">R</span>]&gt;]
+      : [<span class="tk-t">B</span>, ...<span class="tk-t">Pass</span>&lt;[<span class="tk-t">A</span>, ...<span class="tk-t">R</span>]&gt;]
+    : <span class="tk-t">T</span>;
+
+<span class="tk-k">type</span> <span class="tk-f">BubbleSort</span>&lt;<span class="tk-t">T</span>&gt; = ...<span class="tk-c">// 一趟没交换 → 有序；否则再来一趟</span></pre>
+        </div>
+
+        <blockquote>数字比较不能直接用 <code>&lt;</code>，得转成字符串长度或逐位比较——类型体操的老朋友了。</blockquote>
+
+        <h2><span class="chip">02</span>几个细节</h2>
+        <ul>
+          <li><code>infer A extends number</code> 收窄推断结果，省掉一层条件判断；</li>
+          <li>终止条件是「这一趟没有发生任何交换」，用深度相等判断；</li>
+          <li>元组很长时记得给 TS 足够的递归深度，或者拆成小测试。</li>
+        </ul>
+        <p>完整题解在仓库 <code>type-challenges</code> 里，配合测试用例食用更佳。</p>
+      </div>
+    </article>
+
+    <div class="page-head" style="padding:34px 0 10px"><span class="h-banner">COMMENTS · 2</span></div>
+    <div class="card cmt-card">
+      <div class="cmt-h"><span class="who">alice@example.com</span><span>2021-05-09</span></div>
+      <p>Equal 判终止这个思路太优雅了，比数长度 hack 干净。</p>
+    </div>
+    <div class="card cmt-card reply">
+      <div class="cmt-h"><span class="who" style="background:var(--orange)">bob@example.com</span><span>2021-05-10</span></div>
+      <p>数长度在负数场景直接爆炸，还是深度相等稳。</p>
+    </div>
+    <form class="cmt-form" onsubmit="return false">
+      <input type="text" placeholder="说点什么……（支持 markdown）" aria-label="新评论">
+      <button class="btn fill" type="submit">评论！</button>
+    </form>
+  </section>
+
+  <!-- ================= PROJECTS ================= -->
+  <section class="page" data-page="projects" hidden>
+    <div class="page-head">
+      <span class="h-banner">PROJECTS</span>
+      <h1>项目</h1>
+    </div>
+    <div class="proj-grid">
+      <div class="card lift proj-card">
+        <h2>blog <span class="sticker y tilt-r">★ FEATURED</span></h2>
+        <p>本博客——TanStack Start 前台，全量部署在 Cloudflare Workers + D1 上。</p>
+        <div class="tags"><span class="sticker v">TanStack</span><span class="sticker s">Cloudflare</span><span class="sticker">TS</span></div>
+        <div class="links"><a class="btn" href="#" onclick="return false">CODE ↗</a><a class="btn o" href="#" onclick="return false">DEMO ↗</a></div>
+      </div>
+      <div class="card lift proj-card">
+        <h2>logseq-plugin-code-formatter <span class="sticker y tilt-l">★ FEATURED</span></h2>
+        <p>Logseq 插件——用 Prettier 一键格式化代码块，支持 JS / TS / HTML / CSS / Markdown / JSON。</p>
+        <div class="tags"><span class="sticker v">TS</span><span class="sticker">Logseq</span><span class="sticker s">Prettier</span></div>
+        <div class="links"><a class="btn" href="#" onclick="return false">CODE ↗</a></div>
+      </div>
+      <div class="card lift proj-card">
+        <h2>ocvm</h2>
+        <p>OpenClaw 版本管理器——nvm 风格的 Rust CLI，按项目安装、切换、锁定与回滚版本。</p>
+        <div class="tags"><span class="sticker m">Rust</span><span class="sticker">CLI</span></div>
+        <div class="links"><a class="btn" href="#" onclick="return false">CODE ↗</a><a class="btn o" href="#" onclick="return false">DEMO ↗</a></div>
+      </div>
+      <div class="card lift proj-card">
+        <h2>agent-presence</h2>
+        <p>把本地编码 agent 的在线状态与 token 用量同步到飞书签名链接预览。</p>
+        <div class="tags"><span class="sticker v">TS</span><span class="sticker">CLI</span><span class="sticker p">Feishu</span></div>
+        <div class="links"><a class="btn" href="#" onclick="return false">CODE ↗</a><a class="btn o" href="#" onclick="return false">DEMO ↗</a></div>
+      </div>
+      <div class="card lift proj-card">
+        <h2>base64</h2>
+        <p>Moonbit 语言实现的 Base64 编解码库，遵循 RFC 4648。</p>
+        <div class="tags"><span class="sticker m">Moonbit</span></div>
+        <div class="links"><a class="btn" href="#" onclick="return false">CODE ↗</a></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= LOGIN ================= -->
+  <section class="page" data-page="login" hidden>
+    <div class="gate">
+      <div class="card lift">
+        <span class="sticker o badge-top tilt-l">LOGIN</span>
+        <h1>登录</h1>
+        <p class="sub">会友可读「会员可读」文章 · 也支持 GitHub</p>
+        <form onsubmit="return false">
+          <div class="field"><label for="f-em">邮箱 EMAIL</label><input id="f-em" type="email" placeholder="you@example.com"></div>
+          <div class="field"><label for="f-pw">密码 PASSWORD</label><input id="f-pw" type="password" placeholder="••••••••"></div>
+          <div class="actions">
+            <button class="btn fill" type="submit">登入 →</button>
+            <button class="btn" type="button">GitHub 登录</button>
+          </div>
+          <span class="err" hidden>邮箱或密码不正确！</span>
+        </form>
+        <p class="aside">还没账号？<a href="#" onclick="return false">注册一个 →</a></p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= SIGNUP ================= -->
+  <section class="page" data-page="signup" hidden>
+    <div class="gate">
+      <div class="card lift">
+        <span class="sticker v badge-top tilt-r">SIGN UP</span>
+        <h1>注册</h1>
+        <p class="sub">注册即成为 member</p>
+        <form onsubmit="return false">
+          <div class="field"><label for="f-sem">邮箱 EMAIL</label><input id="f-sem" type="email" placeholder="you@example.com"></div>
+          <div class="field"><label for="f-spw">密码 PASSWORD</label><input id="f-spw" type="password" placeholder="至少 8 位"></div>
+          <div class="field"><label for="f-spw2">确认 CONFIRM</label><input id="f-spw2" type="password" placeholder="再输一遍"></div>
+          <div class="actions">
+            <button class="btn fill" type="submit">创建账号！</button>
+            <button class="btn" type="button">GitHub 注册</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= UNLOCK ================= -->
+  <section class="page" data-page="unlock" hidden>
+    <div class="gate">
+      <div class="card lift">
+        <span class="sticker o badge-top tilt-l">🔒 LOCKED</span>
+        <h1>解锁文章</h1>
+        <p class="sub">这篇用单文密码上着锁 ・ 输对后 24 小时免密</p>
+        <form onsubmit="return false">
+          <div class="field"><label for="f-upw">文章密码</label><input id="f-upw" type="password" placeholder="••••••••" autofocus></div>
+          <span class="err">密码不对，再试试！（连错会限流）</span>
+          <div class="actions">
+            <button class="btn o" type="submit">解锁！</button>
+            <a class="btn" href="#" onclick="return false">← 返回文章</a>
+          </div>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= ADMIN ================= -->
+  <section class="page" data-page="admin" hidden>
+    <div class="page-head">
+      <span class="h-banner">ADMIN</span>
+      <h1>后台</h1>
+      <div style="margin-left:auto;display:flex;gap:10px;flex-wrap:wrap">
+        <a class="btn fill" href="#" onclick="return false">＋ 新文章</a>
+        <a class="btn" href="#" onclick="return false">评论 (23)</a>
+      </div>
+    </div>
+    <div class="card" style="padding:6px 26px 16px">
+      <table class="adm">
+        <thead><tr><th>№</th><th>标题</th><th>状态</th><th>可见</th><th>更新</th><th>操作</th></tr></thead>
+        <tbody>
+          <tr><td class="d" style="font-family:var(--mono);font-size:11px;color:rgba(20,20,20,0.55)">016</td><td class="tt">初探 Github Blocks</td><td><span class="sticker m">已发布</span></td><td><span class="sticker y">public</span></td><td style="font-family:var(--mono);font-size:11px;color:rgba(20,20,20,0.55)">2023-02-18</td><td class="ops"><a href="#" onclick="return false">编辑</a><a class="del" href="#" onclick="return false">删除</a></td></tr>
+          <tr><td style="font-family:var(--mono);font-size:11px;color:rgba(20,20,20,0.55)">015</td><td class="tt">Type Challenge · 冒泡排序</td><td><span class="sticker m">已发布</span></td><td><span class="sticker y">public</span></td><td style="font-family:var(--mono);font-size:11px;color:rgba(20,20,20,0.55)">2021-05-08</td><td class="ops"><a href="#" onclick="return false">编辑</a><a class="del" href="#" onclick="return false">删除</a></td></tr>
+          <tr><td style="font-family:var(--mono);font-size:11px;color:rgba(20,20,20,0.55)">014</td><td class="tt">回顾 2020</td><td><span class="sticker m">已发布</span></td><td><span class="sticker p">member</span></td><td style="font-family:var(--mono);font-size:11px;color:rgba(20,20,20,0.55)">2021-02-28</td><td class="ops"><a href="#" onclick="return false">编辑</a><a class="del" href="#" onclick="return false">删除</a></td></tr>
+          <tr><td style="font-family:var(--mono);font-size:11px;color:rgba(20,20,20,0.55)">010</td><td class="tt">文档书写要点整理</td><td><span class="sticker m">已发布</span></td><td><span class="sticker o">password</span></td><td style="font-family:var(--mono);font-size:11px;color:rgba(20,20,20,0.55)">2020-03-01</td><td class="ops"><a href="#" onclick="return false">编辑</a><a class="del" href="#" onclick="return false">删除</a></td></tr>
+          <tr><td style="font-family:var(--mono);font-size:11px;color:rgba(20,20,20,0.55)">017</td><td class="tt">Cloudflare 迁移实录</td><td><span class="sticker">草稿</span></td><td><span class="sticker y">public</span></td><td style="font-family:var(--mono);font-size:11px;color:rgba(20,20,20,0.55)">2026-08-12</td><td class="ops"><a href="#" onclick="return false">编辑</a><a class="del" href="#" onclick="return false">删除</a></td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- ================= EDITOR ================= -->
+  <section class="page" data-page="editor" hidden>
+    <div class="page-head">
+      <span class="h-banner">EDITOR · NEW</span>
+      <h1>编辑器</h1>
+    </div>
+    <div class="card lift" style="padding:26px 30px 30px">
+      <form onsubmit="return false">
+        <div class="ed-grid">
+          <div class="field"><label>标题 TITLE</label><input type="text" value="Cloudflare 迁移实录"></div>
+          <div class="field"><label>SLUG</label><input type="text" value="cloudflare-migration"></div>
+          <div class="field"><label>可见性</label>
+            <select><option>public</option><option>member</option><option>vip</option><option>admin</option><option>password</option></select>
+          </div>
+          <div class="field"><label>标签 TAGS</label><input type="text" value="Cloudflare, D1, Workers"></div>
+        </div>
+        <div class="field"><label>正文 — MARKDOWN</label>
+          <textarea class="draft" spellcheck="false">## 为什么要迁
+
+Postgres 免费额度撑不住了……
+
+```ts
+export default { fetch } = ...
+```</textarea>
+        </div>
+        <div class="ed-foot">
+          <button class="btn" type="button">存草稿</button>
+          <button class="btn fill" type="button">发布！</button>
+          <span class="stat">642 字 · 3 MIN · 自动保存 12:41</span>
+        </div>
+      </form>
+    </div>
+  </section>
+
+  <!-- ================= 404 ================= -->
+  <section class="page" data-page="404" hidden>
+    <div class="nf">
+      <span class="sticker o tilt-l">PAGE NOT FOUND</span>
+      <div class="code">4<b>0</b>4</div>
+      <p>你闯入了无人之境……</p>
+      <a class="btn fill" href="#" onclick="return false">← 回到博客</a>
+    </div>
+  </section>
+
+</div>
+
+<!-- ⌘K palette -->
+<div class="pal-veil" id="pal-veil" hidden>
+  <div class="pal" role="dialog" aria-label="搜索文章">
+    <div class="pal-in">
+      <span class="sticker y">⌘K</span>
+      <input type="text" id="pal-input" placeholder="搜点什么……" aria-label="搜索">
+    </div>
+    <div class="pal-list">
+      <div class="pal-item sel"><span class="d">015</span><span style="font-weight:700">Type Challenge · 冒泡排序</span><span class="sticker v">TS</span></div>
+      <div class="pal-item"><span class="d">012</span><span style="font-weight:700">LeetCode 中国区 TypeScript 面试题题解</span><span class="sticker v">TS</span></div>
+      <div class="pal-item"><span class="d">008</span><span style="font-weight:700">Codeforces Round#605(Div. 3) D/E/F 题解</span><span class="sticker m">DP</span></div>
+      <div class="pal-item"><span class="d">005</span><span style="font-weight:700">Codeforces 1149B Three Religions</span><span class="sticker m">DP</span></div>
+    </div>
+    <div class="pal-foot">↑↓ 选择 · ↵ 打开 · ESC 关闭</div>
+  </div>
+</div>
+
+<script>
+  var tabs = document.querySelectorAll('.pt-tab');
+  var pages = document.querySelectorAll('.page');
+  function go(id) {
+    pages.forEach(function(p){ p.hidden = p.dataset.page !== id; });
+    tabs.forEach(function(t){ t.classList.toggle('active', t.dataset.target === id); });
+    window.scrollTo(0, 0);
+    history.replaceState(null, '', '#' + id);
+  }
+  tabs.forEach(function(t){ if (t.dataset.target) t.addEventListener('click', function(){ go(t.dataset.target); }); });
+  var h = location.hash.slice(1);
+  if (h && document.querySelector('.page[data-page="' + h + '"]')) go(h);
+  window.addEventListener('hashchange', function(){
+    var h = location.hash.slice(1);
+    if (h && document.querySelector('.page[data-page="' + h + '"]')) go(h);
+  });
+
+  var veil = document.getElementById('pal-veil');
+  var input = document.getElementById('pal-input');
+  document.addEventListener('keydown', function(e){
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') { e.preventDefault(); veil.hidden = false; input.focus(); }
+    if (e.key === 'Escape') veil.hidden = true;
+  });
+  veil.addEventListener('click', function(e){ if (e.target === veil) veil.hidden = true; });
+</script>
+</body>
+</html>

--- a/prototypes/g-synthwave.html
+++ b/prototypes/g-synthwave.html
@@ -1,0 +1,662 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>方向 G · 霓虹夜行 · PerfectPan's Blog 原型</title>
+<style>
+  /* ============ tokens ============ */
+  :root {
+    --bg: #120E24;         /* 夜紫 */
+    --bg2: #1A1433;
+    --panel: rgba(233,228,255,0.045);
+    --panel-line: rgba(233,228,255,0.13);
+    --ink: #E9E4FF;
+    --dim: #9C93C9;
+    --faint: #5E5690;
+    --pink: #FF4FD8;
+    --violet: #8B6CFF;
+    --cyan: #3EE6D2;
+    --grad: linear-gradient(92deg, #FF4FD8 0%, #8B6CFF 52%, #3EE6D2 100%);
+    --sans: "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", system-ui, sans-serif;
+    --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scrollbar-color: #3A3160 var(--bg); }
+  body {
+    background:
+      radial-gradient(1100px 500px at 85% -10%, rgba(255,79,216,0.14), transparent 60%),
+      radial-gradient(900px 500px at 10% 110%, rgba(62,230,210,0.10), transparent 60%),
+      var(--bg);
+    color: var(--ink);
+    font-family: var(--sans); font-size: 15px; line-height: 1.85;
+    min-height: 100vh;
+  }
+  /* 扫描线（很轻） */
+  body::before {
+    content: ""; position: fixed; inset: 0; pointer-events: none; z-index: 90;
+    background: repeating-linear-gradient(0deg, rgba(0,0,0,0.10) 0 1px, transparent 1px 3px);
+    mix-blend-mode: multiply; opacity: 0.5;
+  }
+  ::selection { background: rgba(255,79,216,0.35); }
+  a { color: var(--cyan); text-decoration: none; }
+  a:hover { text-shadow: 0 0 12px rgba(62,230,210,0.55); }
+  :focus-visible { outline: 2px solid var(--pink); outline-offset: 3px; }
+
+  /* ============ prototype chrome ============ */
+  .pt-bar {
+    background: #0C0918; color: #7A70A8; font-size: 12.5px;
+    padding: 0 16px; display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
+    position: sticky; top: 0; z-index: 95; border-bottom: 1px solid rgba(233,228,255,0.09);
+  }
+  .pt-bar .pt-title { font-weight: 700; letter-spacing: 0.06em; background: var(--grad); -webkit-background-clip: text; background-clip: text; color: transparent; }
+  .pt-tab {
+    font-family: inherit; font-size: 12.5px; color: #7A70A8; background: none;
+    border: 0; padding: 9px 10px; cursor: pointer;
+  }
+  .pt-tab:hover { color: var(--ink); }
+  .pt-tab.active { color: #0C0918; background: linear-gradient(92deg, #FF4FD8, #8B6CFF); font-weight: 700; }
+  .pt-links { margin-left: auto; display: flex; gap: 12px; }
+  .pt-links a { color: #4E4678; text-shadow: none; }
+  .pt-links a:hover { color: var(--cyan); }
+
+  /* ============ 通用 ============ */
+  .wrap { max-width: 1060px; margin: 0 auto; padding: 0 24px 90px; }
+  .page[hidden] { display: none; }
+
+  .gradtext {
+    background: var(--grad); -webkit-background-clip: text; background-clip: text; color: transparent;
+  }
+  .panel {
+    background: var(--panel); border: 1px solid var(--panel-line); border-radius: 14px;
+    backdrop-filter: blur(6px);
+  }
+  .btn {
+    font: inherit; font-size: 13.5px; font-weight: 700; cursor: pointer;
+    color: var(--ink); background: none; border: 1px solid var(--panel-line);
+    border-radius: 999px; padding: 10px 24px; transition: box-shadow .15s, border-color .15s;
+  }
+  .btn:hover { border-color: var(--cyan); box-shadow: 0 0 18px rgba(62,230,210,0.28); text-shadow: none; color: var(--cyan); }
+  .btn.grad {
+    background: var(--grad); color: #140F26; border: 0;
+  }
+  .btn.grad:hover { box-shadow: 0 0 24px rgba(255,79,216,0.45); color: #140F26; }
+  .tagchip {
+    display: inline-flex; align-items: center; font-family: var(--mono); font-size: 11px;
+    border: 1px solid var(--panel-line); border-radius: 999px; padding: 1px 11px; color: var(--dim);
+  }
+  .tagchip.pink { color: var(--pink); border-color: rgba(255,79,216,0.4); }
+  .tagchip.violet { color: var(--violet); border-color: rgba(139,108,255,0.4); }
+  .tagchip.cyan { color: var(--cyan); border-color: rgba(62,230,210,0.4); }
+
+  /* ============ header ============ */
+  .site-head { padding: 26px 0 22px; display: flex; align-items: center; gap: 26px; flex-wrap: wrap; }
+  .logo { font-size: 17px; font-weight: 800; letter-spacing: 0.06em; color: var(--ink); }
+  .logo b { background: var(--grad); -webkit-background-clip: text; background-clip: text; color: transparent; }
+  .site-head nav { display: flex; gap: 20px; font-size: 13.5px; }
+  .site-head nav a { color: var(--dim); }
+  .site-head nav a.on { color: var(--ink); border-bottom: 2px solid transparent; border-image: var(--grad) 1; padding-bottom: 2px; }
+  .site-head nav a:hover { color: var(--ink); text-shadow: none; }
+  .site-head .tools { margin-left: auto; display: flex; gap: 8px; }
+  .tool-btn {
+    font: inherit; font-size: 12px; color: var(--dim); background: none;
+    border: 1px solid var(--panel-line); border-radius: 999px; padding: 5px 14px; cursor: pointer;
+  }
+  .tool-btn:hover { color: var(--cyan); border-color: rgba(62,230,210,0.5); box-shadow: 0 0 14px rgba(62,230,210,0.2); }
+
+  /* ============ HOME ============ */
+  .hero {
+    position: relative; border: 1px solid var(--panel-line); border-radius: 18px;
+    background: linear-gradient(180deg, rgba(255,79,216,0.06), rgba(18,14,36,0) 40%), var(--panel);
+    overflow: hidden; padding: 64px 48px 150px;
+  }
+  /* 落日 */
+  .sun {
+    position: absolute; right: 84px; top: 44px; width: 150px; height: 150px; border-radius: 50%;
+    background: linear-gradient(180deg, #FFE29A 0%, #FF9A5C 34%, #FF4FD8 100%);
+    box-shadow: 0 0 60px rgba(255,79,216,0.35), 0 0 130px rgba(255,79,216,0.18);
+    animation: float 7s ease-in-out infinite;
+  }
+  .sun::before {
+    content: ""; position: absolute; inset: 0; border-radius: 50%;
+    background: repeating-linear-gradient(0deg, transparent 0 12px, var(--bg) 12px 16px);
+    mask: linear-gradient(180deg, transparent 42%, #000 46%);
+    -webkit-mask: linear-gradient(180deg, transparent 42%, #000 46%);
+  }
+  @keyframes float { 50% { transform: translateY(-8px); } }
+  /* 地平线网格 */
+  .hero::after {
+    content: ""; position: absolute; left: -24%; right: -24%; bottom: -58px; height: 130px;
+    background:
+      linear-gradient(rgba(62,230,210,0.22) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(139,108,255,0.22) 1px, transparent 1px);
+    background-size: 46px 32px, 46px 32px;
+    transform: perspective(340px) rotateX(48deg);
+    -webkit-mask-image: linear-gradient(180deg, transparent, #000 55%);
+    mask-image: linear-gradient(180deg, transparent, #000 55%);
+    pointer-events: none;
+  }
+  .hero .kicker { font-family: var(--mono); font-size: 11.5px; letter-spacing: 0.4em; color: var(--cyan); }
+  .hero h1 {
+    margin-top: 16px; font-size: clamp(42px, 7vw, 74px); font-weight: 900; line-height: 1.06; letter-spacing: 0.01em;
+    background: var(--grad); -webkit-background-clip: text; background-clip: text; color: transparent;
+    filter: drop-shadow(0 0 22px rgba(255,79,216,0.25));
+  }
+  .hero p { margin-top: 18px; color: var(--dim); max-width: 52ch; }
+  .hero .cta { margin-top: 30px; display: flex; gap: 14px; flex-wrap: wrap; }
+  .home-grid { display: grid; grid-template-columns: 1.5fr 1fr; gap: 18px; margin-top: 18px; }
+  .hpanel { padding: 22px 26px; }
+  .hpanel h3 { font-size: 12px; letter-spacing: 0.3em; font-family: var(--mono); color: var(--pink); margin-bottom: 12px; }
+  .hpanel h3.c { color: var(--cyan); }
+  .hitem { display: flex; gap: 14px; align-items: baseline; padding: 8px 0; border-bottom: 1px dashed rgba(233,228,255,0.09); }
+  .hitem:last-child { border-bottom: 0; }
+  .hitem .no { font-family: var(--mono); font-size: 11px; color: var(--faint); }
+  .hitem .t { flex: 1; color: var(--ink); font-weight: 600; font-size: 14.5px; }
+  .hitem .t:hover { color: var(--pink); text-shadow: 0 0 12px rgba(255,79,216,0.4); }
+  .hstat { display: flex; justify-content: space-between; align-items: center; padding: 10px 0; border-bottom: 1px dashed rgba(233,228,255,0.09); }
+  .hstat:last-child { border-bottom: 0; }
+  .hstat b { font-size: 25px; font-weight: 800; background: var(--grad); -webkit-background-clip: text; background-clip: text; color: transparent; }
+  .hstat span { font-size: 12.5px; color: var(--dim); }
+
+  /* ============ BLOG ================= */
+  .page-head { padding: 36px 0 20px; display: flex; align-items: baseline; gap: 18px; flex-wrap: wrap; }
+  .page-head h1 { font-size: 36px; font-weight: 900; }
+  .page-head .cnt { font-family: var(--mono); font-size: 11.5px; color: var(--faint); letter-spacing: 0.14em; }
+  .filters { margin-left: auto; display: flex; gap: 8px; flex-wrap: wrap; }
+  .filter { font-family: var(--mono); font-size: 11.5px; color: var(--dim); background: none; border: 1px solid var(--panel-line); border-radius: 999px; padding: 4px 14px; cursor: pointer; }
+  .filter.on { background: var(--grad); color: #140F26; border-color: transparent; font-weight: 700; }
+  .yrline { display: flex; align-items: center; gap: 16px; padding: 26px 6px 10px; font-family: var(--mono); font-size: 12px; letter-spacing: 0.4em; color: var(--faint); }
+  .yrline::after { content: ""; flex: 1; border-top: 1px dashed rgba(233,228,255,0.14); }
+  .post-row {
+    display: grid; grid-template-columns: 56px 1fr auto 84px; gap: 18px; align-items: center;
+    padding: 13px 16px; border-radius: 12px; border: 1px solid transparent;
+  }
+  a.post-row { color: var(--ink); }
+  a.post-row:hover { background: var(--panel); border-color: var(--panel-line); box-shadow: 0 0 24px rgba(139,108,255,0.12); }
+  .post-row .no { font-family: var(--mono); font-size: 12px; color: var(--faint); }
+  .post-row .t { font-weight: 600; font-size: 15.5px; }
+  .post-row .tags { display: flex; gap: 6px; justify-content: flex-end; }
+  .post-row .d { font-family: var(--mono); font-size: 11px; color: var(--faint); text-align: right; }
+  .vis { font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em; margin-left: 10px; }
+  .vis.mem { color: var(--cyan); } .vis.vip { color: var(--violet); } .vis.pw { color: var(--pink); }
+  .pager { display: flex; gap: 8px; justify-content: center; margin-top: 30px; }
+  .pager button { font-family: var(--mono); font-size: 12px; color: var(--dim); background: none; border: 1px solid var(--panel-line); border-radius: 8px; padding: 5px 14px; cursor: pointer; }
+  .pager .cur { background: var(--grad); color: #140F26; border-color: transparent; font-weight: 700; }
+
+  /* ============ ARTICLE ============ */
+  .art { padding: 38px 44px 44px; }
+  .art h1 { font-size: clamp(26px, 4vw, 38px); font-weight: 900; line-height: 1.3; }
+  .art .meta { display: flex; gap: 10px; margin: 16px 0 6px; flex-wrap: wrap; }
+  .prose { margin-top: 28px; max-width: 70ch; }
+  .prose p { margin: 17px 0; color: #D6CFF2; }
+  .prose h2 {
+    font-size: 20px; font-weight: 800; margin: 38px 0 12px;
+    display: flex; align-items: center; gap: 14px;
+  }
+  .prose h2 .no { font-family: var(--mono); font-size: 12px; font-weight: 400; color: var(--pink); letter-spacing: 0.2em; }
+  .prose h2::after { content: ""; flex: 1; height: 1px; background: linear-gradient(90deg, rgba(139,108,255,0.4), transparent); }
+  .prose ul { margin: 14px 0; list-style: none; }
+  .prose li { padding: 7px 0 7px 26px; position: relative; color: #D6CFF2; }
+  .prose li::before { content: "◈"; position: absolute; left: 0; color: var(--cyan); font-size: 12px; }
+  .prose blockquote {
+    border-left: 3px solid; border-image: linear-gradient(180deg, #FF4FD8, #8B6CFF) 1;
+    background: rgba(139,108,255,0.08); padding: 12px 22px; margin: 22px 0; color: var(--dim); border-radius: 0 10px 10px 0;
+  }
+  .prose code { font-family: var(--mono); font-size: 0.85em; color: var(--cyan); background: rgba(62,230,210,0.08); border: 1px solid rgba(62,230,210,0.18); border-radius: 6px; padding: 1px 7px; }
+  .prose pre {
+    font-family: var(--mono); font-size: 13px; line-height: 1.8; color: #E4DEF9;
+    background: #0D0A1C; border: 1px solid rgba(233,228,255,0.12); border-radius: 12px;
+    box-shadow: inset 0 0 40px rgba(139,108,255,0.07);
+    padding: 20px 22px; overflow-x: auto; margin: 24px 0;
+  }
+  .pre-wrap { position: relative; }
+  .pre-wrap .fname { position: absolute; top: -11px; left: 20px; font-family: var(--mono); font-size: 10.5px; color: var(--pink); background: var(--bg); border: 1px solid rgba(255,79,216,0.35); border-radius: 999px; padding: 0 12px; }
+  .tk-c { color: #655C99; } .tk-k { color: #FF7DE2; } .tk-t { color: #6FD8FF; }
+  .tk-s { color: #3EE6D2; } .tk-f { color: #B79CFF; }
+
+  .cmt { padding: 16px 20px; margin: 12px 0; }
+  .cmt-h { display: flex; gap: 12px; font-family: var(--mono); font-size: 11.5px; color: var(--dim); margin-bottom: 6px; }
+  .cmt-h .who { color: var(--cyan); }
+  .cmt.reply { margin-left: 44px; border-left: 2px solid rgba(139,108,255,0.5); }
+  .cmt-form { display: flex; gap: 12px; margin-top: 18px; }
+  .cmt-form input[type=text] { flex: 1; }
+
+  /* ============ PROJECTS ============ */
+  .proj-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+  .proj-card { padding: 24px 26px; position: relative; overflow: hidden; }
+  .proj-card::before {
+    content: ""; position: absolute; top: 0; left: 0; right: 0; height: 2px;
+    background: var(--grad); opacity: 0.65;
+  }
+  .proj-card h2 { font-size: 18px; font-weight: 800; display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+  .proj-card h2 .feat { font-size: 10px; font-family: var(--mono); letter-spacing: 0.2em; color: var(--pink); border: 1px solid rgba(255,79,216,0.4); border-radius: 999px; padding: 0 10px; }
+  .proj-card p { margin-top: 8px; font-size: 13.5px; color: var(--dim); }
+  .proj-card .tags { margin: 14px 0; display: flex; gap: 6px; flex-wrap: wrap; }
+  .proj-card .links { display: flex; gap: 16px; font-family: var(--mono); font-size: 12px; }
+
+  /* ============ forms ============ */
+  .gate { max-width: 440px; margin: 30px auto 0; }
+  .gate .panel { padding: 36px 38px 38px; position: relative; }
+  .gate .glowline { position: absolute; top: 0; left: 24px; right: 24px; height: 2px; background: var(--grad); border-radius: 2px; }
+  .gate h1 { font-size: 27px; font-weight: 900; }
+  .gate .sub { font-size: 13px; color: var(--dim); margin: 6px 0 24px; }
+  .field { margin: 16px 0; }
+  .field label { display: block; font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.24em; color: var(--faint); margin-bottom: 6px; }
+  input[type=text], input[type=email], input[type=password], textarea, select {
+    width: 100%; font-family: var(--sans); font-size: 14.5px; color: var(--ink);
+    background: rgba(10,7,22,0.6); border: 1px solid var(--panel-line); border-radius: 10px; padding: 11px 15px;
+  }
+  input::placeholder, textarea::placeholder { color: var(--faint); }
+  input:focus, textarea:focus, select:focus { outline: none; border-color: rgba(62,230,210,0.55); box-shadow: 0 0 16px rgba(62,230,210,0.15); }
+  .gate .actions { display: flex; gap: 12px; margin-top: 24px; flex-wrap: wrap; }
+  .err { margin-top: 16px; font-size: 13px; color: var(--pink); border: 1px solid rgba(255,79,216,0.4); background: rgba(255,79,216,0.07); border-radius: 10px; padding: 8px 14px; }
+  .gate .aside { margin-top: 20px; font-size: 13px; color: var(--dim); }
+  .lock-ic { width: 52px; height: 52px; border-radius: 50%; border: 1px solid rgba(255,79,216,0.5); box-shadow: 0 0 24px rgba(255,79,216,0.25); display: flex; align-items: center; justify-content: center; font-size: 22px; margin-bottom: 18px; }
+
+  /* ============ admin ============ */
+  table.adm { width: 100%; border-collapse: collapse; font-size: 13px; }
+  .adm th { text-align: left; font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.2em; color: var(--faint); font-weight: 400; padding: 12px 14px; border-bottom: 1px solid var(--panel-line); }
+  .adm td { padding: 12px 14px; border-bottom: 1px solid rgba(233,228,255,0.07); }
+  .adm tbody tr:hover td { background: rgba(139,108,255,0.06); }
+  .adm td.tt { font-weight: 700; }
+  .adm .st { font-family: var(--mono); font-size: 11px; }
+  .adm .st.pub { color: var(--cyan); } .adm .st.draft { color: var(--faint); }
+  .adm .ops a { margin-right: 14px; font-family: var(--mono); font-size: 11.5px; }
+  .ed-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 0 24px; }
+  textarea.draft { min-height: 300px; font-family: var(--mono); font-size: 13.5px; line-height: 1.8; }
+  .ed-foot { display: flex; gap: 12px; margin-top: 18px; flex-wrap: wrap; align-items: center; }
+  .ed-foot .stat { margin-left: auto; font-family: var(--mono); font-size: 10.5px; color: var(--faint); }
+
+  /* ============ 404 ============ */
+  .nf { text-align: center; padding: 80px 0 40px; }
+  .nf .code { font-size: 96px; font-weight: 900; background: var(--grad); -webkit-background-clip: text; background-clip: text; color: transparent; filter: drop-shadow(0 0 24px rgba(255,79,216,0.3)); }
+  .nf p { color: var(--dim); margin: 14px 0 28px; }
+
+  /* ============ palette ============ */
+  .pal-veil { position: fixed; inset: 0; background: rgba(8,5,18,0.72); backdrop-filter: blur(3px); display: flex; justify-content: center; padding-top: 13vh; z-index: 100; }
+  .pal-veil[hidden] { display: none; }
+  .pal { width: min(620px, calc(100vw - 32px)); height: fit-content; background: #16112C; border: 1px solid rgba(233,228,255,0.16); border-radius: 14px; overflow: hidden; box-shadow: 0 24px 70px rgba(0,0,0,0.55), 0 0 40px rgba(139,108,255,0.12); }
+  .pal-in { display: flex; gap: 14px; align-items: center; padding: 15px 20px; border-bottom: 1px solid rgba(233,228,255,0.1); }
+  .pal-in .m { font-family: var(--mono); font-size: 11px; letter-spacing: 0.3em; color: var(--pink); }
+  .pal-in input { background: none; border: 0; padding: 0; font-size: 15px; }
+  .pal-in input:focus { box-shadow: none; border: 0; }
+  .pal-list { max-height: 300px; overflow-y: auto; }
+  .pal-item { display: flex; gap: 16px; padding: 11px 20px; align-items: center; }
+  .pal-item .d { font-family: var(--mono); font-size: 11px; color: var(--faint); min-width: 4ch; }
+  .pal-item.sel { background: rgba(139,108,255,0.1); box-shadow: inset 3px 0 0 var(--pink); }
+  .pal-foot { border-top: 1px solid rgba(233,228,255,0.1); padding: 8px 20px; font-family: var(--mono); font-size: 10.5px; color: var(--faint); letter-spacing: 0.1em; }
+
+  @media (prefers-reduced-motion: reduce) {
+    .sun { animation: none; }
+  }
+  @media (max-width: 860px) {
+    .home-grid, .proj-grid { grid-template-columns: 1fr; }
+    .hero { padding: 44px 26px 120px; }
+    .sun { right: 26px; width: 110px; height: 110px; top: 30px; }
+    .art { padding: 26px 22px 32px; }
+    .post-row { grid-template-columns: 44px 1fr; }
+    .post-row .tags, .post-row .d { display: none; }
+  }
+</style>
+</head>
+<body>
+
+<div class="pt-bar">
+  <span class="pt-title">原型 · 方向 G 霓虹夜行</span>
+  <nav aria-label="原型页面" style="display:flex;gap:2px;flex-wrap:wrap">
+    <button class="pt-tab active" data-target="home">首页</button>
+    <button class="pt-tab" data-target="blog">博客</button>
+    <button class="pt-tab" data-target="post">文章</button>
+    <button class="pt-tab" data-target="projects">项目</button>
+    <button class="pt-tab" data-target="login">登录</button>
+    <button class="pt-tab" data-target="signup">注册</button>
+    <button class="pt-tab" data-target="unlock">解锁</button>
+    <button class="pt-tab" data-target="admin">后台</button>
+    <button class="pt-tab" data-target="editor">编辑器</button>
+    <button class="pt-tab" data-target="404">404</button>
+  </nav>
+  <div class="pt-links"><a href="index.html">总览</a></div>
+</div>
+
+<div class="wrap">
+  <header class="site-head">
+    <span class="logo">Perfect<b>PAN</b></span>
+    <nav>
+      <a href="#" onclick="return false">Home</a>
+      <a href="#" onclick="return false" class="on">Blog</a>
+      <a href="#" onclick="return false">Projects</a>
+      <a href="#" onclick="return false">Admin</a>
+    </nav>
+    <div class="tools">
+      <button class="tool-btn" onclick="document.dispatchEvent(new KeyboardEvent('keydown',{key:'k',metaKey:true}))">⌘K</button>
+      <a class="tool-btn" href="#" onclick="return false">RSS</a>
+      <a class="tool-btn" href="#" onclick="return false">GitHub</a>
+    </div>
+  </header>
+
+  <!-- ================= HOME ================= -->
+  <section class="page" data-page="home">
+    <div class="hero">
+      <div class="sun" aria-hidden="true"></div>
+      <div class="kicker">NIGHT DRIVE · SINCE 2019</div>
+      <h1>PERFECTPAN</h1>
+      <p>是个什么都不会的废物.jpg —— 但夜里还在写代码。算法竞赛旧题解、TypeScript 类型体操、Cloudflare $0/月 工程实践，一路霓虹。</p>
+      <div class="cta">
+        <a class="btn grad" href="#" onclick="return false">进入博客 →</a>
+        <a class="btn" href="#" onclick="return false">看看项目</a>
+      </div>
+    </div>
+    <div class="home-grid">
+      <div class="panel hpanel">
+        <h3>LATEST / 最新</h3>
+        <div class="hitem"><span class="no">016</span><a class="t" href="#" onclick="return false">初探 Github Blocks</a><span class="tagchip">MISC</span></div>
+        <div class="hitem"><span class="no">015</span><a class="t" href="#" onclick="return false">Type Challenge · 冒泡排序</a><span class="tagchip violet">TS</span></div>
+        <div class="hitem"><span class="no">014</span><a class="t" href="#" onclick="return false">回顾 2020</a><span class="tagchip cyan">MEMBER</span></div>
+        <div class="hitem"><span class="no">013</span><a class="t" href="#" onclick="return false">一些随想</a><span class="tagchip">随笔</span></div>
+      </div>
+      <div class="panel hpanel">
+        <h3 class="c">DATA / 数据</h3>
+        <div class="hstat"><b>16</b><span>篇文章</span></div>
+        <div class="hstat"><b>5</b><span>个开源项目</span></div>
+        <div class="hstat"><b>$0</b><span>每月托管费</span></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= BLOG ================= -->
+  <section class="page" data-page="blog" hidden>
+    <div class="page-head">
+      <h1>Blog</h1><span class="cnt">— 16 POSTS / 2 PAGES</span>
+      <div class="filters">
+        <button class="filter on">全部</button>
+        <button class="filter">算法</button>
+        <button class="filter">TypeScript</button>
+        <button class="filter">随笔</button>
+        <button class="filter">工程</button>
+      </div>
+    </div>
+
+    <div class="yrline">2023</div>
+    <a class="post-row" href="#" onclick="return false"><span class="no">016</span><span class="t">初探 Github Blocks</span><span class="tags"><span class="tagchip">MISC</span></span><span class="d">02-18</span></a>
+
+    <div class="yrline">2021</div>
+    <a class="post-row" href="#" onclick="return false"><span class="no">015</span><span class="t">Type Challenge · 冒泡排序</span><span class="tags"><span class="tagchip violet">TS</span></span><span class="d">05-08</span></a>
+    <a class="post-row" href="#" onclick="return false"><span class="no">014</span><span class="t">回顾 2020<span class="vis mem">MEMBER</span></span><span class="tags"><span class="tagchip cyan">LIFE</span></span><span class="d">02-28</span></a>
+
+    <div class="yrline">2020</div>
+    <a class="post-row" href="#" onclick="return false"><span class="no">013</span><span class="t">一些随想</span><span class="tags"><span class="tagchip">随笔</span></span><span class="d">08-26</span></a>
+    <a class="post-row" href="#" onclick="return false"><span class="no">012</span><span class="t">LeetCode 中国区 TypeScript 面试题题解</span><span class="tags"><span class="tagchip violet">TS</span></span><span class="d">04-13</span></a>
+    <a class="post-row" href="#" onclick="return false"><span class="no">011</span><span class="t">那些年邂逅的 LeetCode 趣/难题</span><span class="tags"><span class="tagchip pink">LC</span></span><span class="d">03-30</span></a>
+    <a class="post-row" href="#" onclick="return false"><span class="no">010</span><span class="t">文档书写要点整理<span class="vis pw">PASSWORD</span></span><span class="tags"><span class="tagchip pink">LOCKED</span></span><span class="d">03-01</span></a>
+
+    <div class="yrline">2019</div>
+    <a class="post-row" href="#" onclick="return false"><span class="no">009</span><span class="t">回顾 2019<span class="vis vip">VIP</span></span><span class="tags"><span class="tagchip cyan">LIFE</span></span><span class="d">12-31</span></a>
+    <a class="post-row" href="#" onclick="return false"><span class="no">008</span><span class="t">Codeforces Round#605(Div. 3) D/E/F 题解</span><span class="tags"><span class="tagchip violet">DP</span><span class="tagchip">BFS</span></span><span class="d">12-14</span></a>
+    <a class="post-row" href="#" onclick="return false"><span class="no">007</span><span class="t">Codeforces Round#603(Div. 2) E/F 题解</span><span class="tags"><span class="tagchip violet">DP</span><span class="tagchip">STK</span></span><span class="d">12-01</span></a>
+    <a class="post-row" href="#" onclick="return false"><span class="no">006</span><span class="t">银联极客高校挑战赛复赛 D 多项式</span><span class="tags"><span class="tagchip violet">DP</span></span><span class="d">09-17</span></a>
+    <a class="post-row" href="#" onclick="return false"><span class="no">005</span><span class="t">Codeforces 1149B Three Religions</span><span class="tags"><span class="tagchip violet">DP</span><span class="tagchip">STR</span></span><span class="d">04-30</span></a>
+    <a class="post-row" href="#" onclick="return false"><span class="no">004</span><span class="t">2019 ICPC 南昌邀请赛网络赛 G. tsy's number</span><span class="tags"><span class="tagchip cyan">NT</span></span><span class="d">04-22</span></a>
+
+    <div class="pager"><button class="cur">1</button><button>2</button><button>NEXT →</button></div>
+  </section>
+
+  <!-- ================= ARTICLE ================= -->
+  <section class="page" data-page="post" hidden>
+    <div class="page-head" style="padding-bottom:14px">
+      <h1 style="font-size:22px">POST №015</h1>
+      <a class="btn" href="#" onclick="return false" style="margin-left:auto">← BACK</a>
+    </div>
+    <article class="panel art">
+      <h1>Type Challenge · 冒泡排序</h1>
+      <div class="meta">
+        <span class="tagchip violet">TS</span><span class="tagchip">2021-05-08</span><span class="tagchip">9 MIN</span><span class="tagchip cyan">PUBLIC</span>
+      </div>
+      <div class="prose">
+        <p>这题要求在类型系统里实现冒泡排序：给定一个元组 <code>T extends number[]</code>，返回排序后的元组。类型层面上没有循环，所以核心思路是把「一趟冒泡」展开成递归。</p>
+
+        <h2><span class="no">01</span>一趟冒泡：两两比较并交换</h2>
+        <p>先写一个 <code>Pass</code>，从头到尾扫一遍，相邻逆序就交换：</p>
+
+        <div class="pre-wrap"><span class="fname">bubble.ts</span>
+<pre><span class="tk-c">// 一趟冒泡：相邻比较，逆序则交换</span>
+<span class="tk-k">type</span> <span class="tk-t">Pass</span>&lt;<span class="tk-t">T</span> <span class="tk-k">extends</span> <span class="tk-t">number</span>[]&gt; =
+  <span class="tk-t">T</span> <span class="tk-k">extends</span> [<span class="tk-k">infer</span> <span class="tk-t">A</span> <span class="tk-k">extends</span> <span class="tk-t">number</span>, <span class="tk-k">infer</span> <span class="tk-t">B</span> <span class="tk-k">extends</span> <span class="tk-t">number</span>, ...<span class="tk-k">infer</span> <span class="tk-t">R</span> <span class="tk-k">extends</span> <span class="tk-t">number</span>[]]
+    ? <span class="tk-t">A</span> <span class="tk-k">extends</span> <span class="tk-s">`${B}`</span>
+      ? [<span class="tk-t">A</span>, ...<span class="tk-t">Pass</span>&lt;[<span class="tk-t">B</span>, ...<span class="tk-t">R</span>]&gt;]
+      : [<span class="tk-t">B</span>, ...<span class="tk-t">Pass</span>&lt;[<span class="tk-t">A</span>, ...<span class="tk-t">R</span>]&gt;]
+    : <span class="tk-t">T</span>;
+
+<span class="tk-k">type</span> <span class="tk-f">BubbleSort</span>&lt;<span class="tk-t">T</span>&gt; = ...<span class="tk-c">// 一趟没交换 → 有序；否则再来一趟</span></pre>
+        </div>
+
+        <blockquote>数字比较不能直接用 <code>&lt;</code>，得转成字符串长度或逐位比较——类型体操的老朋友了。</blockquote>
+
+        <h2><span class="no">02</span>几个细节</h2>
+        <ul>
+          <li><code>infer A extends number</code> 收窄推断结果，省掉一层条件判断；</li>
+          <li>终止条件是「这一趟没有发生任何交换」，用深度相等判断；</li>
+          <li>元组很长时记得给 TS 足够的递归深度，或者拆成小测试。</li>
+        </ul>
+        <p>完整题解在仓库 <code>type-challenges</code> 里，配合测试用例食用更佳。</p>
+      </div>
+    </article>
+
+    <div class="page-head" style="padding:34px 0 8px"><h1 style="font-size:16px">COMMENTS · 2</h1></div>
+    <div class="panel cmt">
+      <div class="cmt-h"><span class="who">alice@example.com</span><span>2021-05-09</span></div>
+      <p>Equal 判终止这个思路太优雅了，比数长度 hack 干净。</p>
+    </div>
+    <div class="panel cmt reply">
+      <div class="cmt-h"><span class="who">bob@example.com</span><span>2021-05-10</span></div>
+      <p>数长度在负数场景直接爆炸，还是深度相等稳。</p>
+    </div>
+    <form class="cmt-form" onsubmit="return false">
+      <input type="text" placeholder="留下一句……（支持 markdown）" aria-label="新评论">
+      <button class="btn grad" type="submit">评论 →</button>
+    </form>
+  </section>
+
+  <!-- ================= PROJECTS ================= -->
+  <section class="page" data-page="projects" hidden>
+    <div class="page-head"><h1>Projects</h1><span class="cnt">— 5 WORKS / 2 FEATURED</span></div>
+    <div class="proj-grid">
+      <div class="panel proj-card">
+        <h2>blog<span class="feat">FEATURED</span></h2>
+        <p>本博客——TanStack Start 前台，全量部署在 Cloudflare Workers + D1 上。</p>
+        <div class="tags"><span class="tagchip violet">TanStack</span><span class="tagchip cyan">Cloudflare</span><span class="tagchip">TS</span></div>
+        <div class="links"><a href="#" onclick="return false">CODE ↗</a><a href="#" onclick="return false">DEMO ↗</a></div>
+      </div>
+      <div class="panel proj-card">
+        <h2>logseq-plugin-code-formatter<span class="feat">FEATURED</span></h2>
+        <p>Logseq 插件——用 Prettier 一键格式化代码块，支持 JS / TS / HTML / CSS / Markdown / JSON。</p>
+        <div class="tags"><span class="tagchip violet">TS</span><span class="tagchip">Logseq</span><span class="tagchip cyan">Prettier</span></div>
+        <div class="links"><a href="#" onclick="return false">CODE ↗</a></div>
+      </div>
+      <div class="panel proj-card">
+        <h2>ocvm</h2>
+        <p>OpenClaw 版本管理器——nvm 风格的 Rust CLI，按项目安装、切换、锁定与回滚版本。</p>
+        <div class="tags"><span class="tagchip pink">Rust</span><span class="tagchip">CLI</span></div>
+        <div class="links"><a href="#" onclick="return false">CODE ↗</a><a href="#" onclick="return false">DEMO ↗</a></div>
+      </div>
+      <div class="panel proj-card">
+        <h2>agent-presence</h2>
+        <p>把本地编码 agent 的在线状态与 token 用量同步到飞书签名链接预览。</p>
+        <div class="tags"><span class="tagchip violet">TS</span><span class="tagchip">CLI</span><span class="tagchip pink">Feishu</span></div>
+        <div class="links"><a href="#" onclick="return false">CODE ↗</a><a href="#" onclick="return false">DEMO ↗</a></div>
+      </div>
+      <div class="panel proj-card">
+        <h2>base64</h2>
+        <p>Moonbit 语言实现的 Base64 编解码库，遵循 RFC 4648。</p>
+        <div class="tags"><span class="tagchip cyan">Moonbit</span></div>
+        <div class="links"><a href="#" onclick="return false">CODE ↗</a></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= LOGIN ================= -->
+  <section class="page" data-page="login" hidden>
+    <div class="gate">
+      <div class="panel">
+        <div class="glowline"></div>
+        <h1>登录</h1>
+        <p class="sub">会友可读「会员可读」文章 · 亦支持 GitHub OAuth</p>
+        <form onsubmit="return false">
+          <div class="field"><label for="g-em">EMAIL</label><input id="g-em" type="email" placeholder="you@example.com"></div>
+          <div class="field"><label for="g-pw">PASSWORD</label><input id="g-pw" type="password" placeholder="••••••••"></div>
+          <div class="actions">
+            <button class="btn grad" type="submit">登录</button>
+            <button class="btn" type="button">GitHub 登录</button>
+          </div>
+          <p class="err" hidden>邮箱或密码不正确</p>
+        </form>
+        <p class="aside">没有账号？<a href="#" onclick="return false">注册 →</a></p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= SIGNUP ================= -->
+  <section class="page" data-page="signup" hidden>
+    <div class="gate">
+      <div class="panel">
+        <div class="glowline"></div>
+        <h1>注册</h1>
+        <p class="sub">注册即成为 member</p>
+        <form onsubmit="return false">
+          <div class="field"><label for="g-sem">EMAIL</label><input id="g-sem" type="email" placeholder="you@example.com"></div>
+          <div class="field"><label for="g-spw">PASSWORD</label><input id="g-spw" type="password" placeholder="至少 8 位"></div>
+          <div class="field"><label for="g-spw2">CONFIRM</label><input id="g-spw2" type="password" placeholder="再输一遍"></div>
+          <div class="actions">
+            <button class="btn grad" type="submit">创建账号</button>
+            <button class="btn" type="button">GitHub 注册</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= UNLOCK ================= -->
+  <section class="page" data-page="unlock" hidden>
+    <div class="gate">
+      <div class="panel">
+        <div class="glowline"></div>
+        <div class="lock-ic" aria-hidden="true">🔑</div>
+        <h1>解锁文章</h1>
+        <p class="sub">这篇用单文密码上锁 ・ 验证后 24 小时免密阅读</p>
+        <form onsubmit="return false">
+          <div class="field"><label for="g-upw">POST PASSWORD</label><input id="g-upw" type="password" placeholder="••••••••" autofocus></div>
+          <p class="err">密码错误，请重试（连续失败会触发限流）</p>
+          <div class="actions">
+            <button class="btn grad" type="submit">解锁</button>
+            <a class="btn" href="#" onclick="return false">← 返回文章</a>
+          </div>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <!-- ================= ADMIN ================= -->
+  <section class="page" data-page="admin" hidden>
+    <div class="page-head">
+      <h1 style="font-size:26px">后台</h1>
+      <div style="margin-left:auto;display:flex;gap:10px;flex-wrap:wrap">
+        <a class="btn grad" href="#" onclick="return false">＋ 新文章</a>
+        <a class="btn" href="#" onclick="return false">评论 (23)</a>
+      </div>
+    </div>
+    <div class="panel" style="padding:4px 10px 10px">
+      <table class="adm">
+        <thead><tr><th>№</th><th>标题</th><th>状态</th><th>可见</th><th>更新</th><th>操作</th></tr></thead>
+        <tbody>
+          <tr><td style="font-family:var(--mono);font-size:11px;color:var(--faint)">016</td><td class="tt">初探 Github Blocks</td><td class="st pub">● published</td><td style="font-family:var(--mono);font-size:11px">public</td><td style="font-family:var(--mono);font-size:11px;color:var(--faint)">2023-02-18</td><td class="ops"><a href="#" onclick="return false">编辑</a><a href="#" onclick="return false" style="color:var(--pink)">删除</a></td></tr>
+          <tr><td style="font-family:var(--mono);font-size:11px;color:var(--faint)">015</td><td class="tt">Type Challenge · 冒泡排序</td><td class="st pub">● published</td><td style="font-family:var(--mono);font-size:11px">public</td><td style="font-family:var(--mono);font-size:11px;color:var(--faint)">2021-05-08</td><td class="ops"><a href="#" onclick="return false">编辑</a><a href="#" onclick="return false" style="color:var(--pink)">删除</a></td></tr>
+          <tr><td style="font-family:var(--mono);font-size:11px;color:var(--faint)">014</td><td class="tt">回顾 2020</td><td class="st pub">● published</td><td style="font-family:var(--mono);font-size:11px">member</td><td style="font-family:var(--mono);font-size:11px;color:var(--faint)">2021-02-28</td><td class="ops"><a href="#" onclick="return false">编辑</a><a href="#" onclick="return false" style="color:var(--pink)">删除</a></td></tr>
+          <tr><td style="font-family:var(--mono);font-size:11px;color:var(--faint)">010</td><td class="tt">文档书写要点整理</td><td class="st pub">● published</td><td style="font-family:var(--mono);font-size:11px">password</td><td style="font-family:var(--mono);font-size:11px;color:var(--faint)">2020-03-01</td><td class="ops"><a href="#" onclick="return false">编辑</a><a href="#" onclick="return false" style="color:var(--pink)">删除</a></td></tr>
+          <tr><td style="font-family:var(--mono);font-size:11px;color:var(--faint)">017</td><td class="tt">Cloudflare 迁移实录</td><td class="st draft">○ draft</td><td style="font-family:var(--mono);font-size:11px">public</td><td style="font-family:var(--mono);font-size:11px;color:var(--faint)">2026-08-12</td><td class="ops"><a href="#" onclick="return false">编辑</a><a href="#" onclick="return false" style="color:var(--pink)">删除</a></td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- ================= EDITOR ================= -->
+  <section class="page" data-page="editor" hidden>
+    <div class="page-head"><h1 style="font-size:26px">编辑器</h1></div>
+    <div class="panel" style="padding:26px 30px 30px">
+      <form onsubmit="return false">
+        <div class="ed-grid">
+          <div class="field"><label>TITLE</label><input type="text" value="Cloudflare 迁移实录"></div>
+          <div class="field"><label>SLUG</label><input type="text" value="cloudflare-migration"></div>
+          <div class="field"><label>VISIBILITY</label>
+            <select><option>public</option><option>member</option><option>vip</option><option>admin</option><option>password</option></select>
+          </div>
+          <div class="field"><label>TAGS</label><input type="text" value="Cloudflare, D1, Workers"></div>
+        </div>
+        <div class="field"><label>CONTENT — MARKDOWN</label>
+          <textarea class="draft" spellcheck="false">## 为什么要迁
+
+Postgres 免费额度撑不住了……
+
+```ts
+export default { fetch } = ...
+```</textarea>
+        </div>
+        <div class="ed-foot">
+          <button class="btn" type="button">存草稿</button>
+          <button class="btn grad" type="button">发布</button>
+          <span class="stat">642 CHARS · 3 MIN · AUTOSAVED 12:41</span>
+        </div>
+      </form>
+    </div>
+  </section>
+
+  <!-- ================= 404 ================= -->
+  <section class="page" data-page="404" hidden>
+    <div class="nf">
+      <div class="code">404</div>
+      <p>你驶入了没有霓虹的街区。</p>
+      <a class="btn grad" href="#" onclick="return false">← 回到博客</a>
+    </div>
+  </section>
+
+</div>
+
+<!-- ⌘K palette -->
+<div class="pal-veil" id="pal-veil" hidden>
+  <div class="pal" role="dialog" aria-label="搜索文章">
+    <div class="pal-in"><span class="m">SEARCH</span><input type="text" id="pal-input" placeholder="在夜色里搜索……" aria-label="搜索"></div>
+    <div class="pal-list">
+      <div class="pal-item sel"><span class="d">015</span><span style="font-weight:600">Type Challenge · 冒泡排序</span><span class="tagchip violet">TS</span></div>
+      <div class="pal-item"><span class="d">012</span><span style="font-weight:600">LeetCode 中国区 TypeScript 面试题题解</span><span class="tagchip violet">TS</span></div>
+      <div class="pal-item"><span class="d">008</span><span style="font-weight:600">Codeforces Round#605(Div. 3) D/E/F 题解</span><span class="tagchip violet">DP</span></div>
+      <div class="pal-item"><span class="d">005</span><span style="font-weight:600">Codeforces 1149B Three Religions</span><span class="tagchip violet">DP</span></div>
+    </div>
+    <div class="pal-foot">↑↓ SELECT · ↵ OPEN · ESC CLOSE — 权限按当前身份过滤</div>
+  </div>
+</div>
+
+<script>
+  var tabs = document.querySelectorAll('.pt-tab');
+  var pages = document.querySelectorAll('.page');
+  function go(id) {
+    pages.forEach(function(p){ p.hidden = p.dataset.page !== id; });
+    tabs.forEach(function(t){ t.classList.toggle('active', t.dataset.target === id); });
+    window.scrollTo(0, 0);
+    history.replaceState(null, '', '#' + id);
+  }
+  tabs.forEach(function(t){ if (t.dataset.target) t.addEventListener('click', function(){ go(t.dataset.target); }); });
+  var h = location.hash.slice(1);
+  if (h && document.querySelector('.page[data-page="' + h + '"]')) go(h);
+  window.addEventListener('hashchange', function(){
+    var h = location.hash.slice(1);
+    if (h && document.querySelector('.page[data-page="' + h + '"]')) go(h);
+  });
+
+  var veil = document.getElementById('pal-veil');
+  var input = document.getElementById('pal-input');
+  document.addEventListener('keydown', function(e){
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') { e.preventDefault(); veil.hidden = false; input.focus(); }
+    if (e.key === 'Escape') veil.hidden = true;
+  });
+  veil.addEventListener('click', function(e){ if (e.target === veil) veil.hidden = true; });
+</script>
+</body>
+</html>

--- a/prototypes/index.html
+++ b/prototypes/index.html
@@ -1,0 +1,175 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>UX 改版原型总览 · PerfectPan's Blog</title>
+<style>
+  :root {
+    --bg: #101214;
+    --card: #17191C;
+    --line: #26292E;
+    --text: #E8E9EA;
+    --dim: #9A9FA6;
+    --faint: #63686F;
+    --accent: #E8B14A;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", system-ui, sans-serif;
+    line-height: 1.7;
+    padding: 48px 24px 96px;
+  }
+  .wrap { max-width: 1120px; margin: 0 auto; }
+  .eyebrow { color: var(--accent); font-size: 13px; letter-spacing: 0.2em; font-weight: 600; }
+  h1 { font-size: 34px; margin: 8px 0 12px; letter-spacing: 0.01em; }
+  .lede { color: var(--dim); max-width: 680px; font-size: 15px; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 20px; margin-top: 40px; }
+  a.card {
+    display: block;
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 24px;
+    text-decoration: none;
+    color: var(--text);
+    transition: transform 0.15s ease, border-color 0.15s ease;
+  }
+  a.card:hover { transform: translateY(-3px); border-color: var(--faint); }
+  a.card:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .dir { font-size: 12px; font-weight: 700; letter-spacing: 0.18em; color: var(--faint); }
+  .card h2 { font-size: 21px; margin: 10px 0 6px; }
+  .card p { color: var(--dim); font-size: 14px; }
+  .swatches { display: flex; gap: 6px; margin-top: 16px; }
+  .sw { width: 26px; height: 26px; border-radius: 6px; border: 1px solid rgba(255,255,255,0.12); }
+  .meta { margin-top: 14px; font-size: 12.5px; color: var(--faint); font-family: ui-monospace, "SF Mono", Menlo, monospace; }
+  section.notes { margin-top: 48px; border-top: 1px solid var(--line); padding-top: 28px; }
+  section.notes h3 { font-size: 16px; margin-bottom: 10px; }
+  section.notes ul { color: var(--dim); font-size: 14px; padding-left: 20px; }
+  section.notes li { margin: 6px 0; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="eyebrow">UX REDESIGN · PROTOTYPES</div>
+  <h1>整站 UX 改版 · 七个方向的原型</h1>
+  <p class="lede">
+    每个方向是一个独立 HTML 文件，内置页面切换器，覆盖站点全部页面：
+    首页 / 博客列表 / 文章页 / 项目 / 登录 / 注册 / 密码解锁 / 后台列表 / 后台编辑器 / 404 / ⌘K 搜索。
+    直接点击卡片打开（本地文件，无外部依赖）。
+  </p>
+
+  <div class="grid">
+    <a class="card" href="a-terminal.html">
+      <div class="dir">方向 A · TERMINAL</div>
+      <h2>终端会话 <span style="font-family:ui-monospace,monospace;font-size:15px;color:var(--faint)">~ %</span></h2>
+      <p>把现有站点若隐若现的终端梗做成整个设计语言：站点 = tmux 会话，文件权限表示可见性。极客本命。</p>
+      <div class="swatches">
+        <div class="sw" style="background:#0C1218"></div>
+        <div class="sw" style="background:#C9D4DE"></div>
+        <div class="sw" style="background:#E9B44C"></div>
+        <div class="sw" style="background:#6FC5D8"></div>
+        <div class="sw" style="background:#7CBF8B"></div>
+      </div>
+      <div class="meta">暗色 only · 等宽 · 签名：tmux 状态栏 + 权限位</div>
+    </a>
+
+    <a class="card" href="b-journal.html">
+      <div class="dir">方向 B · JOURNAL</div>
+      <h2>文学集刊 《废墨集》</h2>
+      <p>面向中文长文阅读：宋体大标题、竖排卷标、朱砂印章、书刊式目次、首字下沉与眉批。</p>
+      <div class="swatches">
+        <div class="sw" style="background:#F6F3EC"></div>
+        <div class="sw" style="background:#262523"></div>
+        <div class="sw" style="background:#A63A2B"></div>
+        <div class="sw" style="background:#2E4A68"></div>
+        <div class="sw" style="background:#D9D3C5"></div>
+      </div>
+      <div class="meta">亮色 only · 宋体 · 签名：朱印 + 竖排卷标</div>
+    </a>
+
+    <a class="card" href="c-swiss.html">
+      <div class="dir">方向 C · SWISS DATA</div>
+      <h2>瑞士网格 × 评级色</h2>
+      <p>算法竞赛博客的数据气质：严格键线网格、索引编号（№042）、标签用竞赛评级色。冷静现代。</p>
+      <div class="swatches">
+        <div class="sw" style="background:#FFFFFF"></div>
+        <div class="sw" style="background:#16181D"></div>
+        <div class="sw" style="background:#E5484D"></div>
+        <div class="sw" style="background:#3D6BE8"></div>
+        <div class="sw" style="background:#8F5AE8"></div>
+      </div>
+      <div class="meta">亮暗双主题 · 无衬线 · 签名：编号 + 评级色系统</div>
+    </a>
+
+    <a class="card" href="d-zen.html">
+      <div class="dir">方向 D · ZEN</div>
+      <h2>日式余白 · 字纸篓</h2>
+      <p>大留白、轻字重、「間」分隔，唯一的竹青色只做点睛。列表不画线，靠呼吸对齐。安静耐读。</p>
+      <div class="swatches">
+        <div class="sw" style="background:#F7F8F5"></div>
+        <div class="sw" style="background:#2B302B"></div>
+        <div class="sw" style="background:#557C67"></div>
+        <div class="sw" style="background:#EFF1EC"></div>
+        <div class="sw" style="background:#A9B2A3"></div>
+      </div>
+      <div class="meta">亮色 only · 细字重 · 签名：「間」分隔 + 竖排边注</div>
+    </a>
+
+    <a class="card" href="e-blueprint.html">
+      <div class="dir">方向 E · BLUEPRINT</div>
+      <h2>工程蓝图 · 图纸集</h2>
+      <p>整站做成一叠工程图纸：蓝底白线坐标纸、双线图框、角标记、右下角图签（DWG NO./REV/SHEET）。博客列表是材料清单 BOM。</p>
+      <div class="swatches">
+        <div class="sw" style="background:#173E62"></div>
+        <div class="sw" style="background:#E8F1FA"></div>
+        <div class="sw" style="background:#FFC957"></div>
+        <div class="sw" style="background:#8FDCFF"></div>
+        <div class="sw" style="background:#FF8E7A"></div>
+      </div>
+      <div class="meta">蓝图蓝 · 等宽标注 · 签名：图框 + 标题栏图签</div>
+    </a>
+
+    <a class="card" href="f-neopop.html">
+      <div class="dir">方向 F · NEO-POP</div>
+      <h2>糖果粗野 · 贴纸墙</h2>
+      <p>黑粗边 + 硬阴影 + 高饱和撞色（黄/橙/紫/粉/青绿），旋转贴纸徽章，hover 时卡片跳起来。 loud but disciplined。</p>
+      <div class="swatches">
+        <div class="sw" style="background:#FFDE59"></div>
+        <div class="sw" style="background:#141414"></div>
+        <div class="sw" style="background:#FF6B35"></div>
+        <div class="sw" style="background:#7C5CFF"></div>
+        <div class="sw" style="background:#FF90C2"></div>
+      </div>
+      <div class="meta">亮色 · 900 字重 · 签名：硬阴影卡片 + 贴纸</div>
+    </a>
+
+    <a class="card" href="g-synthwave.html">
+      <div class="dir">方向 G · SYNTHWAVE</div>
+      <h2>霓虹夜行 · 夜驰</h2>
+      <p>夜紫底 + 粉→紫→青渐层、落日与地平线网格、扫描线与辉光。正文保持素净，霓虹只做骨架。</p>
+      <div class="swatches">
+        <div class="sw" style="background:#120E24"></div>
+        <div class="sw" style="background:#E9E4FF"></div>
+        <div class="sw" style="background:#FF4FD8"></div>
+        <div class="sw" style="background:#8B6CFF"></div>
+        <div class="sw" style="background:#3EE6D2"></div>
+      </div>
+      <div class="meta">暗色 only · 渐层 · 签名：落日 + 透视网格 hero</div>
+    </a>
+  </div>
+
+  <section class="notes">
+    <h3>怎么评估这七个方向</h3>
+    <ul>
+      <li><strong>每个文件里都有顶部标签栏</strong>，点击切换页面；⌘K 搜索面板可以真实唤起，部分方向带小动效。</li>
+      <li>原型内容用的是<strong>真实数据</strong>（真实文章标题、真实项目）；少量可见性标记（member/vip/password）为演示虚构。</li>
+      <li>七个方向都保留现有信息架构与路由（/blog、/blog/:slug 等），只改视觉与交互层，任选其一即可落地。</li>
+      <li>风格光谱：D 最静 → B/C 克制 → A/E 有性格 → F/G 最张扬。也可以混搭（如 C 的骨架 + B 的正文排版）。</li>
+    </ul>
+  </section>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## What

静态 HTML 原型库（`prototypes/`，不参与构建），用于整站 UX 改版的方向评审：

- **方向 A** 终端会话（tmux 状态栏 / 权限位表示可见性）
- **方向 B** 文学集刊《废墨集》（竖排卷标 / 朱印 / 目次点线）
- **方向 C** 瑞士网格 × 评级色（№编号 / 竞赛评级色标签 / 亮暗双主题）
- **方向 D** 日式余白（竹青 / 「間」分隔 / 大留白）
- **方向 E** 工程蓝图（坐标纸 / 图框图签 / BOM 列表）
- **方向 F** 糖果粗野（硬阴影 / 贴纸 / 高饱和撞色）
- **方向 G** 霓虹夜行（渐层 / 落日网格 / 扫描线）

每个原型内置页面切换器，覆盖全部页面（首页/列表/文章/项目/登录/注册/解锁/后台/编辑器/404/⌘K）。

## Notes

- 本 PR 只加静态文件，不影响线上站点。
- 后续每个方向会各有一个落地 PR（基于本目录原型实现），可用 Workers Builds 的 preview URL 逐个预览。