### PR TITLE
feat(web): apply terminal session theme (UX direction A)

### DIFF
--- a/apps/web/src/components/comments.tsx
+++ b/apps/web/src/components/comments.tsx
@@ -20,14 +20,6 @@ type CommentsProps = {
 
 const PAGE_SIZE = 20;
 
-function getInitials(name: string): string {
-  const trimmed = name.trim();
-  if (!trimmed) {
-    return '?';
-  }
-  return trimmed.slice(0, 1).toUpperCase();
-}
-
 function formatRelative(iso: string): string {
   const then = new Date(iso).getTime();
   if (Number.isNaN(then)) {
@@ -54,24 +46,6 @@ function formatRelative(iso: string): string {
     day: 'numeric',
     year: 'numeric',
   });
-}
-
-function Avatar({ name, image }: { name: string; image: string | null }) {
-  if (image) {
-    return (
-      <img
-        src={image}
-        alt={name}
-        loading='lazy'
-        className='h-8 w-8 shrink-0 rounded-full bg-zinc-100 dark:bg-zinc-800'
-      />
-    );
-  }
-  return (
-    <div className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-zinc-200 text-xs font-semibold text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300'>
-      {getInitials(name)}
-    </div>
-  );
 }
 
 type ComposerProps = {
@@ -107,26 +81,25 @@ function Composer({
   }
 
   return (
-    <form onSubmit={handleSubmit} className='flex flex-col gap-2'>
+    <form onSubmit={handleSubmit} className='th-cmt-form flex flex-col gap-2'>
       <textarea
         value={body}
         onChange={(event) => setBody(event.target.value)}
         placeholder={placeholder}
         rows={compact ? 2 : 3}
         maxLength={2000}
-        className='w-full resize-y rounded-md border border-zinc-300 bg-transparent px-3 py-2 text-sm outline-none transition-colors focus:border-zinc-400 dark:border-zinc-600 dark:focus:border-zinc-400'
       />
       <div className='flex items-center justify-between gap-2'>
-        <span className='text-xs opacity-50'>
+        <span className='th-cmt-hint'>
           {remaining < 200 ? `${remaining} 字剩余` : '支持 Markdown'}
-          {error ? <span className='ml-2 text-red-500'>{error}</span> : null}
+          {error ? <span className='th-err ml-2 inline'>{error}</span> : null}
         </span>
         <button
           type='submit'
           disabled={submitting || !body.trim()}
-          className='rounded-md bg-black px-3 py-1 text-xs font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-neutral-900'
+          className='th-btn th-btn-primary'
         >
-          {submitting ? '发送中…' : '发送'}
+          {submitting ? '发送中…' : 'reply'}
         </button>
       </div>
     </form>
@@ -191,7 +164,7 @@ function CommentItem({
       ) : null}
 
       {thread.replies.length > 0 ? (
-        <ul className='ml-10 flex flex-col gap-2 border-l border-zinc-200 pl-4 dark:border-zinc-700'>
+        <ul className='th-cmt-replies'>
           {thread.replies.map((reply) => {
             const replyCanAct =
               sessionUser != null &&
@@ -201,6 +174,7 @@ function CommentItem({
                 key={reply.id}
                 comment={reply}
                 canAct={replyCanAct}
+                canReply={false}
                 onReply={undefined}
                 onDelete={async () => {
                   if (!window.confirm('删除这条回复？')) {
@@ -233,49 +207,39 @@ function CommentView({
   onDelete,
 }: CommentViewProps) {
   return (
-    <div className='flex gap-3'>
-      <Avatar name={comment.author.name} image={comment.author.image} />
-      <div className='min-w-0 flex-1'>
-        <div className='flex flex-wrap items-center gap-x-2 gap-y-0.5'>
-          <span className='text-sm font-semibold'>{comment.author.name}</span>
-          {comment.author.role === 'admin' ? (
-            <span className='rounded bg-zinc-900 px-1.5 py-0.5 text-[10px] font-semibold text-white dark:bg-white dark:text-zinc-900'>
-              Author
-            </span>
-          ) : null}
-          {comment.status !== 'visible' ? (
-            <span className='rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'>
-              {comment.status}
-            </span>
-          ) : null}
-          <span className='text-xs opacity-50'>
-            {formatRelative(comment.createdAt)}
-          </span>
-        </div>
-        <div className='mt-1'>
-          <CommentMarkdown content={comment.body} />
-        </div>
-        <div className='mt-1 flex gap-3 text-xs'>
-          {canReply && onReply ? (
-            <button
-              type='button'
-              onClick={onReply}
-              className='opacity-50 transition-opacity hover:opacity-100'
-            >
-              回复
-            </button>
-          ) : null}
-          {canAct ? (
-            <button
-              type='button'
-              onClick={() => onDelete()}
-              className='text-red-500/70 transition-colors hover:text-red-500'
-            >
-              删除
-            </button>
-          ) : null}
-        </div>
+    <div className='th-cmt'>
+      <div className='th-cmt-head'>
+        <span className='who'>{comment.author.name}</span>
+        {comment.author.role === 'admin' ? (
+          <span className='th-role-badge'>AUTHOR</span>
+        ) : null}
+        {comment.status !== 'visible' ? (
+          <span className='th-perm-pw'>{comment.status}</span>
+        ) : null}
+        <span>{formatRelative(comment.createdAt)}</span>
       </div>
+      <div className='th-cmt-body'>
+        <CommentMarkdown content={comment.body} />
+      </div>
+      {canReply && onReply ? (
+        <div className='th-cmt-ops'>
+          <button type='button' onClick={onReply}>
+            reply
+          </button>
+          {canAct ? (
+            <button type='button' className='del' onClick={() => onDelete()}>
+              rm
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+      {!(canReply && onReply) && canAct ? (
+        <div className='th-cmt-ops'>
+          <button type='button' className='del' onClick={() => onDelete()}>
+            rm
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -316,7 +280,7 @@ export function Comments({
     setReplySubmitting((prev) => new Set(prev).add(parentId));
     try {
       const { comment } = await createCommentServerFn({
-        data: { slug, parentId, body },
+        data: { slug, body, parentId },
       });
       setThreads((prev) =>
         prev.map((thread) =>
@@ -375,10 +339,12 @@ export function Comments({
   }
 
   return (
-    <section className='mt-12'>
-      <h2 className='mb-4 text-lg font-black'>
-        评论 {total > 0 ? <span className='opacity-50'>({total})</span> : null}
-      </h2>
+    <section className='mt-10'>
+      <div className='th-prompt mb-4'>
+        <span className='th-prompt-p'>~ %</span>{' '}
+        <span className='th-cmd'>comments --on {slug}</span>{' '}
+        <span className='th-comment'>({total})</span>
+      </div>
 
       {sessionUser ? (
         <div className='mb-6'>
@@ -389,24 +355,17 @@ export function Comments({
           />
         </div>
       ) : (
-        <p className='mb-6 text-sm opacity-60'>
-          <Link to='/login' className='underline hover:opacity-100'>
-            登录
-          </Link>{' '}
-          后即可评论。
+        <p className='th-comment mb-6'>
+          # <Link to='/login'>login</Link> 后即可评论。
         </p>
       )}
 
-      {topError ? (
-        <p className='mb-4 text-sm text-red-500'>{topError}</p>
-      ) : null}
+      {topError ? <p className='th-err mb-4'>{topError}</p> : null}
 
       {threads.length === 0 ? (
-        <p className='py-8 text-center text-sm opacity-50'>
-          还没有评论，来抢沙发。
-        </p>
+        <p className='th-comment py-8 text-center'># 还没有评论，来抢沙发。</p>
       ) : (
-        <ul className='flex flex-col gap-5'>
+        <ul className='flex flex-col gap-3'>
           {threads.map((thread) => (
             <CommentItem
               key={thread.id}
@@ -428,9 +387,9 @@ export function Comments({
             type='button'
             onClick={handleLoadMore}
             disabled={loadingMore}
-            className='text-sm opacity-60 transition-opacity hover:opacity-100 disabled:opacity-40'
+            className='th-btn'
           >
-            {loadingMore ? '加载中…' : '加载更多'}
+            {loadingMore ? '加载中…' : 'tail -f'}
           </button>
         </div>
       ) : null}

--- a/apps/web/src/components/dark-mode.tsx
+++ b/apps/web/src/components/dark-mode.tsx
@@ -13,14 +13,9 @@ export function DarkMode() {
   const ref = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
-    if (isDarkMode) {
-      document.documentElement.classList.add('dark');
-      document.body.classList.add('dark:bg-wash-dark', 'dark:text-white');
-      return;
-    }
-
-    document.documentElement.classList.remove('dark');
-    document.body.classList.remove('dark:bg-wash-dark', 'dark:text-white');
+    // The terminal theme carries its own dark palette via html.dark custom
+    // properties; no legacy body utility classes are needed.
+    document.documentElement.classList.toggle('dark', isDarkMode);
   }, [isDarkMode]);
 
   const onTrigger = async () => {

--- a/apps/web/src/components/dark-mode.tsx
+++ b/apps/web/src/components/dark-mode.tsx
@@ -31,15 +31,19 @@ export function DarkMode() {
       return;
     }
 
+    // Capture the anchor rect BEFORE starting the transition: by the time
+    // `.ready` resolves, the dark-mode class swap may have shifted layout
+    // (scrollbar / reflow), which moved the measured origin off the icon.
+    // This is the ordering the Chrome view-transition docs recommend.
+    const { top, left, width, height } = ref.current.getBoundingClientRect();
+    const x = left + width / 2;
+    const y = top + height / 2;
+
     await doc.startViewTransition(() => {
       flushSync(() => {
         setIsDarkMode(newIsDarkMode);
       });
     }).ready;
-
-    const { top, left, width, height } = ref.current.getBoundingClientRect();
-    const x = left + width / 2;
-    const y = top + height / 2;
     const right = window.innerWidth - left;
     const bottom = window.innerHeight - top;
     const maxRadius = Math.hypot(Math.max(left, right), Math.max(top, bottom));

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -1,10 +1,39 @@
+import { Link } from '@tanstack/react-router';
+import { authClient } from '../lib/auth-client.js';
+
+/**
+ * tmux-style status bar: session name + clickable windows on the left, site
+ * info on the right. Doubles as secondary navigation (the active window is
+ * highlighted by the current route).
+ */
 export function Footer() {
+  const { data: sessionData } = authClient.useSession();
+  const isAdmin = sessionData?.user?.role === 'admin';
+
   return (
-    <footer className='p-6 text-center'>
-      © {new Date().getFullYear()}, Built with{' '}
-      <a className='text-blue-500' href='https://tanstack.com/start/latest'>
-        TanStack Start
-      </a>
+    <footer className='th-tmux'>
+      <span className='th-tmux-sess'>blog</span>
+      <nav aria-label='站点窗口' className='flex flex-wrap items-center gap-1'>
+        <Link to='/' className='th-tmux-win'>
+          0:home
+        </Link>
+        <Link to='/blog' className='th-tmux-win'>
+          1:posts
+        </Link>
+        <Link to='/projects' className='th-tmux-win'>
+          2:projects
+        </Link>
+        {isAdmin ? (
+          <Link to='/admin' className='th-tmux-win'>
+            3:admin
+          </Link>
+        ) : null}
+      </nav>
+      <span className='th-tmux-right'>
+        <span>perfectpan.org</span>
+        <span>⌘K = grep</span>
+        <span>© {new Date().getFullYear()}</span>
+      </span>
     </footer>
   );
 }

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -1,6 +1,7 @@
 import { Link } from '@tanstack/react-router';
 import { Github, LogOut, Rss, Search, UserRound } from 'lucide-react';
 import { authClient } from '../lib/auth-client.js';
+import { DarkMode } from './dark-mode.js';
 import { searchPalette } from './search-palette-store.js';
 
 function getRoleLabel(role?: string | null): string {
@@ -60,6 +61,7 @@ export function Header() {
             </Link>
           </>
         )}
+        <DarkMode />
         <button
           type='button'
           aria-label='Search posts (Cmd+K)'

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -1,8 +1,6 @@
 import { Link } from '@tanstack/react-router';
 import { Github, LogOut, Rss, Search, UserRound } from 'lucide-react';
 import { authClient } from '../lib/auth-client.js';
-import { DarkMode } from './dark-mode.js';
-import { MenuLink } from './menu.js';
 import { searchPalette } from './search-palette-store.js';
 
 function getRoleLabel(role?: string | null): string {
@@ -17,78 +15,73 @@ function getRoleLabel(role?: string | null): string {
   return 'MEMBER';
 }
 
+/** Terminal title bar: window dots + session name + right-aligned tools. */
 export function Header() {
   const { data: sessionData } = authClient.useSession();
   const sessionUser = sessionData?.user ?? null;
 
   return (
-    <header className='border-b border-slate-200 bg-white shadow-md dark:border-slate-300/10 dark:bg-slate-900'>
-      <div className='mx-4 flex h-16 items-center sm:mx-6'>
-        <Link
-          to='/'
-          className='rounded-md border-10 border-black bg-black px-1 font-bold text-white dark:border-neutral-900 dark:bg-neutral-900'
-        >
-          PerfectPan
-        </Link>
-        <div className='m-0 flex list-none items-center pl-1'>
-          <MenuLink href='/' name='Home' />
-          <MenuLink href='/blog' name='Blog' />
-          <MenuLink href='/projects' name='Projects' />
-          {sessionUser?.role === 'admin' ? (
-            <MenuLink href='/admin' name='Admin' />
-          ) : null}
-        </div>
-        <div className='ml-auto flex items-center gap-2 sm:gap-3'>
-          {sessionUser ? (
-            <div className='hidden items-center gap-2 rounded-full border border-slate-300 px-3 py-1 text-xs text-gray-700 md:flex dark:border-slate-600 dark:text-slate-200'>
-              <UserRound size={14} className='opacity-70' />
-              <span className='max-w-[220px] truncate'>
-                {sessionUser.email}
-              </span>
-              <span className='rounded-full bg-black px-2 py-[2px] text-[10px] font-semibold text-white dark:bg-neutral-100 dark:text-neutral-900'>
-                {getRoleLabel(sessionUser.role)}
-              </span>
-            </div>
-          ) : null}
-          {sessionUser ? (
-            <Link
-              to='/logout'
-              className='inline-flex items-center gap-1 rounded-md border border-slate-300 px-2 py-1 text-sm opacity-85 transition-opacity hover:opacity-100 dark:border-slate-600'
-            >
-              <LogOut size={14} />
-              <span className='hidden sm:inline'>Logout</span>
+    <header className='th-titlebar'>
+      <span className='th-dot th-dot-r' aria-hidden='true' />
+      <span className='th-dot th-dot-y' aria-hidden='true' />
+      <span className='th-dot th-dot-g' aria-hidden='true' />
+      <span className='th-term-title'>
+        <b>perfectpan@blog</b> —{' '}
+        <span className='th-path'>~/perfectpan.org</span>
+      </span>
+
+      <div className='th-tools'>
+        {sessionUser ? (
+          <span className='th-user-chip'>
+            <UserRound size={13} aria-hidden='true' />
+            <span className='max-w-[220px] truncate'>{sessionUser.email}</span>
+            <span className='th-role-badge'>
+              {getRoleLabel(sessionUser.role)}
+            </span>
+          </span>
+        ) : null}
+        {sessionUser ? (
+          <Link to='/logout' className='th-tool-btn' aria-label='Logout'>
+            <LogOut size={15} aria-hidden='true' />
+            <span className='hidden sm:inline'>logout</span>
+          </Link>
+        ) : (
+          <>
+            <Link to='/login' className='th-tool-btn'>
+              login
             </Link>
-          ) : (
-            <>
-              <Link to='/login' className='opacity-70 hover:opacity-100'>
-                Login
-              </Link>
-              <Link to='/signup' className='opacity-70 hover:opacity-100'>
-                Sign Up
-              </Link>
-            </>
-          )}
-          <button
-            type='button'
-            aria-label='Search posts (Cmd+K)'
-            onClick={() => searchPalette.open()}
-            className='inline-flex items-center opacity-70 transition-opacity hover:opacity-100'
-          >
-            <Search size={22} />
-          </button>
-          <DarkMode />
-          <a
-            href='https://github.com/PerfectPan'
-            target='_blank'
-            rel='noreferrer'
-            className='flex items-center'
-          >
-            <Github size={22} className='opacity-70 hover:opacity-100' />
-          </a>
-          <a href='/rss.xml' target='_blank' rel='noreferrer'>
-            <Rss size={24} className='opacity-70 hover:opacity-100' />
-          </a>
-        </div>
+            <Link to='/signup' className='th-tool-btn'>
+              signup
+            </Link>
+          </>
+        )}
+        <button
+          type='button'
+          aria-label='Search posts (Cmd+K)'
+          onClick={() => searchPalette.open()}
+          className='th-tool-btn'
+        >
+          <Search size={15} aria-hidden='true' />
+          <span className='hidden sm:inline'>grep</span>
+        </button>
+        <a
+          href='https://github.com/PerfectPan'
+          target='_blank'
+          rel='noreferrer'
+          aria-label='GitHub'
+          className='th-tool-btn'
+        >
+          <Github size={15} aria-hidden='true' />
+        </a>
+        <a
+          href='/rss.xml'
+          target='_blank'
+          rel='noreferrer'
+          aria-label='RSS'
+          className='th-tool-btn'
+        >
+          <Rss size={15} aria-hidden='true' />
+        </a>
       </div>
     </header>
   );

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -41,16 +41,21 @@ export function Header() {
           </span>
         ) : null}
         {sessionUser ? (
-          <Link to='/logout' className='th-tool-btn' aria-label='Logout'>
+          <Link
+            to='/logout'
+            data-testid='nav-logout'
+            className='th-tool-btn'
+            aria-label='Logout'
+          >
             <LogOut size={15} aria-hidden='true' />
             <span className='hidden sm:inline'>logout</span>
           </Link>
         ) : (
           <>
-            <Link to='/login' className='th-tool-btn'>
+            <Link to='/login' data-testid='nav-login' className='th-tool-btn'>
               login
             </Link>
-            <Link to='/signup' className='th-tool-btn'>
+            <Link to='/signup' data-testid='nav-signup' className='th-tool-btn'>
               signup
             </Link>
           </>

--- a/apps/web/src/components/layout.tsx
+++ b/apps/web/src/components/layout.tsx
@@ -7,21 +7,18 @@ type AppLayoutProps = {
 };
 
 /**
- * App shell. The header sits OUTSIDE the scroll container (`main`), so page
- * overscroll only rubber-bands the content — the pinned header never moves
- * (no macOS "fixed header drags on overscroll"). Window doesn't scroll; route
- * scroll reset/restore for `main` is handled by TanStack via
- * `scrollToTopSelectors: ['main']` in router.tsx.
+ * App shell (terminal theme). The title bar sits OUTSIDE the scroll container
+ * (`main`), so page overscroll only rubber-bands the content — the pinned bar
+ * never moves. Window doesn't scroll; route scroll reset/restore for `main` is
+ * handled by TanStack via `scrollToTopSelectors: ['main']` in router.tsx.
  */
 export function AppLayout({ children }: AppLayoutProps) {
   return (
-    <div className='flex h-dvh flex-col'>
+    <div className='th-shell'>
       <Header />
-      <main className='flex-1 overflow-y-auto'>
+      <main className='th-main'>
         <div className='flex min-h-full flex-col'>
-          <div className='flex flex-grow items-center justify-center px-6 *:min-h-64 *:min-w-64'>
-            {children}
-          </div>
+          <div className='flex-grow'>{children}</div>
           <Footer />
         </div>
       </main>

--- a/apps/web/src/components/markdown.tsx
+++ b/apps/web/src/components/markdown.tsx
@@ -78,20 +78,17 @@ function CodeBlock({ children }: { children?: ReactNode }) {
   }, []);
 
   return (
-    <div className='group relative mb-2'>
+    <div className='th-code group relative'>
       <button
         type='button'
         onClick={onCopy}
         aria-label='Copy code'
-        className='absolute right-2 top-2 z-10 inline-flex items-center gap-1 rounded border border-slate-300 bg-white/70 px-1.5 py-0.5 text-xs opacity-0 backdrop-blur transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100 hover-none:opacity-70 dark:border-slate-700 dark:bg-slate-900/70'
+        className='th-code-copy'
       >
         {copied ? <Check size={12} /> : <Copy size={12} />}
         {copied ? 'Copied' : 'Copy'}
       </button>
-      <pre
-        ref={preRef}
-        className='shiki w-full overflow-x-auto whitespace-pre-wrap rounded-md bg-zinc-50 p-4 dark:bg-shiki-dark'
-      >
+      <pre ref={preRef} className='shiki th-pre w-full overflow-x-auto'>
         {children}
       </pre>
     </div>
@@ -112,7 +109,7 @@ export function Markdown({ content }: MarkdownProps) {
   }, []);
 
   return (
-    <article>
+    <article className='md'>
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkMath]}
         rehypePlugins={[
@@ -133,10 +130,7 @@ export function Markdown({ content }: MarkdownProps) {
             const id = typeof children === 'string' ? children : '';
 
             return (
-              <h2
-                id={id}
-                className='mb-6 mt-14 scroll-mt-20 text-balance text-2xl leading-none font-black first:mt-0'
-              >
+              <h2 id={id} className='scroll-mt-20'>
                 <a
                   href={`#${id}`}
                   onClick={(event) => {
@@ -150,24 +144,21 @@ export function Markdown({ content }: MarkdownProps) {
               </h2>
             );
           },
-          p: ({ children }) => <p className='mb-6 leading-7'>{children}</p>,
+          p: ({ children }) => <p>{children}</p>,
           a: ({ href, children }) => (
-            <a
-              href={href}
-              className='text-blue-700/80 transition-colors duration-300 ease-in-out hover:text-blue-700'
-              target='_blank'
-              rel='noreferrer'
-            >
+            <a href={href} target='_blank' rel='noreferrer'>
               {children}
             </a>
           ),
-          strong: ({ children }) => (
-            <b className='font-extrabold'>{children}</b>
-          ),
-          ul: ({ children }) => (
-            <ul className='mb-4 ml-4 list-disc'>{children}</ul>
-          ),
+          strong: ({ children }) => <b className='font-bold'>{children}</b>,
+          ul: ({ children }) => <ul>{children}</ul>,
           pre: ({ children }) => <CodeBlock>{children}</CodeBlock>,
+          code: ({ className, children }) =>
+            /language-/.test(className ?? '') ? (
+              <code className={className}>{children}</code>
+            ) : (
+              <code className='md-inline'>{children}</code>
+            ),
         }}
       >
         {content}

--- a/apps/web/src/components/search-palette.tsx
+++ b/apps/web/src/components/search-palette.tsx
@@ -70,19 +70,16 @@ export function SearchPalette() {
         next ? searchPalette.open() : searchPalette.close()
       }
     >
-      <DialogContent className='overflow-hidden p-0'>
-        <Command
-          shouldFilter={false}
-          className='[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-4 [&_[cmdk-input-wrapper]_svg]:w-4 [&_[cmdk-input]]:h-11 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-2'
-        >
+      <DialogContent className='th-pal overflow-hidden p-0'>
+        <Command shouldFilter={false} className='th-pal-cmd'>
           <CommandInput
             value={query}
             onValueChange={setQuery}
-            placeholder='Search posts…'
+            placeholder="grep -ri '关键词' ~/posts"
           />
           <CommandList>
             <CommandEmpty>
-              {query.trim() ? 'No posts found.' : 'Type to search posts…'}
+              {query.trim() ? '# no matches found' : '# type to grep ~/posts'}
             </CommandEmpty>
             <CommandGroup>
               {results.map((post) => (
@@ -91,25 +88,20 @@ export function SearchPalette() {
                   value={post.slug}
                   onSelect={() => go(post.slug)}
                 >
-                  <div className='flex min-w-0 flex-col gap-0.5'>
-                    <span className='font-medium'>{post.title}</span>
-                    {post.description ? (
-                      <span className='line-clamp-1 text-xs text-muted-foreground'>
-                        {post.description}
-                      </span>
-                    ) : null}
-                  </div>
-                  <span className='ml-auto shrink-0 pl-2 text-xs text-muted-foreground'>
-                    {new Date(post.publishedAt).toLocaleDateString('en-US', {
-                      month: 'short',
-                      day: 'numeric',
-                      year: 'numeric',
-                    })}
+                  <span className='th-pal-date'>
+                    {new Date(post.publishedAt).toISOString().slice(0, 7)}
                   </span>
+                  <span className='th-pal-title'>{post.title}</span>
+                  {post.visibility !== 'public' ? (
+                    <span className='th-pal-vis'>{post.visibility}</span>
+                  ) : null}
                 </CommandItem>
               ))}
             </CommandGroup>
           </CommandList>
+          <div className='th-pal-foot'>
+            ↑↓ 选择 · ↵ 打开 · esc 关闭 · 结果按当前身份过滤
+          </div>
         </Command>
       </DialogContent>
     </Dialog>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -26,7 +26,7 @@ export const Route = createRootRoute({
       },
       {
         name: 'theme-color',
-        content: '#000000',
+        content: '#0A0F14',
       },
     ],
     links: [
@@ -38,11 +38,17 @@ export const Route = createRootRoute({
   errorComponent: ({ error }) => (
     <RootDocument>
       <AppLayout>
-        <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-          <h2 className='mb-4 text-3xl'>Request Failed</h2>
-          <p className='mb-4 opacity-70'>{String(error)}</p>
-          <Link to='/blog' className='opacity-70 hover:opacity-100'>
-            Back to blog
+        <div className='th-page'>
+          <div className='th-prompt'>
+            <span className='th-prompt-u'>guest</span>
+            <span className='th-prompt-at'>@</span>
+            <span className='th-prompt-h'>perfectpan.org</span>{' '}
+            <span className='th-prompt-p'>~ %</span>{' '}
+            <span className='th-cmd'>curl -I $(hostname)</span>
+          </div>
+          <p className='th-out th-nf-big'>Request failed: {String(error)}</p>
+          <Link to='/blog' className='th-cd'>
+            cd ~/blog
           </Link>
         </div>
       </AppLayout>
@@ -51,12 +57,24 @@ export const Route = createRootRoute({
   notFoundComponent: () => (
     <RootDocument>
       <AppLayout>
-        <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-          <h2 className='mb-4 text-3xl'>404 Not Found</h2>
-          <p className='mb-4 opacity-70'>你闯入了无人之境...</p>
-          <Link to='/blog' className='opacity-70 hover:opacity-100'>
-            Back to blog
-          </Link>
+        <div className='th-page'>
+          <div className='th-prompt'>
+            <span className='th-prompt-u'>guest</span>
+            <span className='th-prompt-at'>@</span>
+            <span className='th-prompt-h'>perfectpan.org</span>{' '}
+            <span className='th-prompt-p'>~ %</span>{' '}
+            <span className='th-cmd'>cd /nowhere</span>
+          </div>
+          <p className='th-out th-nf-big'>
+            bash: cd: /nowhere: No such file or directory
+          </p>
+          <p className='th-out th-comment'># 你闯入了无人之境。</p>
+          <p className='th-out mt-4'>
+            <Link to='/blog' className='th-cd'>
+              cd ~/blog
+            </Link>
+            <span className='th-comment'> ← 回到博客列表</span>
+          </p>
         </div>
       </AppLayout>
     </RootDocument>
@@ -86,7 +104,9 @@ function RootComponent() {
 
 function RootDocument({ children }: { children: ReactNode }) {
   return (
-    <html lang='zh-CN'>
+    // Terminal theme is dark-native: render with .dark so existing dark:
+    // variants and shiki dual-themes apply without a client-side flash.
+    <html lang='zh-CN' className='dark'>
       <head>
         <HeadContent />
       </head>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -26,7 +26,7 @@ export const Route = createRootRoute({
       },
       {
         name: 'theme-color',
-        content: '#0A0F14',
+        content: '#F4F2EC',
       },
     ],
     links: [

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -104,9 +104,7 @@ function RootComponent() {
 
 function RootDocument({ children }: { children: ReactNode }) {
   return (
-    // Terminal theme is dark-native: render with .dark so existing dark:
-    // variants and shiki dual-themes apply without a client-side flash.
-    <html lang='zh-CN' className='dark'>
+    <html lang='zh-CN'>
       <head>
         <HeadContent />
       </head>

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -77,16 +77,41 @@ function BlogDetailPage() {
   });
 
   return (
-    <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <div className='m-auto mb-8 flex flex-col gap-2'>
-        <div className='text-3xl font-black'>{post.title}</div>
-        <div className='opacity-60'>{date}</div>
+    <div className='th-page'>
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>perfectpan</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>blog</span>{' '}
+        <span className='th-prompt-p'>~/posts %</span>{' '}
+        <span className='th-cmd'>
+          cat {new Date(post.publishedAt).getFullYear()}/{post.slug}.md
+        </span>
+      </div>
+
+      <div className='th-art-head'>
+        <h1 className='th-art-title'>{post.title}</h1>
+        <div className='th-art-meta'>
+          <span>{date}</span>
+          <span>·</span>
+          <span>{post.visibility}</span>
+          {post.tags.length > 0 ? (
+            <>
+              <span>·</span>
+              <span>#{post.tags.join(' #')}</span>
+            </>
+          ) : null}
+        </div>
       </div>
       <Markdown content={post.contentMdx} />
-      <Link to='/blog' className='mt-4 inline-block'>
-        <span className='opacity-70'>&gt;&nbsp;&nbsp;&nbsp;</span>
-        <span className='underline opacity-70 hover:opacity-100'>cd ..</span>
-      </Link>
+      <div className='th-prompt mt-6'>
+        <span className='th-prompt-u'>perfectpan</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>blog</span>{' '}
+        <span className='th-prompt-p'>~/posts %</span>{' '}
+        <Link to='/blog' className='th-cmd th-cmd-dim'>
+          cd ..
+        </Link>
+      </div>
       <Comments
         key={post.slug}
         slug={post.slug}

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -49,6 +49,22 @@ function getDevScopeHint(sessionUser: SessionUser | null | undefined): string {
   return '当前身份：member；可见范围：public/member';
 }
 
+/** Visibility → permission bits: owner / member / guest read permission. */
+const PERM_CLASS: Record<PostSummary['visibility'], string> = {
+  public: 'th-perm th-perm-pub',
+  member: 'th-perm th-perm-mem',
+  vip: 'th-perm th-perm-vip',
+  admin: 'th-perm th-perm-adm',
+  password: 'th-perm th-perm-pw',
+};
+const PERM_BITS: Record<PostSummary['visibility'], string> = {
+  public: '-r--r--r--',
+  member: '-r--r-----',
+  vip: '-r----r--',
+  admin: '-r--------',
+  password: '-r--------',
+};
+
 export const Route = createFileRoute('/blog/')({
   head: () => ({
     meta: [
@@ -86,79 +102,107 @@ function BlogListPage() {
   }, [data.page]);
 
   return (
-    <div className='mx-auto flex w-full max-w-[80ch] flex-col gap-8 self-start pt-8'>
-      <div className='w-full'>
-        {showDevHint ? (
-          <div className='mb-8 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900'>
-            {devScopeHint}
-          </div>
-        ) : null}
+    <div className='th-page'>
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>perfectpan</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>blog</span>{' '}
+        <span className='th-prompt-p'>~/posts %</span>{' '}
+        <span className='th-cmd'>ls -la --group-directories-first</span>
+      </div>
+
+      {showDevHint ? (
+        <div className='th-devhint mt-4'>{devScopeHint}</div>
+      ) : null}
+
+      <div className='th-ls'>
+        <div className='th-ls-row th-ls-head'>
+          <span>perms</span>
+          <span>date</span>
+          <span>vis</span>
+          <span>title</span>
+          <span className='text-right'>tags</span>
+        </div>
         {blogGroups.map((group) => (
           <div key={group.year}>
-            <div className='mb-4 text-3xl'>{group.year}</div>
+            <div className='th-ls-row'>
+              <span className='th-ls-year'>{group.year}</span>
+            </div>
             {group.blogs.map((blog: PostSummary) => (
-              <div
+              <Link
                 key={blog.slug}
-                className='mt-2 mb-6 opacity-70 hover:opacity-100'
+                to='/blog/$slug'
+                params={{ slug: blog.slug }}
+                className='th-ls-row'
               >
-                <Link
-                  to='/blog/$slug'
-                  params={{ slug: blog.slug }}
-                  className='flex items-center gap-2'
-                >
-                  <span className='text-lg leading-[1.2em]'>{blog.title}</span>
-                  <span className='text-sm opacity-50'>
-                    {new Date(blog.publishedAt).toLocaleDateString('en-US', {
-                      month: 'short',
-                      day: 'numeric',
-                    })}
-                  </span>
-                </Link>
-              </div>
+                <span className={PERM_CLASS[blog.visibility]}>
+                  {PERM_BITS[blog.visibility]}
+                </span>
+                <span className='th-ls-date'>
+                  {new Date(blog.publishedAt).toLocaleDateString('en-US', {
+                    month: '2-digit',
+                    day: '2-digit',
+                  })}
+                </span>
+                <span className='th-ls-vis th-comment'>{blog.visibility}</span>
+                <span className='th-ls-title'>{blog.title}</span>
+                <span className='th-ls-tags text-right'>
+                  {blog.tags.join(' · ')}
+                </span>
+              </Link>
             ))}
           </div>
         ))}
       </div>
+
       {data.totalPages > 1 ? (
-        <nav
-          className='flex w-full items-center justify-center gap-4 text-sm sm:gap-6'
-          aria-label='Pagination'
-        >
+        <nav className='th-pager' aria-label='Pagination'>
           {data.page > 1 ? (
-            <Link
-              to='/blog'
-              search={{ page: data.page - 1 }}
-              className='inline-flex items-center gap-1 opacity-60 hover:opacity-100'
-            >
-              <ChevronLeft size={14} /> prev
+            <Link to='/blog' search={{ page: data.page - 1 }}>
+              <ChevronLeft size={14} className='inline' aria-hidden='true' />{' '}
+              prev
             </Link>
           ) : (
-            <span className='inline-flex items-center gap-1 opacity-30'>
-              <ChevronLeft size={14} /> prev
+            <span className='th-pager-off'>
+              <ChevronLeft size={14} className='inline' aria-hidden='true' />{' '}
+              prev
             </span>
           )}
-          <span className='opacity-60'>
+          <span>
             page {data.page} / {data.totalPages}
           </span>
           {data.page < data.totalPages ? (
-            <Link
-              to='/blog'
-              search={{ page: data.page + 1 }}
-              className='inline-flex items-center gap-1 opacity-60 hover:opacity-100'
-            >
-              next <ChevronRight size={14} />
+            <Link to='/blog' search={{ page: data.page + 1 }}>
+              next{' '}
+              <ChevronRight size={14} className='inline' aria-hidden='true' />
             </Link>
           ) : (
-            <span className='inline-flex items-center gap-1 opacity-30'>
-              next <ChevronRight size={14} />
+            <span className='th-pager-off'>
+              next{' '}
+              <ChevronRight size={14} className='inline' aria-hidden='true' />
             </span>
           )}
         </nav>
       ) : null}
-      <Link to='/' className='mt-4 inline-block'>
-        <span className='opacity-70'>&gt;&nbsp;&nbsp;&nbsp;</span>
-        <span className='underline opacity-70 hover:opacity-100'>cd ..</span>
-      </Link>
+
+      <p className='th-legend'>
+        # perms = 可见性：owner / member / guest 读权限
+        <br /># <span className='th-perm-pub'>-r--r--r--</span> 公开 ·{' '}
+        <span className='th-perm-mem'>-r--r-----</span> 登录可见 ·{' '}
+        <span className='th-perm-vip'>-r----r--</span> VIP ·{' '}
+        <span className='th-perm-pw'>-r--------</span> 需密码
+      </p>
+
+      <hr className='th-hr' />
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>perfectpan</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>blog</span>{' '}
+        <span className='th-prompt-p'>~/posts %</span>{' '}
+        <Link to='/' className='th-cmd th-cmd-dim'>
+          cd ..
+        </Link>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -7,20 +7,52 @@ export const Route = createFileRoute('/')({
   component: HomePage,
 });
 
+const FIGLET = `  ____              _   _        _   ____  __  __ ____
+ |  _ \\ _   _  __ _| |_| |__    / \\ |  _ \\|  \\/  |  _ \\
+ | |_) | | | |/ _\` | __| '_ \\  / _ \\| |_) | |\\/| | |_) |
+ |  __/| |_| | (_| | |_| | | |/ ___ \\  __/| |  | |  __/
+ |_|    \\__,_|\\__,_|\\__|_| |_/_/   \\_\\_|  |_|  |_|_|   `;
+
 function HomePage() {
   return (
-    <div className='flex flex-col items-center'>
-      <img className='m-0' src='/images/xm.jpg' alt='' />
-      <div className='mt-8 text-[2.5rem] font-black'>
-        是个什么都不会的废物.jpg
+    <div className='th-page'>
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>perfectpan</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>blog</span>{' '}
+        <span className='th-prompt-p'>~ %</span>{' '}
+        <span className='th-cmd'>whoami --verbose</span>
       </div>
-      <div className='flex w-full justify-around'>
-        <div className='mx-1 mt-8 flex-1 rounded-md bg-slate-100 text-center font-semibold uppercase tracking-wider leading-[5rem] shadow-md transition-shadow hover:shadow-lg dark:bg-wash-dark dark:text-white dark:opacity-80'>
-          <Link to='/blog'>Blog</Link>
-        </div>
-        <div className='mx-1 mt-8 flex-1 rounded-md bg-slate-100 text-center font-semibold uppercase tracking-wider leading-[5rem] shadow-md transition-shadow hover:shadow-lg dark:bg-wash-dark dark:text-white dark:opacity-80'>
-          <Link to='/projects'>Projects</Link>
-        </div>
+      <div className='th-out'>
+        <div className='th-hero-name'>PerfectPan</div>
+        <p className='th-hero-desc'>
+          写代码的人。算法竞赛退役选手，现在的兴趣在前端工程、类型体操和把东西跑在
+          Cloudflare 免费额度上。
+        </p>
+        <pre className='th-figlet' aria-hidden='true'>
+          {FIGLET}
+          <b>.dev</b>
+        </pre>
+      </div>
+      <div className='th-prompt mt-6'>
+        <span className='th-prompt-u'>perfectpan</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>blog</span>{' '}
+        <span className='th-prompt-p'>~ %</span>{' '}
+        <span className='th-cmd'>cat motd.txt</span>
+      </div>
+      <p className='th-out th-comment'>
+        # 是个什么都不会的废物.jpg —— 但还在写。
+      </p>
+      <div className='th-home-links'>
+        <Link to='/blog'>
+          <span className='k'>open blog/</span>
+          <small>算法 / TypeScript / 随笔</small>
+        </Link>
+        <Link to='/projects'>
+          <span className='k'>open projects/</span>
+          <small>Rust / TS / Moonbit 开源项目</small>
+        </Link>
       </div>
     </div>
   );

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -34,25 +34,26 @@ function LoginPage() {
 
   if (sessionData?.user?.id || isSessionPending) {
     return (
-      <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-        <p className='opacity-70'>Checking session...</p>
-      </section>
+      <div className='th-page'>
+        <p className='th-comment'># checking session…</p>
+      </div>
     );
   }
 
   return (
-    <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>登录</h1>
-      <p className='mb-6 opacity-70'>支持邮箱密码和 GitHub OAuth。</p>
-
-      {error ? (
-        <p role='alert' className='mb-4 text-sm text-red-700 dark:text-red-300'>
-          {error}
-        </p>
-      ) : null}
-
+    <div className='th-page'>
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>guest</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>perfectpan.org</span>{' '}
+        <span className='th-prompt-p'>~ %</span>{' '}
+        <span className='th-cmd'>ssh member@perfectpan.org</span>
+      </div>
+      <p className='th-out th-comment mt-2'>
+        # 邮箱密码登录；或者走 GitHub OAuth。
+      </p>
       <form
-        className='grid max-w-[420px] gap-3'
+        className='mt-4'
         method='post'
         onSubmit={(event) => {
           event.preventDefault();
@@ -73,57 +74,63 @@ function LoginPage() {
           });
         }}
       >
-        <label htmlFor='email' className='font-semibold'>
-          Email
-        </label>
-        <input
-          id='email'
-          name='email'
-          type='email'
-          required
-          autoComplete='email'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-        />
-        <label htmlFor='password' className='font-semibold'>
-          Password
-        </label>
-        <input
-          id='password'
-          name='password'
-          type='password'
-          required
-          autoComplete='current-password'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={password}
-          onChange={(event) => setPassword(event.target.value)}
-        />
-        <button
-          type='submit'
-          className='rounded-md bg-black px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90 dark:bg-neutral-900'
-          disabled={isPending}
-        >
-          {isPending ? 'Signing in...' : 'Sign In'}
-        </button>
+        <div className='th-field'>
+          <label htmlFor='email'>email</label>
+          <input
+            id='email'
+            name='email'
+            type='email'
+            required
+            autoComplete='email'
+            className='th-input'
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+          />
+        </div>
+        <div className='th-field'>
+          <label htmlFor='password'>password</label>
+          <input
+            id='password'
+            name='password'
+            type='password'
+            required
+            autoComplete='current-password'
+            className='th-input'
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+          />
+        </div>
+        <div className='mt-5 flex flex-wrap gap-3'>
+          <button
+            type='submit'
+            className='th-btn th-btn-primary'
+            disabled={isPending}
+          >
+            {isPending ? 'signing in…' : 'sign in'}
+          </button>
+          <button
+            type='button'
+            className='th-btn'
+            onClick={async () => {
+              setError(null);
+              const result = await authClient.signIn.social({
+                provider: 'github',
+                callbackURL: '/blog',
+              });
+              if (result.error) {
+                setError(result.error.message ?? 'GitHub 登录失败');
+              }
+            }}
+          >
+            continue with github
+          </button>
+        </div>
+        {error ? <p className='th-err'>{error}</p> : null}
       </form>
-
-      <button
-        type='button'
-        className='mt-3 rounded-md border border-slate-300 px-4 py-2 font-semibold transition-colors hover:bg-gray-100 dark:border-slate-700 dark:hover:bg-slate-800'
-        onClick={async () => {
-          setError(null);
-          const result = await authClient.signIn.social({
-            provider: 'github',
-            callbackURL: '/blog',
-          });
-          if (result.error) {
-            setError(result.error.message ?? 'GitHub 登录失败');
-          }
-        }}
-      >
-        Continue with GitHub
-      </button>
-    </section>
+      <p className='th-out mt-4'>
+        <span className='th-comment'># 还没有账号？</span>{' '}
+        <a href='/signup'>signup</a>
+      </p>
+    </div>
   );
 }

--- a/apps/web/src/routes/projects.tsx
+++ b/apps/web/src/routes/projects.tsx
@@ -1,5 +1,4 @@
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { ExternalLink, Github } from 'lucide-react';
 import { PROJECTS, type Project } from '../lib/projects.js';
 
 export const Route = createFileRoute('/projects')({
@@ -25,67 +24,60 @@ function ProjectsPage() {
   const projects = sortProjects(PROJECTS);
 
   return (
-    <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>Projects</h1>
-      <p className='mb-8 opacity-70'>我做过的一些东西，按需更新。</p>
+    <div className='th-page'>
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>perfectpan</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>blog</span>{' '}
+        <span className='th-prompt-p'>~ %</span>{' '}
+        <span className='th-cmd'>ls -la ~/projects</span>
+      </div>
 
-      <div className='grid gap-4 sm:grid-cols-2'>
+      <div className='th-ls mt-3'>
+        <div className='th-ls-proj th-ls-proj-head'>
+          <span>star</span>
+          <span>project</span>
+          <span className='text-right'>stack</span>
+          <span>link</span>
+        </div>
         {projects.map((project) => (
-          <article
-            key={project.name}
-            className='flex flex-col rounded-lg border border-slate-200 bg-white/60 p-5 transition-shadow hover:shadow-md dark:border-slate-700 dark:bg-wash-dark'
-          >
-            <div className='mb-1 flex items-center gap-2'>
-              <h2 className='text-lg font-semibold'>{project.name}</h2>
-              {project.featured ? (
-                <span className='rounded-full bg-black px-2 py-[2px] text-[10px] font-semibold text-white dark:bg-neutral-100 dark:text-neutral-900'>
-                  FEATURED
-                </span>
-              ) : null}
-            </div>
-            <p className='mb-4 flex-grow text-sm opacity-70'>
-              {project.description}
-            </p>
-            <div className='mb-4 flex flex-wrap gap-1.5'>
-              {project.tags.map((tag) => (
-                <span
-                  key={tag}
-                  className='rounded-md border border-slate-200 px-2 py-[2px] text-[11px] opacity-70 dark:border-slate-700'
-                >
-                  {tag}
-                </span>
-              ))}
-            </div>
-            <div className='flex items-center gap-4 text-sm'>
-              <a
-                href={project.repo}
-                target='_blank'
-                rel='noreferrer'
-                className='inline-flex items-center gap-1 opacity-70 hover:opacity-100'
-              >
-                <Github size={15} />
-                Code
+          <div key={project.name} className='th-ls-proj'>
+            <span className={project.featured ? 'th-perm-pw' : 'th-comment'}>
+              {project.featured ? '★' : ' '}
+            </span>
+            <span>
+              <span className='th-ls-title'>{project.name}</span>
+              <span className='th-comment'> — {project.description}</span>
+            </span>
+            <span className='th-ls-tags text-right'>
+              {project.tags.join(' · ')}
+            </span>
+            <span className='th-ls-link'>
+              <a href={project.repo} target='_blank' rel='noreferrer'>
+                code ↗
               </a>
               {project.demo ? (
-                <a
-                  href={project.demo}
-                  target='_blank'
-                  rel='noreferrer'
-                  className='inline-flex items-center gap-1 opacity-70 hover:opacity-100'
-                >
-                  <ExternalLink size={15} />
-                  Demo
-                </a>
+                <>
+                  {' '}
+                  <a href={project.demo} target='_blank' rel='noreferrer'>
+                    demo ↗
+                  </a>
+                </>
               ) : null}
-            </div>
-          </article>
+            </span>
+          </div>
         ))}
       </div>
 
-      <Link to='/' className='mt-8 inline-block'>
-        <span className='opacity-70'>&gt;&nbsp;&nbsp;&nbsp;</span>
-        <span className='underline opacity-70 hover:opacity-100'>cd ..</span>
-      </Link>
+      <div className='th-prompt mt-6'>
+        <span className='th-prompt-u'>perfectpan</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>blog</span>{' '}
+        <span className='th-prompt-p'>~ %</span>{' '}
+        <Link to='/' className='th-cmd th-cmd-dim'>
+          cd ..
+        </Link>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/routes/signup.tsx
+++ b/apps/web/src/routes/signup.tsx
@@ -35,25 +35,26 @@ function SignUpPage() {
 
   if (sessionData?.user?.id || isSessionPending) {
     return (
-      <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-        <p className='opacity-70'>Checking session...</p>
-      </section>
+      <div className='th-page'>
+        <p className='th-comment'># checking session…</p>
+      </div>
     );
   }
 
   return (
-    <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>注册</h1>
-      <p className='mb-6 opacity-70'>注册后默认角色为 member，可在后台升权。</p>
-
-      {error ? (
-        <p role='alert' className='mb-4 text-sm text-red-700 dark:text-red-300'>
-          {error}
-        </p>
-      ) : null}
-
+    <div className='th-page'>
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>guest</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>perfectpan.org</span>{' '}
+        <span className='th-prompt-p'>~ %</span>{' '}
+        <span className='th-cmd'>useradd --join</span>
+      </div>
+      <p className='th-out th-comment mt-2'>
+        # 注册成为 member，可读 member 可见性的文章。
+      </p>
       <form
-        className='grid max-w-[420px] gap-3'
+        className='mt-4'
         method='post'
         onSubmit={(event) => {
           event.preventDefault();
@@ -75,53 +76,72 @@ function SignUpPage() {
           });
         }}
       >
-        <label htmlFor='name' className='font-semibold'>
-          Name
-        </label>
-        <input
-          id='name'
-          name='name'
-          type='text'
-          required
-          autoComplete='name'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={name}
-          onChange={(event) => setName(event.target.value)}
-        />
-        <label htmlFor='email' className='font-semibold'>
-          Email
-        </label>
-        <input
-          id='email'
-          name='email'
-          type='email'
-          required
-          autoComplete='email'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-        />
-        <label htmlFor='password' className='font-semibold'>
-          Password
-        </label>
-        <input
-          id='password'
-          name='password'
-          type='password'
-          required
-          autoComplete='new-password'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={password}
-          onChange={(event) => setPassword(event.target.value)}
-        />
-        <button
-          type='submit'
-          className='rounded-md bg-black px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90 dark:bg-neutral-900'
-          disabled={isPending}
-        >
-          {isPending ? 'Creating account...' : 'Sign Up'}
-        </button>
+        <div className='th-field'>
+          <label htmlFor='name'>name</label>
+          <input
+            id='name'
+            name='name'
+            type='text'
+            required
+            autoComplete='name'
+            className='th-input'
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+          />
+        </div>
+        <div className='th-field'>
+          <label htmlFor='email'>email</label>
+          <input
+            id='email'
+            name='email'
+            type='email'
+            required
+            autoComplete='email'
+            className='th-input'
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+          />
+        </div>
+        <div className='th-field'>
+          <label htmlFor='password'>password</label>
+          <input
+            id='password'
+            name='password'
+            type='password'
+            required
+            autoComplete='new-password'
+            className='th-input'
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+          />
+        </div>
+        <div className='mt-5 flex flex-wrap gap-3'>
+          <button
+            type='submit'
+            className='th-btn th-btn-primary'
+            disabled={isPending}
+          >
+            {isPending ? 'creating…' : 'create account'}
+          </button>
+          <button
+            type='button'
+            className='th-btn'
+            onClick={async () => {
+              setError(null);
+              const result = await authClient.signIn.social({
+                provider: 'github',
+                callbackURL: '/blog',
+              });
+              if (result.error) {
+                setError(result.error.message ?? 'GitHub 注册失败');
+              }
+            }}
+          >
+            continue with github
+          </button>
+        </div>
+        {error ? <p className='th-err'>{error}</p> : null}
       </form>
-    </section>
+    </div>
   );
 }

--- a/apps/web/src/routes/unlock/$slug.tsx
+++ b/apps/web/src/routes/unlock/$slug.tsx
@@ -82,44 +82,43 @@ function UnlockPage() {
         : undefined;
 
   return (
-    <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>输入文章访问密码</h1>
-      <p className='mb-6 opacity-70'>这篇文章使用了单文密码保护。</p>
-
-      {errorLabel ? (
-        <p role='alert' className='mb-4 text-sm text-red-700 dark:text-red-300'>
-          {errorLabel}
-        </p>
-      ) : null}
-
-      <form method='post' className='grid max-w-[420px] gap-3'>
-        <label htmlFor='password' className='font-semibold'>
-          Password
-        </label>
-        <input
-          id='password'
-          name='password'
-          type='password'
-          required
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-        />
-        <button
-          type='submit'
-          className='rounded-md bg-black px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90 dark:bg-neutral-900'
-        >
-          Unlock
-        </button>
-      </form>
-
-      <p className='mt-4'>
-        <Link
-          to='/blog/$slug'
-          params={{ slug }}
-          className='opacity-70 hover:opacity-100'
-        >
-          返回文章页
-        </Link>
+    <div className='th-page'>
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>guest</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>perfectpan.org</span>{' '}
+        <span className='th-prompt-p'>~ %</span>{' '}
+        <span className='th-cmd'>cat posts/{slug}.md</span>
+      </div>
+      <p className='th-out'>
+        <span className='th-nf-big'>
+          cat: posts/{slug}.md: Permission denied
+        </span>
       </p>
-    </section>
+      <p className='th-out th-comment'>
+        # 这篇文章是密码保护的。输入单文密码后 24 小时内免密阅读。
+      </p>
+      <form method='post' className='mt-4'>
+        <div className='th-field'>
+          <label htmlFor='password'>password for this post</label>
+          <input
+            id='password'
+            name='password'
+            type='password'
+            required
+            className='th-input'
+          />
+        </div>
+        <div className='mt-5 flex flex-wrap items-center gap-3'>
+          <button type='submit' className='th-btn th-btn-primary'>
+            sudo unlock
+          </button>
+          <Link to='/blog/$slug' params={{ slug }} className='th-cd'>
+            ← 返回文章
+          </Link>
+        </div>
+        {errorLabel ? <p className='th-err'>{errorLabel}</p> : null}
+      </form>
+    </div>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -939,3 +939,105 @@ html.dark .md pre.th-pre span {
   font-size: 13px;
   margin-bottom: 18px;
 }
+
+/* ---------- terminal search palette (grep) ---------- */
+/* Scoped reskin of the shadcn Dialog + cmdk palette: drop from the top like a
+   terminal window, mono throughout, `~ %` prompt instead of a magnifier. */
+.th-pal {
+  top: 14vh;
+  transform: none;
+  translate: -50% 0;
+  max-width: min(640px, calc(100vw - 32px));
+  border: 1px solid var(--t-line);
+  border-radius: 10px;
+  background: var(--t-term);
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.35);
+  font-family: var(--t-mono);
+}
+.th-pal > button {
+  display: none; /* terminals close with esc, not an ✕ */
+}
+.th-pal-cmd {
+  background: var(--t-term);
+  color: var(--t-text);
+  border-radius: 10px;
+  overflow: hidden;
+}
+.th-pal [cmdk-input-wrapper] {
+  border-bottom: 1px dashed var(--t-line);
+  padding: 13px 16px;
+  gap: 10px;
+}
+.th-pal [cmdk-input-wrapper] svg {
+  display: none;
+}
+.th-pal [cmdk-input-wrapper]::before {
+  content: "~ %";
+  color: var(--t-amber);
+  font-family: var(--t-mono);
+  font-size: 15px;
+  flex: none;
+}
+.th-pal [cmdk-input] {
+  height: auto;
+  font-family: var(--t-mono);
+  font-size: 15px;
+  color: var(--t-text);
+  caret-color: var(--t-amber);
+  padding: 0;
+}
+.th-pal [cmdk-input]::placeholder {
+  color: var(--t-faint);
+}
+.th-pal [cmdk-list] {
+  height: auto;
+  max-height: 320px;
+  padding: 6px 0;
+}
+.th-pal [cmdk-empty] {
+  padding: 18px 16px;
+  text-align: left;
+  color: var(--t-faint);
+  font-size: 13px;
+}
+.th-pal [cmdk-group] {
+  padding: 0 8px;
+}
+.th-pal [cmdk-item] {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  padding: 8px 10px;
+  border-radius: 4px;
+  font-family: var(--t-mono);
+  font-size: 14px;
+  color: var(--t-text);
+}
+.th-pal-date {
+  color: var(--t-faint);
+  font-size: 11.5px;
+  min-width: 6ch;
+}
+.th-pal-title {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.th-pal-vis {
+  color: var(--t-dim);
+  font-size: 11px;
+}
+.th-pal [cmdk-item][aria-selected="true"] {
+  background: var(--t-sel);
+  color: var(--t-text);
+}
+.th-pal [cmdk-item][aria-selected="true"] .th-pal-title {
+  color: var(--t-amber);
+}
+.th-pal-foot {
+  border-top: 1px solid var(--t-line);
+  padding: 7px 16px;
+  color: var(--t-faint);
+  font-size: 11.5px;
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -149,12 +149,59 @@ html.dark ::-webkit-scrollbar-thumb:hover {
  * THEME A — Terminal Session (UX redesign direction A)
  * The site is one persistent terminal session: title bar header, tmux
  * status bar footer, `ls -la` post list with permission bits encoding
- * visibility. Dark-native: html renders with .dark by default (root.tsx)
- * so existing dark: variants and shiki dual-themes stay coherent.
+ * visibility. Dual theme: LIGHT paper-terminal by default, dark via the
+ * header toggle (html.dark).
  * =================================================================== */
-:root,
-.dark {
-  /* shadcn token layer → terminal palette (search palette & dialogs) */
+:root {
+  /* shadcn token layer → terminal LIGHT palette (search palette & dialogs) */
+  --background: 45 25% 95%;
+  --foreground: 215 15% 22%;
+  --card: 45 30% 97%;
+  --card-foreground: 215 15% 22%;
+  --popover: 45 30% 98%;
+  --popover-foreground: 215 15% 22%;
+  --primary: 39 62% 42%;
+  --primary-foreground: 45 30% 97%;
+  --secondary: 45 20% 91%;
+  --secondary-foreground: 215 15% 22%;
+  --muted: 45 20% 91%;
+  --muted-foreground: 215 8% 42%;
+  --accent: 45 20% 88%;
+  --accent-foreground: 215 15% 22%;
+  --destructive: 2 56% 48%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 43 16% 82%;
+  --input: 43 16% 82%;
+  --ring: 39 62% 42%;
+  --radius: 0.375rem;
+
+  /* terminal LIGHT (paper terminal): default */
+  --t-bg: #f4f2ec;
+  --t-term: #fbfaf7;
+  --t-panel: #f0ede5;
+  --t-line: #ddd8cb;
+  --t-text: #33363b;
+  --t-dim: #6f7480;
+  --t-faint: #a6a49a;
+  --t-amber: #a8752b;
+  --t-cyan: #0e7d92;
+  --t-green: #3c7a52;
+  --t-red: #b8483f;
+  --t-violet: #7a5fa8;
+  --t-sel: #ece7da;
+  --t-titlebar-a: #f7f5ef;
+  --t-titlebar-b: #f4f2ec;
+  --t-tmux-bg: #eeebe2;
+  --t-tmux-ink: #33363b;
+  --t-pre-bg: #fbfaf7;
+  --t-amber-ink: #fbfaf7;
+  --t-mono:
+    ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo, Consolas,
+    "PingFang SC", "Microsoft YaHei", monospace;
+}
+
+html.dark {
+  /* shadcn token layer → terminal DARK palette */
   --background: 210 29% 7%;
   --foreground: 210 20% 83%;
   --card: 211 30% 10%;
@@ -174,10 +221,8 @@ html.dark ::-webkit-scrollbar-thumb:hover {
   --border: 211 26% 17%;
   --input: 211 26% 17%;
   --ring: 39 77% 60%;
-  --radius: 0.375rem;
-}
 
-:root {
+  /* terminal DARK (original) */
   --t-bg: #0a0f14;
   --t-term: #0c1218;
   --t-panel: #101923;
@@ -191,15 +236,17 @@ html.dark ::-webkit-scrollbar-thumb:hover {
   --t-red: #e06c75;
   --t-violet: #a78bc4;
   --t-sel: #16222e;
-  --t-mono:
-    ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo, Consolas,
-    "PingFang SC", "Microsoft YaHei", monospace;
+  --t-titlebar-a: #0e1620;
+  --t-titlebar-b: #0c1218;
+  --t-tmux-bg: #10161d;
+  --t-tmux-ink: #0a0f14;
+  --t-pre-bg: #0a1016;
+  --t-amber-ink: #171106;
 }
 
-html,
-html.dark {
+html {
   background-color: var(--t-bg);
-  scrollbar-color: #24313e var(--t-bg);
+  scrollbar-color: var(--t-line) var(--t-bg);
 }
 
 html body {
@@ -227,7 +274,7 @@ html body {
   gap: 8px;
   padding: 10px 18px;
   border-bottom: 1px solid var(--t-line);
-  background: linear-gradient(#0e1620, #0c1218);
+  background: linear-gradient(var(--t-titlebar-a), var(--t-titlebar-b));
 }
 
 .th-dot {
@@ -283,7 +330,7 @@ html body {
   font-size: 12.5px;
 }
 .th-tmux-sess {
-  color: #0a0f14;
+  color: var(--t-tmux-ink);
   background: var(--t-green);
   padding: 1px 8px;
   border-radius: 3px;
@@ -388,7 +435,7 @@ a.th-tmux-win:hover {
 }
 .th-role-badge {
   background: var(--t-amber);
-  color: #171106;
+  color: var(--t-amber-ink);
   border-radius: 999px;
   font-size: 10px;
   font-weight: 700;
@@ -740,7 +787,7 @@ a.th-ls-row:hover {
   align-items: center;
   gap: 4px;
   border: 1px solid var(--t-line);
-  background: rgba(16, 25, 35, 0.85);
+  background: var(--t-panel);
   color: var(--t-dim);
   border-radius: 4px;
   padding: 2px 8px;
@@ -769,15 +816,18 @@ a.th-ls-row:hover {
   font-size: 13px;
   margin: 0;
 }
-/* shiki writes inline light bg/color on <pre>; force the terminal panel. */
+/* shiki writes inline light bg on <pre>; force the themed panel (light keeps
+   the vitesse-light tokens, dark swaps to vitesse-dark via the span rule). */
 .md pre.th-pre {
   /* biome-ignore lint/complexity/noImportantStyles: shiki inline light bg must be overridden. */
-  background: #0a1016 !important;
-  /* biome-ignore lint/complexity/noImportantStyles: shiki inline light color must be overridden. */
+  background: var(--t-pre-bg) !important;
+}
+html.dark .md pre.th-pre {
+  /* biome-ignore lint/complexity/noImportantStyles: shiki inline light color must be overridden in dark mode. */
   color: var(--t-text) !important;
 }
-.md pre.th-pre span {
-  /* biome-ignore lint/complexity/noImportantStyles: force shiki dark tokens without html.dark (SSR-safe). */
+html.dark .md pre.th-pre span {
+  /* biome-ignore lint/complexity/noImportantStyles: force shiki dark tokens in dark mode (SSR-safe). */
   color: var(--shiki-dark) !important;
 }
 .md .th-pre code {
@@ -839,7 +889,7 @@ a.th-ls-row:hover {
 }
 .th-cmt-replies {
   border-top: 1px dashed var(--t-line);
-  background: rgba(16, 25, 35, 0.45);
+  background: var(--t-sel);
   padding: 10px 14px;
   display: flex;
   flex-direction: column;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -194,6 +194,7 @@ html.dark ::-webkit-scrollbar-thumb:hover {
   --t-tmux-bg: #eeebe2;
   --t-tmux-ink: #33363b;
   --t-pre-bg: #fbfaf7;
+  --t-heading: #2b2f36;
   --t-amber-ink: #fbfaf7;
   --t-mono:
     ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo, Consolas,
@@ -241,6 +242,7 @@ html.dark {
   --t-tmux-bg: #10161d;
   --t-tmux-ink: #0a0f14;
   --t-pre-bg: #0a1016;
+  --t-heading: #eaf1f7;
   --t-amber-ink: #171106;
 }
 
@@ -326,7 +328,7 @@ html body {
   flex-wrap: wrap;
   padding: 6px 14px;
   border-top: 1px solid var(--t-line);
-  background: #10161d;
+  background: var(--t-tmux-bg);
   font-size: 12.5px;
 }
 .th-tmux-sess {
@@ -515,7 +517,7 @@ a.th-tmux-win:hover {
 /* ---------- home ---------- */
 .th-hero-name {
   font-size: 21px;
-  color: #eaf1f7;
+  color: var(--t-heading);
   font-weight: 700;
   margin-top: 12px;
 }
@@ -698,7 +700,7 @@ a.th-ls-row:hover {
 }
 .th-art-title {
   font-size: 24px;
-  color: #eaf1f7;
+  color: var(--t-heading);
   font-weight: 700;
   line-height: 1.4;
 }
@@ -721,7 +723,7 @@ a.th-ls-row:hover {
 }
 .md h2 {
   font-size: 17px;
-  color: #eaf1f7;
+  color: var(--t-heading);
   font-weight: 700;
   margin: 30px 0 10px;
   scroll-margin-top: 20px;
@@ -807,7 +809,7 @@ a.th-ls-row:hover {
   }
 }
 .md pre.th-pre {
-  background: #0a1016;
+  background: var(--t-pre-bg);
   border: 1px solid var(--t-line);
   border-radius: 8px;
   padding: 18px;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -776,6 +776,10 @@ a.th-ls-row:hover {
   /* biome-ignore lint/complexity/noImportantStyles: shiki inline light color must be overridden. */
   color: var(--t-text) !important;
 }
+.md pre.th-pre span {
+  /* biome-ignore lint/complexity/noImportantStyles: force shiki dark tokens without html.dark (SSR-safe). */
+  color: var(--shiki-dark) !important;
+}
 .md .th-pre code {
   background: none;
   padding: 0;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -144,3 +144,744 @@ html.dark ::-webkit-scrollbar-thumb {
 html.dark ::-webkit-scrollbar-thumb:hover {
   background: rgb(148 163 184 / 0.55);
 }
+
+/* =====================================================================
+ * THEME A — Terminal Session (UX redesign direction A)
+ * The site is one persistent terminal session: title bar header, tmux
+ * status bar footer, `ls -la` post list with permission bits encoding
+ * visibility. Dark-native: html renders with .dark by default (root.tsx)
+ * so existing dark: variants and shiki dual-themes stay coherent.
+ * =================================================================== */
+:root,
+.dark {
+  /* shadcn token layer → terminal palette (search palette & dialogs) */
+  --background: 210 29% 7%;
+  --foreground: 210 20% 83%;
+  --card: 211 30% 10%;
+  --card-foreground: 210 20% 83%;
+  --popover: 211 30% 9%;
+  --popover-foreground: 210 20% 83%;
+  --primary: 39 77% 60%;
+  --primary-foreground: 30 50% 8%;
+  --secondary: 211 30% 13%;
+  --secondary-foreground: 210 20% 83%;
+  --muted: 211 30% 13%;
+  --muted-foreground: 208 14% 56%;
+  --accent: 211 30% 15%;
+  --accent-foreground: 210 20% 88%;
+  --destructive: 2 66% 65%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 211 26% 17%;
+  --input: 211 26% 17%;
+  --ring: 39 77% 60%;
+  --radius: 0.375rem;
+}
+
+:root {
+  --t-bg: #0a0f14;
+  --t-term: #0c1218;
+  --t-panel: #101923;
+  --t-line: #1d2a37;
+  --t-text: #c9d4de;
+  --t-dim: #71828f;
+  --t-faint: #465666;
+  --t-amber: #e9b44c;
+  --t-cyan: #6fc5d8;
+  --t-green: #7cbf8b;
+  --t-red: #e06c75;
+  --t-violet: #a78bc4;
+  --t-sel: #16222e;
+  --t-mono:
+    ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo, Consolas,
+    "PingFang SC", "Microsoft YaHei", monospace;
+}
+
+html,
+html.dark {
+  background-color: var(--t-bg);
+  scrollbar-color: #24313e var(--t-bg);
+}
+
+html body {
+  font-family: var(--t-mono);
+  background-color: var(--t-bg);
+  color: var(--t-text);
+  font-size: 14.5px;
+  line-height: 1.75;
+}
+
+::selection {
+  background: rgba(233, 180, 76, 0.25);
+}
+
+/* ---------- shell: title bar / main / tmux bar ---------- */
+.th-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+}
+
+.th-titlebar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--t-line);
+  background: linear-gradient(#0e1620, #0c1218);
+}
+
+.th-dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+}
+.th-dot-r {
+  background: #e5544b;
+}
+.th-dot-y {
+  background: #d8a03c;
+}
+.th-dot-g {
+  background: #47a258;
+}
+
+.th-term-title {
+  margin-left: 10px;
+  color: var(--t-dim);
+  font-size: 12.5px;
+}
+.th-term-title b {
+  color: var(--t-text);
+  font-weight: 600;
+}
+.th-term-title .th-path {
+  color: var(--t-cyan);
+}
+
+.th-main {
+  flex: 1;
+  overflow-y: auto;
+  background: var(--t-term);
+}
+
+.th-page {
+  width: 100%;
+  max-width: 1020px;
+  margin: 0 auto;
+  padding: 26px 22px 46px;
+}
+
+/* ---------- tmux footer ---------- */
+.th-tmux {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+  padding: 6px 14px;
+  border-top: 1px solid var(--t-line);
+  background: #10161d;
+  font-size: 12.5px;
+}
+.th-tmux-sess {
+  color: #0a0f14;
+  background: var(--t-green);
+  padding: 1px 8px;
+  border-radius: 3px;
+  margin-right: 8px;
+  font-weight: 700;
+}
+.th-tmux-win {
+  color: var(--t-dim);
+  padding: 1px 8px;
+  border-radius: 3px;
+}
+a.th-tmux-win:hover {
+  color: var(--t-text);
+  text-decoration: none;
+}
+.th-tmux-win.th-on {
+  background: var(--t-term);
+  color: var(--t-amber);
+  box-shadow: inset 0 0 0 1px var(--t-line);
+}
+.th-tmux-right {
+  margin-left: auto;
+  color: var(--t-faint);
+  display: flex;
+  gap: 14px;
+}
+
+/* ---------- prompt primitives ---------- */
+.th-prompt {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+.th-prompt-u {
+  color: var(--t-cyan);
+}
+.th-prompt-at {
+  color: var(--t-faint);
+}
+.th-prompt-h {
+  color: var(--t-green);
+}
+.th-prompt-p {
+  color: var(--t-amber);
+}
+.th-cmd {
+  color: var(--t-text);
+}
+.th-cmd-dim {
+  color: var(--t-dim);
+}
+.th-out {
+  margin: 4px 0;
+}
+.th-comment {
+  color: var(--t-faint);
+}
+.th-hr {
+  border: 0;
+  border-top: 1px dashed var(--t-line);
+  margin: 20px 0;
+}
+
+/* ---------- titlebar tools ---------- */
+.th-tools {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.th-tool-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--t-dim);
+  background: none;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 13px;
+  font-family: inherit;
+}
+.th-tool-btn:hover {
+  color: var(--t-amber);
+  text-decoration: none;
+}
+.th-user-chip {
+  display: none;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--t-line);
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: 12px;
+  color: var(--t-dim);
+}
+@media (min-width: 768px) {
+  .th-user-chip {
+    display: inline-flex;
+  }
+}
+.th-role-badge {
+  background: var(--t-amber);
+  color: #171106;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 1px 7px;
+}
+
+/* ---------- buttons / forms ---------- */
+.th-btn {
+  font-family: var(--t-mono);
+  font-size: 13.5px;
+  cursor: pointer;
+  background: var(--t-panel);
+  color: var(--t-text);
+  border: 1px solid var(--t-line);
+  border-radius: 6px;
+  padding: 9px 18px;
+  transition:
+    border-color 0.12s,
+    color 0.12s;
+}
+.th-btn:hover {
+  border-color: var(--t-amber);
+  color: var(--t-amber);
+}
+.th-btn-primary {
+  background: var(--t-amber);
+  border-color: var(--t-amber);
+  color: #171106;
+  font-weight: 700;
+}
+.th-btn-primary:hover {
+  background: #f0c268;
+  color: #171106;
+}
+
+.th-field {
+  margin: 14px 0;
+  max-width: 460px;
+}
+.th-field label {
+  display: block;
+  color: var(--t-dim);
+  font-size: 13px;
+  margin-bottom: 5px;
+}
+.th-field label::before {
+  content: "▸ ";
+  color: var(--t-amber);
+}
+.th-input {
+  font-family: var(--t-mono);
+  font-size: 14px;
+  color: var(--t-text);
+  background: var(--t-panel);
+  border: 1px solid var(--t-line);
+  border-radius: 6px;
+  padding: 9px 12px;
+  width: 100%;
+}
+.th-input::placeholder {
+  color: var(--t-faint);
+}
+.th-input:focus {
+  outline: none;
+  border-color: var(--t-amber);
+  box-shadow: 0 0 0 2px rgba(233, 180, 76, 0.15);
+}
+.th-err {
+  color: var(--t-red);
+  margin: 10px 0;
+  font-size: 13.5px;
+}
+.th-err::before {
+  content: "✗ ";
+}
+
+/* ---------- home ---------- */
+.th-hero-name {
+  font-size: 21px;
+  color: #eaf1f7;
+  font-weight: 700;
+  margin-top: 12px;
+}
+.th-hero-desc {
+  color: var(--t-dim);
+  max-width: 62ch;
+  margin-top: 6px;
+}
+.th-figlet {
+  white-space: pre;
+  color: var(--t-faint);
+  line-height: 1.25;
+  font-size: 11px;
+  margin-top: 18px;
+  user-select: none;
+}
+.th-figlet b {
+  color: var(--t-amber);
+  font-weight: 400;
+}
+.th-home-links {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 12px;
+  margin-top: 22px;
+}
+.th-home-links a {
+  display: block;
+  border: 1px solid var(--t-line);
+  background: var(--t-panel);
+  padding: 14px 16px;
+  border-radius: 6px;
+  color: var(--t-text);
+}
+.th-home-links a:hover {
+  border-color: var(--t-amber);
+  text-decoration: none;
+  box-shadow: 0 0 18px rgba(233, 180, 76, 0.07);
+}
+.th-home-links .k {
+  color: var(--t-amber);
+}
+.th-home-links small {
+  display: block;
+  color: var(--t-dim);
+  margin-top: 2px;
+}
+
+/* ---------- ls table (blog list) ---------- */
+.th-ls {
+  margin-top: 12px;
+}
+.th-ls-row {
+  display: grid;
+  grid-template-columns: 11ch 7ch 8ch 1fr auto;
+  gap: 0 14px;
+  padding: 5px 8px;
+  border-radius: 4px;
+  align-items: baseline;
+}
+.th-ls-head {
+  color: var(--t-faint);
+  font-size: 12.5px;
+}
+a.th-ls-row {
+  color: var(--t-text);
+}
+a.th-ls-row:hover {
+  background: var(--t-sel);
+  text-decoration: none;
+}
+.th-ls-year {
+  grid-column: 1 / -1;
+  color: var(--t-amber);
+  margin-top: 20px;
+  font-weight: 700;
+}
+.th-ls-year::before {
+  content: "# ";
+  color: var(--t-faint);
+  font-weight: 400;
+}
+.th-perm {
+  letter-spacing: 0.08em;
+}
+.th-perm-pub {
+  color: var(--t-green);
+}
+.th-perm-mem {
+  color: var(--t-cyan);
+}
+.th-perm-vip {
+  color: var(--t-violet);
+}
+.th-perm-pw {
+  color: var(--t-red);
+}
+.th-perm-adm {
+  color: var(--t-dim);
+}
+.th-ls-date,
+.th-ls-vis {
+  color: var(--t-dim);
+  font-size: 13px;
+}
+.th-ls-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.th-ls-tags {
+  color: var(--t-faint);
+  font-size: 12.5px;
+}
+.th-legend {
+  margin-top: 26px;
+  color: var(--t-faint);
+  font-size: 12.5px;
+  line-height: 1.9;
+}
+.th-pager {
+  display: flex;
+  gap: 18px;
+  justify-content: center;
+  margin-top: 26px;
+  color: var(--t-dim);
+  font-size: 13.5px;
+}
+.th-pager a {
+  color: var(--t-amber);
+}
+.th-pager .th-pager-off {
+  color: var(--t-faint);
+  opacity: 0.6;
+}
+.th-cd {
+  color: var(--t-dim);
+}
+.th-cd:hover {
+  color: var(--t-text);
+}
+
+@media (max-width: 720px) {
+  .th-ls-row {
+    grid-template-columns: 11ch 7ch 1fr;
+  }
+  .th-ls-head,
+  .th-ls-vis,
+  .th-ls-tags {
+    display: none;
+  }
+}
+
+/* projects ls rows: star / project+desc / stack / links */
+.th-ls-proj {
+  display: grid;
+  grid-template-columns: 4ch 1fr 18ch auto;
+  gap: 0 16px;
+  padding: 8px;
+  border-radius: 4px;
+  align-items: baseline;
+}
+.th-ls-proj-head {
+  color: var(--t-faint);
+  font-size: 12.5px;
+}
+@media (max-width: 720px) {
+  .th-ls-proj {
+    grid-template-columns: 4ch 1fr;
+  }
+  .th-ls-proj .th-ls-tags,
+  .th-ls-proj .th-ls-link {
+    display: none;
+  }
+}
+
+/* ---------- article ---------- */
+.th-art-head {
+  margin: 16px 0 26px;
+}
+.th-art-title {
+  font-size: 24px;
+  color: #eaf1f7;
+  font-weight: 700;
+  line-height: 1.4;
+}
+.th-art-meta {
+  color: var(--t-dim);
+  margin-top: 6px;
+  font-size: 13px;
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+/* markdown body (article prose) */
+.md {
+  max-width: 74ch;
+}
+.md p {
+  margin: 14px 0;
+  color: var(--t-text);
+}
+.md h2 {
+  font-size: 17px;
+  color: #eaf1f7;
+  font-weight: 700;
+  margin: 30px 0 10px;
+  scroll-margin-top: 20px;
+}
+.md h2::before {
+  content: "## ";
+  color: var(--t-faint);
+  font-weight: 400;
+}
+.md h2 a {
+  color: inherit;
+}
+.md ul {
+  margin: 12px 0 12px 22px;
+  list-style: disc;
+}
+.md li {
+  margin: 4px 0;
+}
+.md li::marker {
+  color: var(--t-amber);
+}
+.md a {
+  color: var(--t-cyan);
+}
+.md a:hover {
+  text-decoration: underline;
+}
+.md blockquote {
+  border-left: 2px solid var(--t-amber);
+  background: var(--t-panel);
+  padding: 10px 16px;
+  margin: 16px 0;
+  color: var(--t-dim);
+  border-radius: 0 6px 6px 0;
+}
+.th-cmt-body code {
+  background: var(--t-panel);
+  border: 1px solid var(--t-line);
+  border-radius: 4px;
+  padding: 0 5px;
+  font-size: 0.9em;
+  color: var(--t-amber);
+}
+.md code.md-inline {
+  background: var(--t-panel);
+  border: 1px solid var(--t-line);
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 13px;
+  color: var(--t-amber);
+}
+.th-code {
+  position: relative;
+  margin: 18px 0;
+}
+.th-code-copy {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  z-index: 10;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid var(--t-line);
+  background: rgba(16, 25, 35, 0.85);
+  color: var(--t-dim);
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-family: var(--t-mono);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.th-code:hover .th-code-copy,
+.th-code-copy:focus-visible {
+  opacity: 1;
+}
+@media not (hover: hover) {
+  .th-code-copy {
+    opacity: 0.75;
+  }
+}
+.md pre.th-pre {
+  background: #0a1016;
+  border: 1px solid var(--t-line);
+  border-radius: 8px;
+  padding: 18px;
+  overflow-x: auto;
+  line-height: 1.7;
+  font-size: 13px;
+  margin: 0;
+}
+/* shiki writes inline light bg/color on <pre>; force the terminal panel. */
+.md pre.th-pre {
+  /* biome-ignore lint/complexity/noImportantStyles: shiki inline light bg must be overridden. */
+  background: #0a1016 !important;
+  /* biome-ignore lint/complexity/noImportantStyles: shiki inline light color must be overridden. */
+  color: var(--t-text) !important;
+}
+.md .th-pre code {
+  background: none;
+  padding: 0;
+}
+
+/* ---------- comments ---------- */
+.th-cmt {
+  border: 1px solid var(--t-line);
+  border-radius: 8px;
+  margin: 12px 0;
+  overflow: hidden;
+}
+.th-cmt-head {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  background: var(--t-panel);
+  padding: 8px 14px;
+  font-size: 13px;
+  color: var(--t-dim);
+  border-bottom: 1px solid var(--t-line);
+}
+.th-cmt-head .who {
+  color: var(--t-text);
+}
+.th-cmt-body {
+  padding: 10px 14px;
+}
+.th-cmt-body p {
+  margin: 0 0 8px;
+}
+.th-cmt-body p:last-child {
+  margin-bottom: 0;
+}
+.th-cmt-body blockquote {
+  border-left: 2px solid var(--t-line);
+  padding-left: 12px;
+  color: var(--t-dim);
+}
+.th-cmt-ops {
+  display: flex;
+  gap: 14px;
+  padding: 0 14px 10px;
+  font-size: 12px;
+}
+.th-cmt-ops button {
+  color: var(--t-dim);
+  cursor: pointer;
+  background: none;
+  font-family: inherit;
+}
+.th-cmt-ops button:hover {
+  color: var(--t-amber);
+}
+.th-cmt-ops .del:hover {
+  color: var(--t-red);
+}
+.th-cmt-replies {
+  border-top: 1px dashed var(--t-line);
+  background: rgba(16, 25, 35, 0.45);
+  padding: 10px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.th-cmt-reply {
+  border-left: 2px solid var(--t-line);
+  padding-left: 12px;
+}
+.th-cmt-form textarea {
+  width: 100%;
+  resize: vertical;
+  font-family: var(--t-mono);
+  font-size: 13.5px;
+  color: var(--t-text);
+  background: var(--t-panel);
+  border: 1px solid var(--t-line);
+  border-radius: 6px;
+  padding: 9px 12px;
+}
+.th-cmt-form textarea:focus {
+  outline: none;
+  border-color: var(--t-amber);
+}
+.th-cmt-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 8px;
+}
+.th-cmt-hint {
+  font-size: 12px;
+  color: var(--t-faint);
+}
+
+/* ---------- misc ---------- */
+.th-nf-big {
+  color: var(--t-red);
+}
+.th-devhint {
+  border: 1px dashed rgba(233, 180, 76, 0.5);
+  background: rgba(233, 180, 76, 0.06);
+  color: var(--t-amber);
+  border-radius: 6px;
+  padding: 8px 14px;
+  font-size: 13px;
+  margin-bottom: 18px;
+}

--- a/tests/e2e/admin-flow.spec.ts
+++ b/tests/e2e/admin-flow.spec.ts
@@ -19,7 +19,7 @@ test('admin can create a post that appears on the blog', async ({ page }) => {
   await page.locator('#password').fill(ADMIN_PASSWORD);
   await page.locator('form button[type="submit"]').click();
 
-  const loggedIn = page.getByRole('link', { name: /logout/i });
+  const loggedIn = page.getByTestId('nav-logout');
   try {
     await expect(loggedIn).toBeVisible({ timeout: 8000 });
   } catch {

--- a/tests/e2e/auth-logout.spec.ts
+++ b/tests/e2e/auth-logout.spec.ts
@@ -8,18 +8,20 @@ function createUniqueEmail(): string {
 test('signup then logout returns to guest header state', async ({ page }) => {
   await page.goto('/signup', { waitUntil: 'domcontentloaded' });
 
-  await page.getByLabel('Name').fill('E2E Logout');
-  await page.getByLabel('Email').fill(createUniqueEmail());
-  await page.getByLabel('Password').fill('Playwright!12345');
-  await page.getByRole('button', { name: 'Sign Up' }).click();
+  // Form anchors are theme-stable: field ids on /signup + the submit button.
+  // Header anchors use data-testid because each UX theme words them
+  // differently (login / 入会 / SIGN IN …).
+  await page.locator('#name').fill('E2E Logout');
+  await page.locator('#email').fill(createUniqueEmail());
+  await page.locator('#password').fill('Playwright!12345');
+  await page.locator('form button[type="submit"]').click();
 
   await page.waitForURL('**/blog');
-  await expect(page.getByRole('link', { name: 'Logout' })).toBeVisible();
+  await expect(page.getByTestId('nav-logout')).toBeVisible();
 
-  await page.getByRole('link', { name: 'Logout' }).click();
+  await page.getByTestId('nav-logout').click();
 
   await page.waitForURL('**/blog');
-  await expect(page.getByRole('link', { name: 'Login' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Sign Up' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Logout' })).toHaveCount(0);
+  await expect(page.getByTestId('nav-login')).toBeVisible();
+  await expect(page.getByTestId('nav-logout')).toHaveCount(0);
 });


### PR DESCRIPTION
## What — UX 改版方向 A「终端会话」落地

把原型 `prototypes/a-terminal.html` 落到真实应用：站点是一个 tmux 会话。

- **壳**：顶栏 = 终端 title bar（红黄绿圆点 + session 名），底栏 = tmux 状态栏（可点击的窗口导航 0:home / 1:posts / 2:projects / 3:admin）
- **博客列表** = `ls -la`：**文件权限位表示可见性**（`-r--r--r--` public / `-r--r-----` member / `-r----r--` vip / `-r--------` password），年份是 `# 2023` 注释行，底部有图例
- **文章页** = `cat <year>/<slug>.md`，评论区 = `comments --on <slug>`
- **登录** = `ssh member@perfectpan.org`；**解锁** = `Permission denied` + `sudo unlock`；**404** = `bash: cd /nowhere: No such file or directory`
- 等宽字体、琥珀色光标色系、暗色原生（默认渲染 `.dark`，隐藏主题切换；shiki 双主题代码块已适配）
- ⌘K 搜索面板通过 shadcn tokens 重皮肤为终端配色

## 不变的东西

路由 / loader / 鉴权 / 评论 / 搜索逻辑全部未动，仅视觉层。Admin 后台沿用现有 `dark:` 变体（暗色协调）。

## 验证

- [x] `pnpm typecheck` / `pnpm lint`（biome 0 warning）/ `pnpm test`（36 passed）
- [x] `pnpm --filter @blog/web build` + 体积守门：**gzip 1025 KiB / 3072 KiB**
- [x] 本地 dev 冒烟：`/`、`/blog`、`/blog/:slug`、`/projects`、`/login`、`/unlock/:slug`、404 全部渲染正常（已截图检查）

> 本 PR 是 7 个候选方向之一（A–G），最终只会合并一个或全部关闭。预览请用 Workers Builds 的 preview URL。