### PR TITLE
feat(web): apply literary journal theme (UX direction B)

### DIFF
--- a/apps/web/src/components/comments.tsx
+++ b/apps/web/src/components/comments.tsx
@@ -20,14 +20,6 @@ type CommentsProps = {
 
 const PAGE_SIZE = 20;
 
-function getInitials(name: string): string {
-  const trimmed = name.trim();
-  if (!trimmed) {
-    return '?';
-  }
-  return trimmed.slice(0, 1).toUpperCase();
-}
-
 function formatRelative(iso: string): string {
   const then = new Date(iso).getTime();
   if (Number.isNaN(then)) {
@@ -54,24 +46,6 @@ function formatRelative(iso: string): string {
     day: 'numeric',
     year: 'numeric',
   });
-}
-
-function Avatar({ name, image }: { name: string; image: string | null }) {
-  if (image) {
-    return (
-      <img
-        src={image}
-        alt={name}
-        loading='lazy'
-        className='h-8 w-8 shrink-0 rounded-full bg-zinc-100 dark:bg-zinc-800'
-      />
-    );
-  }
-  return (
-    <div className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-zinc-200 text-xs font-semibold text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300'>
-      {getInitials(name)}
-    </div>
-  );
 }
 
 type ComposerProps = {
@@ -107,26 +81,25 @@ function Composer({
   }
 
   return (
-    <form onSubmit={handleSubmit} className='flex flex-col gap-2'>
+    <form onSubmit={handleSubmit} className='j-cmt-form flex flex-col gap-2'>
       <textarea
         value={body}
         onChange={(event) => setBody(event.target.value)}
         placeholder={placeholder}
         rows={compact ? 2 : 3}
         maxLength={2000}
-        className='w-full resize-y rounded-md border border-zinc-300 bg-transparent px-3 py-2 text-sm outline-none transition-colors focus:border-zinc-400 dark:border-zinc-600 dark:focus:border-zinc-400'
       />
-      <div className='flex items-center justify-between gap-2'>
-        <span className='text-xs opacity-50'>
-          {remaining < 200 ? `${remaining} 字剩余` : '支持 Markdown'}
-          {error ? <span className='ml-2 text-red-500'>{error}</span> : null}
+      <div className='j-cmt-foot'>
+        <span className='j-cmt-hint'>
+          {remaining < 200 ? `${remaining} 字剩余` : '来函支持 Markdown'}
+          {error ? <span className='j-err'>{error}</span> : null}
         </span>
         <button
           type='submit'
           disabled={submitting || !body.trim()}
-          className='rounded-md bg-black px-3 py-1 text-xs font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-neutral-900'
+          className='j-btn j-btn-red'
         >
-          {submitting ? '发送中…' : '发送'}
+          {submitting ? '投递中…' : '投　函'}
         </button>
       </div>
     </form>
@@ -191,7 +164,7 @@ function CommentItem({
       ) : null}
 
       {thread.replies.length > 0 ? (
-        <ul className='ml-10 flex flex-col gap-2 border-l border-zinc-200 pl-4 dark:border-zinc-700'>
+        <ul className='flex flex-col gap-2'>
           {thread.replies.map((reply) => {
             const replyCanAct =
               sessionUser != null &&
@@ -201,6 +174,7 @@ function CommentItem({
                 key={reply.id}
                 comment={reply}
                 canAct={replyCanAct}
+                canReply={false}
                 onReply={undefined}
                 onDelete={async () => {
                   if (!window.confirm('删除这条回复？')) {
@@ -232,50 +206,42 @@ function CommentView({
   onReply,
   onDelete,
 }: CommentViewProps) {
+  const isReply = comment.parentId !== null;
+
   return (
-    <div className='flex gap-3'>
-      <Avatar name={comment.author.name} image={comment.author.image} />
-      <div className='min-w-0 flex-1'>
-        <div className='flex flex-wrap items-center gap-x-2 gap-y-0.5'>
-          <span className='text-sm font-semibold'>{comment.author.name}</span>
-          {comment.author.role === 'admin' ? (
-            <span className='rounded bg-zinc-900 px-1.5 py-0.5 text-[10px] font-semibold text-white dark:bg-white dark:text-zinc-900'>
-              Author
-            </span>
-          ) : null}
-          {comment.status !== 'visible' ? (
-            <span className='rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'>
-              {comment.status}
-            </span>
-          ) : null}
-          <span className='text-xs opacity-50'>
-            {formatRelative(comment.createdAt)}
-          </span>
-        </div>
-        <div className='mt-1'>
-          <CommentMarkdown content={comment.body} />
-        </div>
-        <div className='mt-1 flex gap-3 text-xs'>
-          {canReply && onReply ? (
-            <button
-              type='button'
-              onClick={onReply}
-              className='opacity-50 transition-opacity hover:opacity-100'
-            >
-              回复
-            </button>
-          ) : null}
+    <div className={isReply ? 'j-letter j-letter-reply' : 'j-letter'}>
+      <div className='j-lhead'>
+        <span className='who'>{comment.author.name}</span>
+        {comment.author.role === 'admin' ? (
+          <span className='badge'>作者</span>
+        ) : null}
+        {comment.status !== 'visible' ? (
+          <span style={{ color: 'var(--j-red)' }}>{comment.status}</span>
+        ) : null}
+        <span className='when'>{formatRelative(comment.createdAt)}</span>
+      </div>
+      <div className='j-lbody'>
+        <CommentMarkdown content={comment.body} />
+      </div>
+      {canReply && onReply ? (
+        <div className='j-lops'>
+          <button type='button' onClick={onReply}>
+            回复
+          </button>
           {canAct ? (
-            <button
-              type='button'
-              onClick={() => onDelete()}
-              className='text-red-500/70 transition-colors hover:text-red-500'
-            >
+            <button type='button' onClick={() => onDelete()}>
               删除
             </button>
           ) : null}
         </div>
-      </div>
+      ) : null}
+      {!(canReply && onReply) && canAct ? (
+        <div className='j-lops'>
+          <button type='button' onClick={() => onDelete()}>
+            删除
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -316,7 +282,7 @@ export function Comments({
     setReplySubmitting((prev) => new Set(prev).add(parentId));
     try {
       const { comment } = await createCommentServerFn({
-        data: { slug, parentId, body },
+        data: { slug, body, parentId },
       });
       setThreads((prev) =>
         prev.map((thread) =>
@@ -375,38 +341,42 @@ export function Comments({
   }
 
   return (
-    <section className='mt-12'>
-      <h2 className='mb-4 text-lg font-black'>
-        评论 {total > 0 ? <span className='opacity-50'>({total})</span> : null}
-      </h2>
+    <section className='mt-10'>
+      <h3 className='j-blockhead'>
+        读 者 来 函 {total > 0 ? `(${total})` : ''}
+      </h3>
 
       {sessionUser ? (
         <div className='mb-6'>
           <Composer
-            placeholder='写下你的评论…（支持 Markdown）'
+            placeholder='来函一句（支持 Markdown）……'
             submitting={submitting}
             onSubmit={handleCreateTopLevel}
           />
         </div>
       ) : (
-        <p className='mb-6 text-sm opacity-60'>
-          <Link to='/login' className='underline hover:opacity-100'>
-            登录
+        <p
+          className='mb-6 text-sm'
+          style={{ color: 'var(--j-faded)', fontFamily: 'var(--j-sans)' }}
+        >
+          <Link to='/login' className='underline'>
+            入会
           </Link>{' '}
-          后即可评论。
+          后即可来函。
         </p>
       )}
 
-      {topError ? (
-        <p className='mb-4 text-sm text-red-500'>{topError}</p>
-      ) : null}
+      {topError ? <p className='j-err mb-4'>{topError}</p> : null}
 
       {threads.length === 0 ? (
-        <p className='py-8 text-center text-sm opacity-50'>
-          还没有评论，来抢沙发。
+        <p
+          className='py-8 text-center text-sm'
+          style={{ color: 'var(--j-faint)', fontFamily: 'var(--j-sans)' }}
+        >
+          尚无来函，静候佳音。
         </p>
       ) : (
-        <ul className='flex flex-col gap-5'>
+        <ul className='flex flex-col gap-3'>
           {threads.map((thread) => (
             <CommentItem
               key={thread.id}
@@ -428,9 +398,9 @@ export function Comments({
             type='button'
             onClick={handleLoadMore}
             disabled={loadingMore}
-            className='text-sm opacity-60 transition-opacity hover:opacity-100 disabled:opacity-40'
+            className='j-btn'
           >
-            {loadingMore ? '加载中…' : '加载更多'}
+            {loadingMore ? '展读中…' : '展读更多来函'}
           </button>
         </div>
       ) : null}

--- a/apps/web/src/components/comments.tsx
+++ b/apps/web/src/components/comments.tsx
@@ -91,7 +91,7 @@ function Composer({
       />
       <div className='j-cmt-foot'>
         <span className='j-cmt-hint'>
-          {remaining < 200 ? `${remaining} 字剩余` : '来函支持 Markdown'}
+          {remaining < 200 ? `${remaining} 字剩余` : '支持 Markdown'}
           {error ? <span className='j-err'>{error}</span> : null}
         </span>
         <button
@@ -99,7 +99,7 @@ function Composer({
           disabled={submitting || !body.trim()}
           className='j-btn j-btn-red'
         >
-          {submitting ? '投递中…' : '投　函'}
+          {submitting ? '发送中…' : '发送'}
         </button>
       </div>
     </form>
@@ -342,14 +342,12 @@ export function Comments({
 
   return (
     <section className='mt-10'>
-      <h3 className='j-blockhead'>
-        读 者 来 函 {total > 0 ? `(${total})` : ''}
-      </h3>
+      <h3 className='j-blockhead'>评论 {total > 0 ? `(${total})` : ''}</h3>
 
       {sessionUser ? (
         <div className='mb-6'>
           <Composer
-            placeholder='来函一句（支持 Markdown）……'
+            placeholder='写下你的评论…（支持 Markdown）'
             submitting={submitting}
             onSubmit={handleCreateTopLevel}
           />
@@ -362,7 +360,7 @@ export function Comments({
           <Link to='/login' className='underline'>
             入会
           </Link>{' '}
-          后即可来函。
+          后即可评论。
         </p>
       )}
 
@@ -373,7 +371,7 @@ export function Comments({
           className='py-8 text-center text-sm'
           style={{ color: 'var(--j-faint)', fontFamily: 'var(--j-sans)' }}
         >
-          尚无来函，静候佳音。
+          还没有评论，来抢沙发。
         </p>
       ) : (
         <ul className='flex flex-col gap-3'>
@@ -400,7 +398,7 @@ export function Comments({
             disabled={loadingMore}
             className='j-btn'
           >
-            {loadingMore ? '展读中…' : '展读更多来函'}
+            {loadingMore ? '加载中…' : '加载更多'}
           </button>
         </div>
       ) : null}

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -1,10 +1,9 @@
 export function Footer() {
   return (
-    <footer className='p-6 text-center'>
-      © {new Date().getFullYear()}, Built with{' '}
-      <a className='text-blue-500' href='https://tanstack.com/start/latest'>
-        TanStack Start
-      </a>
+    <footer className='j-colophon'>
+      废墨集 · {new Date().getFullYear()} 年 · <a href='/rss.xml'>RSS 订阅</a> ·
+      全刊运行于 <a href='https://tanstack.com/start/latest'>TanStack Start</a>{' '}
+      与 Cloudflare 之上
     </footer>
   );
 }

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -1,9 +1,8 @@
 export function Footer() {
   return (
     <footer className='j-colophon'>
-      废墨集 · {new Date().getFullYear()} 年 · <a href='/rss.xml'>RSS 订阅</a> ·
-      全刊运行于 <a href='https://tanstack.com/start/latest'>TanStack Start</a>{' '}
-      与 Cloudflare 之上
+      © {new Date().getFullYear()}, Built with{' '}
+      <a href='https://tanstack.com/start/latest'>TanStack Start</a>
     </footer>
   );
 }

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -54,6 +54,7 @@ export function Header() {
           ) : (
             <Link
               to='/login'
+              data-testid='nav-login'
               className='text-[13.5px]'
               style={{ letterSpacing: '0.28em', color: 'var(--j-faded)' }}
             >

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -48,7 +48,7 @@ export function Header() {
             </span>
           ) : null}
           {sessionUser ? (
-            <Link to='/logout' aria-label='Logout'>
+            <Link to='/logout' data-testid='nav-logout' aria-label='Logout'>
               <LogOut size={17} className='opacity-60 hover:opacity-100' />
             </Link>
           ) : (

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -15,7 +15,7 @@ function getRoleLabel(role?: string | null): string {
   return 'MEMBER';
 }
 
-/** Journal masthead: brand + section nav + tools. Light-only theme. */
+/** Journal masthead: warm-paper shell with the site's original wording. */
 export function Header() {
   const { data: sessionData } = authClient.useSession();
   const sessionUser = sessionData?.user ?? null;
@@ -25,14 +25,15 @@ export function Header() {
       <header className='j-masthead'>
         <div className='j-brand'>
           <Link to='/'>
-            废墨集<span className='j-dot'>。</span>
+            PerfectPan<span className='j-dot'>.</span>
           </Link>
         </div>
-        <nav aria-label='栏目'>
-          <Link to='/blog'>目次</Link>
-          <Link to='/projects'>器物</Link>
+        <nav aria-label='主导航'>
+          <Link to='/'>Home</Link>
+          <Link to='/blog'>Blog</Link>
+          <Link to='/projects'>Projects</Link>
           {sessionUser?.role === 'admin' ? (
-            <Link to='/admin'>编辑部</Link>
+            <Link to='/admin'>Admin</Link>
           ) : null}
         </nav>
         <div className='ml-auto flex items-center gap-3'>
@@ -52,18 +53,27 @@ export function Header() {
               <LogOut size={17} className='opacity-60 hover:opacity-100' />
             </Link>
           ) : (
-            <Link
-              to='/login'
-              data-testid='nav-login'
-              className='text-[13.5px]'
-              style={{ letterSpacing: '0.28em', color: 'var(--j-faded)' }}
-            >
-              入会
-            </Link>
+            <>
+              <Link
+                to='/login'
+                data-testid='nav-login'
+                className='text-[13.5px]'
+                style={{ letterSpacing: '0.28em', color: 'var(--j-faded)' }}
+              >
+                Login
+              </Link>
+              <Link
+                to='/signup'
+                className='text-[13.5px]'
+                style={{ letterSpacing: '0.28em', color: 'var(--j-faded)' }}
+              >
+                Sign Up
+              </Link>
+            </>
           )}
           <button
             type='button'
-            aria-label='检索篇目 (Cmd+K)'
+            aria-label='Search posts (Cmd+K)'
             onClick={() => searchPalette.open()}
           >
             <Search size={17} className='opacity-60 hover:opacity-100' />

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -1,8 +1,6 @@
 import { Link } from '@tanstack/react-router';
 import { Github, LogOut, Rss, Search, UserRound } from 'lucide-react';
 import { authClient } from '../lib/auth-client.js';
-import { DarkMode } from './dark-mode.js';
-import { MenuLink } from './menu.js';
 import { searchPalette } from './search-palette-store.js';
 
 function getRoleLabel(role?: string | null): string {
@@ -17,79 +15,74 @@ function getRoleLabel(role?: string | null): string {
   return 'MEMBER';
 }
 
+/** Journal masthead: brand + section nav + tools. Light-only theme. */
 export function Header() {
   const { data: sessionData } = authClient.useSession();
   const sessionUser = sessionData?.user ?? null;
 
   return (
-    <header className='border-b border-slate-200 bg-white shadow-md dark:border-slate-300/10 dark:bg-slate-900'>
-      <div className='mx-4 flex h-16 items-center sm:mx-6'>
-        <Link
-          to='/'
-          className='rounded-md border-10 border-black bg-black px-1 font-bold text-white dark:border-neutral-900 dark:bg-neutral-900'
-        >
-          PerfectPan
-        </Link>
-        <div className='m-0 flex list-none items-center pl-1'>
-          <MenuLink href='/' name='Home' />
-          <MenuLink href='/blog' name='Blog' />
-          <MenuLink href='/projects' name='Projects' />
-          {sessionUser?.role === 'admin' ? (
-            <MenuLink href='/admin' name='Admin' />
-          ) : null}
+    <div>
+      <header className='j-masthead'>
+        <div className='j-brand'>
+          <Link to='/'>
+            废墨集<span className='j-dot'>。</span>
+          </Link>
         </div>
-        <div className='ml-auto flex items-center gap-2 sm:gap-3'>
+        <nav aria-label='栏目'>
+          <Link to='/blog'>目次</Link>
+          <Link to='/projects'>器物</Link>
+          {sessionUser?.role === 'admin' ? (
+            <Link to='/admin'>编辑部</Link>
+          ) : null}
+        </nav>
+        <div className='ml-auto flex items-center gap-3'>
           {sessionUser ? (
-            <div className='hidden items-center gap-2 rounded-full border border-slate-300 px-3 py-1 text-xs text-gray-700 md:flex dark:border-slate-600 dark:text-slate-200'>
-              <UserRound size={14} className='opacity-70' />
-              <span className='max-w-[220px] truncate'>
+            <span className='j-user-chip hidden md:flex'>
+              <UserRound size={13} aria-hidden='true' />
+              <span className='max-w-[200px] truncate'>
                 {sessionUser.email}
               </span>
-              <span className='rounded-full bg-black px-2 py-[2px] text-[10px] font-semibold text-white dark:bg-neutral-100 dark:text-neutral-900'>
+              <span className='j-user-role'>
                 {getRoleLabel(sessionUser.role)}
               </span>
-            </div>
+            </span>
           ) : null}
           {sessionUser ? (
-            <Link
-              to='/logout'
-              className='inline-flex items-center gap-1 rounded-md border border-slate-300 px-2 py-1 text-sm opacity-85 transition-opacity hover:opacity-100 dark:border-slate-600'
-            >
-              <LogOut size={14} />
-              <span className='hidden sm:inline'>Logout</span>
+            <Link to='/logout' aria-label='Logout'>
+              <LogOut size={17} className='opacity-60 hover:opacity-100' />
             </Link>
           ) : (
-            <>
-              <Link to='/login' className='opacity-70 hover:opacity-100'>
-                Login
-              </Link>
-              <Link to='/signup' className='opacity-70 hover:opacity-100'>
-                Sign Up
-              </Link>
-            </>
+            <Link
+              to='/login'
+              className='text-[13.5px]'
+              style={{ letterSpacing: '0.28em', color: 'var(--j-faded)' }}
+            >
+              入会
+            </Link>
           )}
           <button
             type='button'
-            aria-label='Search posts (Cmd+K)'
+            aria-label='检索篇目 (Cmd+K)'
             onClick={() => searchPalette.open()}
-            className='inline-flex items-center opacity-70 transition-opacity hover:opacity-100'
           >
-            <Search size={22} />
+            <Search size={17} className='opacity-60 hover:opacity-100' />
           </button>
-          <DarkMode />
           <a
             href='https://github.com/PerfectPan'
             target='_blank'
             rel='noreferrer'
-            className='flex items-center'
+            aria-label='GitHub'
           >
-            <Github size={22} className='opacity-70 hover:opacity-100' />
+            <Github size={17} className='opacity-60 hover:opacity-100' />
           </a>
-          <a href='/rss.xml' target='_blank' rel='noreferrer'>
-            <Rss size={24} className='opacity-70 hover:opacity-100' />
+          <a href='/rss.xml' target='_blank' rel='noreferrer' aria-label='RSS'>
+            <Rss size={17} className='opacity-60 hover:opacity-100' />
           </a>
         </div>
+      </header>
+      <div className='j-headrule'>
+        <hr />
       </div>
-    </header>
+    </div>
   );
 }

--- a/apps/web/src/components/layout.tsx
+++ b/apps/web/src/components/layout.tsx
@@ -7,21 +7,18 @@ type AppLayoutProps = {
 };
 
 /**
- * App shell. The header sits OUTSIDE the scroll container (`main`), so page
- * overscroll only rubber-bands the content — the pinned header never moves
- * (no macOS "fixed header drags on overscroll"). Window doesn't scroll; route
- * scroll reset/restore for `main` is handled by TanStack via
+ * App shell (journal theme). The masthead sits OUTSIDE the scroll container
+ * (`main`), so page overscroll only rubber-bands the content. Window doesn't
+ * scroll; route scroll reset/restore for `main` is handled by TanStack via
  * `scrollToTopSelectors: ['main']` in router.tsx.
  */
 export function AppLayout({ children }: AppLayoutProps) {
   return (
-    <div className='flex h-dvh flex-col'>
+    <div className='j-shell'>
       <Header />
-      <main className='flex-1 overflow-y-auto'>
+      <main className='j-main'>
         <div className='flex min-h-full flex-col'>
-          <div className='flex flex-grow items-center justify-center px-6 *:min-h-64 *:min-w-64'>
-            {children}
-          </div>
+          <div className='flex-grow'>{children}</div>
           <Footer />
         </div>
       </main>

--- a/apps/web/src/components/markdown.tsx
+++ b/apps/web/src/components/markdown.tsx
@@ -78,20 +78,17 @@ function CodeBlock({ children }: { children?: ReactNode }) {
   }, []);
 
   return (
-    <div className='group relative mb-2'>
+    <div className='j-code group relative'>
       <button
         type='button'
         onClick={onCopy}
         aria-label='Copy code'
-        className='absolute right-2 top-2 z-10 inline-flex items-center gap-1 rounded border border-slate-300 bg-white/70 px-1.5 py-0.5 text-xs opacity-0 backdrop-blur transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100 hover-none:opacity-70 dark:border-slate-700 dark:bg-slate-900/70'
+        className='j-code-copy'
       >
         {copied ? <Check size={12} /> : <Copy size={12} />}
         {copied ? 'Copied' : 'Copy'}
       </button>
-      <pre
-        ref={preRef}
-        className='shiki w-full overflow-x-auto whitespace-pre-wrap rounded-md bg-zinc-50 p-4 dark:bg-shiki-dark'
-      >
+      <pre ref={preRef} className='shiki j-pre w-full overflow-x-auto'>
         {children}
       </pre>
     </div>
@@ -112,7 +109,7 @@ export function Markdown({ content }: MarkdownProps) {
   }, []);
 
   return (
-    <article>
+    <article className='md'>
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkMath]}
         rehypePlugins={[
@@ -133,10 +130,7 @@ export function Markdown({ content }: MarkdownProps) {
             const id = typeof children === 'string' ? children : '';
 
             return (
-              <h2
-                id={id}
-                className='mb-6 mt-14 scroll-mt-20 text-balance text-2xl leading-none font-black first:mt-0'
-              >
+              <h2 id={id} className='scroll-mt-20'>
                 <a
                   href={`#${id}`}
                   onClick={(event) => {
@@ -150,24 +144,21 @@ export function Markdown({ content }: MarkdownProps) {
               </h2>
             );
           },
-          p: ({ children }) => <p className='mb-6 leading-7'>{children}</p>,
+          p: ({ children }) => <p>{children}</p>,
           a: ({ href, children }) => (
-            <a
-              href={href}
-              className='text-blue-700/80 transition-colors duration-300 ease-in-out hover:text-blue-700'
-              target='_blank'
-              rel='noreferrer'
-            >
+            <a href={href} target='_blank' rel='noreferrer'>
               {children}
             </a>
           ),
-          strong: ({ children }) => (
-            <b className='font-extrabold'>{children}</b>
-          ),
-          ul: ({ children }) => (
-            <ul className='mb-4 ml-4 list-disc'>{children}</ul>
-          ),
+          strong: ({ children }) => <b className='font-bold'>{children}</b>,
+          ul: ({ children }) => <ul>{children}</ul>,
           pre: ({ children }) => <CodeBlock>{children}</CodeBlock>,
+          code: ({ className, children }) =>
+            /language-/.test(className ?? '') ? (
+              <code className={className}>{children}</code>
+            ) : (
+              <code className='j-inline'>{children}</code>
+            ),
         }}
       >
         {content}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -39,10 +39,10 @@ export const Route = createRootRoute({
     <RootDocument>
       <AppLayout>
         <div className='j-sheet'>
-          <h1 className='j-entry-title text-center'>未能成页</h1>
+          <h1 className='j-entry-title text-center'>Request Failed</h1>
           <p className='j-entry-meta text-center'>{String(error)}</p>
           <p className='j-backlink'>
-            <Link to='/blog'>— 返 目 次 —</Link>
+            <Link to='/blog'>Back to blog</Link>
           </p>
         </div>
       </AppLayout>
@@ -56,12 +56,12 @@ export const Route = createRootRoute({
             阙
           </span>
           <div className='zh' style={{ marginTop: 30 }}>
-            此页未收
+            404 Not Found
           </div>
-          <p>本刊并无此篇 · 或已散佚</p>
+          <p>你闯入了无人之境...</p>
           <p style={{ marginTop: 26 }}>
             <Link to='/blog' className='j-btn'>
-              返 目 次
+              Back to blog
             </Link>
           </p>
         </div>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -26,7 +26,7 @@ export const Route = createRootRoute({
       },
       {
         name: 'theme-color',
-        content: '#000000',
+        content: '#F6F3EC',
       },
     ],
     links: [
@@ -38,12 +38,12 @@ export const Route = createRootRoute({
   errorComponent: ({ error }) => (
     <RootDocument>
       <AppLayout>
-        <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-          <h2 className='mb-4 text-3xl'>Request Failed</h2>
-          <p className='mb-4 opacity-70'>{String(error)}</p>
-          <Link to='/blog' className='opacity-70 hover:opacity-100'>
-            Back to blog
-          </Link>
+        <div className='j-sheet'>
+          <h1 className='j-entry-title text-center'>未能成页</h1>
+          <p className='j-entry-meta text-center'>{String(error)}</p>
+          <p className='j-backlink'>
+            <Link to='/blog'>— 返 目 次 —</Link>
+          </p>
         </div>
       </AppLayout>
     </RootDocument>
@@ -51,12 +51,19 @@ export const Route = createRootRoute({
   notFoundComponent: () => (
     <RootDocument>
       <AppLayout>
-        <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-          <h2 className='mb-4 text-3xl'>404 Not Found</h2>
-          <p className='mb-4 opacity-70'>你闯入了无人之境...</p>
-          <Link to='/blog' className='opacity-70 hover:opacity-100'>
-            Back to blog
-          </Link>
+        <div className='j-nf'>
+          <span className='j-seal' aria-hidden='true'>
+            阙
+          </span>
+          <div className='zh' style={{ marginTop: 30 }}>
+            此页未收
+          </div>
+          <p>本刊并无此篇 · 或已散佚</p>
+          <p style={{ marginTop: 26 }}>
+            <Link to='/blog' className='j-btn'>
+              返 目 次
+            </Link>
+          </p>
         </div>
       </AppLayout>
     </RootDocument>

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -63,6 +63,14 @@ export const Route = createFileRoute('/blog/$slug')({
   component: BlogDetailPage,
 });
 
+const VIS_TEXT: Record<string, string> = {
+  public: '',
+  member: '会员可见',
+  vip: 'VIP 可见',
+  admin: '仅后台',
+  password: '密码保护',
+};
+
 function BlogDetailPage() {
   const data = Route.useLoaderData();
   const post = data.post;
@@ -70,46 +78,31 @@ function BlogDetailPage() {
     return null;
   }
 
-  const date = new Date(post.publishedAt).toLocaleDateString('zh-CN', {
-    year: 'numeric',
+  const date = new Date(post.publishedAt).toLocaleDateString('en-US', {
     month: 'long',
     day: 'numeric',
+    year: 'numeric',
   });
 
   return (
     <div className='j-sheet'>
       <aside className='j-spine' aria-hidden='true'>
-        废墨集 · {new Date(post.publishedAt).getFullYear()} 年卷 · {post.slug}
+        PerfectPan's Blog · {post.slug}
       </aside>
       <article className='j-article'>
-        <div className='j-running-head'>
-          废墨集 · {date} · 栏目：
-          {post.tags.length > 0 ? post.tags.join('・') : '未分栏'}
-        </div>
         <h1 className='j-entry-title'>{post.title}</h1>
-
-        <div className='j-article'>
-          <p className='j-entry-meta'>
-            <span>{date}</span>
-            <span>·</span>
-            <span>
-              {post.visibility === 'public'
-                ? '公开'
-                : post.visibility === 'member'
-                  ? '会员可读'
-                  : post.visibility === 'vip'
-                    ? 'VIP'
-                    : post.visibility === 'admin'
-                      ? '编者'
-                      : '密笈'}
-            </span>
-          </p>
-        </div>
-
+        <p className='j-entry-meta'>
+          <span>{date}</span>
+          {post.visibility !== 'public' ? (
+            <span> · {VIS_TEXT[post.visibility]}</span>
+          ) : null}
+          {post.tags.length > 0 ? (
+            <span> · {post.tags.join(' / ')}</span>
+          ) : null}
+        </p>
         <Markdown content={post.contentMdx} />
-
         <div className='j-backlink'>
-          <Link to='/blog'>— 返 目 次 —</Link>
+          <Link to='/blog'>← Back to blog</Link>
         </div>
       </article>
       <div className='j-letters'>

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -70,31 +70,58 @@ function BlogDetailPage() {
     return null;
   }
 
-  const date = new Date(post.publishedAt).toLocaleDateString('en-US', {
+  const date = new Date(post.publishedAt).toLocaleDateString('zh-CN', {
+    year: 'numeric',
     month: 'long',
     day: 'numeric',
-    year: 'numeric',
   });
 
   return (
-    <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <div className='m-auto mb-8 flex flex-col gap-2'>
-        <div className='text-3xl font-black'>{post.title}</div>
-        <div className='opacity-60'>{date}</div>
+    <div className='j-sheet'>
+      <aside className='j-spine' aria-hidden='true'>
+        废墨集 · {new Date(post.publishedAt).getFullYear()} 年卷 · {post.slug}
+      </aside>
+      <article className='j-article'>
+        <div className='j-running-head'>
+          废墨集 · {date} · 栏目：
+          {post.tags.length > 0 ? post.tags.join('・') : '未分栏'}
+        </div>
+        <h1 className='j-entry-title'>{post.title}</h1>
+
+        <div className='j-article'>
+          <p className='j-entry-meta'>
+            <span>{date}</span>
+            <span>·</span>
+            <span>
+              {post.visibility === 'public'
+                ? '公开'
+                : post.visibility === 'member'
+                  ? '会员可读'
+                  : post.visibility === 'vip'
+                    ? 'VIP'
+                    : post.visibility === 'admin'
+                      ? '编者'
+                      : '密笈'}
+            </span>
+          </p>
+        </div>
+
+        <Markdown content={post.contentMdx} />
+
+        <div className='j-backlink'>
+          <Link to='/blog'>— 返 目 次 —</Link>
+        </div>
+      </article>
+      <div className='j-letters'>
+        <Comments
+          key={post.slug}
+          slug={post.slug}
+          initialComments={data.comments.comments}
+          initialHasMore={data.comments.hasMore}
+          initialTotal={data.comments.total}
+          sessionUser={data.sessionUser}
+        />
       </div>
-      <Markdown content={post.contentMdx} />
-      <Link to='/blog' className='mt-4 inline-block'>
-        <span className='opacity-70'>&gt;&nbsp;&nbsp;&nbsp;</span>
-        <span className='underline opacity-70 hover:opacity-100'>cd ..</span>
-      </Link>
-      <Comments
-        key={post.slug}
-        slug={post.slug}
-        initialComments={data.comments.comments}
-        initialHasMore={data.comments.hasMore}
-        initialTotal={data.comments.total}
-        sessionUser={data.sessionUser}
-      />
     </div>
   );
 }

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -86,9 +86,6 @@ function BlogDetailPage() {
 
   return (
     <div className='j-sheet'>
-      <aside className='j-spine' aria-hidden='true'>
-        PerfectPan's Blog · {post.slug}
-      </aside>
       <article className='j-article'>
         <h1 className='j-entry-title'>{post.title}</h1>
         <p className='j-entry-meta'>

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -1,6 +1,5 @@
 import type { PostSummary, SessionUser } from '@blog/shared';
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useEffect } from 'react';
 import { z } from 'zod';
 import { getBlogListServerFn } from '../../lib/blog-service.js';
@@ -49,6 +48,32 @@ function getDevScopeHint(sessionUser: SessionUser | null | undefined): string {
   return '当前身份：member；可见范围：public/member';
 }
 
+const CN_DIGITS = ['〇', '一', '二', '三', '四', '五', '六', '七', '八', '九'];
+
+/** TOC page number in Chinese digits, zero-padded to 3 (〇一六). */
+function tocNumber(n: number): string {
+  return String(n)
+    .padStart(3, '0')
+    .split('')
+    .map((d) => CN_DIGITS[Number(d)])
+    .join('');
+}
+
+const NOTE_CLASS: Record<PostSummary['visibility'], string> = {
+  public: '',
+  member: 'j-note mem',
+  vip: 'j-note vip',
+  admin: 'j-note adm',
+  password: 'j-note pw',
+};
+const NOTE_TEXT: Record<PostSummary['visibility'], string> = {
+  public: '',
+  member: '会员可读',
+  vip: 'VIP',
+  admin: '编者',
+  password: '密笈',
+};
+
 export const Route = createFileRoute('/blog/')({
   head: () => ({
     meta: [
@@ -75,90 +100,71 @@ function BlogListPage() {
   const blogGroups = groupByYear(data.posts);
   const showDevHint = data.isDev;
   const devScopeHint = getDevScopeHint(data.sessionUser);
+  let runningIndex = 0;
 
   // Conventional blog pagination: the page scrolls naturally; jump back to the
-  // top on each page change so the new page starts at its first post. (Without
-  // this, clicking "next" while scrolled to the bottom leaves the reader past a
-  // shorter page — the original "bounce".)
+  // top on each page change so the new page starts at its first post.
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-run on page change, value unused in body on purpose
   useEffect(() => {
     document.querySelector('main')?.scrollTo({ top: 0 });
   }, [data.page]);
 
   return (
-    <div className='mx-auto flex w-full max-w-[80ch] flex-col gap-8 self-start pt-8'>
-      <div className='w-full'>
-        {showDevHint ? (
-          <div className='mb-8 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900'>
-            {devScopeHint}
+    <div className='j-sheet'>
+      <h1 className='j-entry-title text-center'>目　次</h1>
+      <p className='j-entry-meta text-center'>全刊总目 · 按年分卷 · 自新迄旧</p>
+
+      {showDevHint ? <div className='j-devhint'>{devScopeHint}</div> : null}
+
+      {blogGroups.map((group) => (
+        <div key={group.year}>
+          <div className='j-juan'>
+            <h2>卷 · {group.year}</h2>
+            <span className='sub'>{group.blogs.length} 篇</span>
           </div>
-        ) : null}
-        {blogGroups.map((group) => (
-          <div key={group.year}>
-            <div className='mb-4 text-3xl'>{group.year}</div>
-            {group.blogs.map((blog: PostSummary) => (
-              <div
-                key={blog.slug}
-                className='mt-2 mb-6 opacity-70 hover:opacity-100'
-              >
-                <Link
-                  to='/blog/$slug'
-                  params={{ slug: blog.slug }}
-                  className='flex items-center gap-2'
-                >
-                  <span className='text-lg leading-[1.2em]'>{blog.title}</span>
-                  <span className='text-sm opacity-50'>
-                    {new Date(blog.publishedAt).toLocaleDateString('en-US', {
-                      month: 'short',
-                      day: 'numeric',
-                    })}
+          {group.blogs.map((blog: PostSummary) => {
+            runningIndex += 1;
+            return (
+              <div className='j-toc-line' key={blog.slug}>
+                <Link to='/blog/$slug' params={{ slug: blog.slug }}>
+                  <span className='t'>
+                    {blog.title}
+                    {blog.visibility !== 'public' ? (
+                      <span className={NOTE_CLASS[blog.visibility]}>
+                        {NOTE_TEXT[blog.visibility]}
+                      </span>
+                    ) : null}
                   </span>
+                  <span className='dots' />
                 </Link>
+                <span className='n'>{tocNumber(runningIndex)}</span>
               </div>
-            ))}
-          </div>
-        ))}
-      </div>
+            );
+          })}
+        </div>
+      ))}
+
       {data.totalPages > 1 ? (
-        <nav
-          className='flex w-full items-center justify-center gap-4 text-sm sm:gap-6'
-          aria-label='Pagination'
-        >
+        <nav className='j-pager' aria-label='翻页'>
           {data.page > 1 ? (
-            <Link
-              to='/blog'
-              search={{ page: data.page - 1 }}
-              className='inline-flex items-center gap-1 opacity-60 hover:opacity-100'
-            >
-              <ChevronLeft size={14} /> prev
+            <Link to='/blog' search={{ page: data.page - 1 }}>
+              上一页
             </Link>
           ) : (
-            <span className='inline-flex items-center gap-1 opacity-30'>
-              <ChevronLeft size={14} /> prev
-            </span>
+            <span>上一页</span>
           )}
-          <span className='opacity-60'>
-            page {data.page} / {data.totalPages}
+          <span>
+            · {data.page} / {data.totalPages} ·
           </span>
           {data.page < data.totalPages ? (
-            <Link
-              to='/blog'
-              search={{ page: data.page + 1 }}
-              className='inline-flex items-center gap-1 opacity-60 hover:opacity-100'
-            >
-              next <ChevronRight size={14} />
+            <Link to='/blog' search={{ page: data.page + 1 }}>
+              下一页
             </Link>
           ) : (
-            <span className='inline-flex items-center gap-1 opacity-30'>
-              next <ChevronRight size={14} />
-            </span>
+            <span>下一页</span>
           )}
         </nav>
       ) : null}
-      <Link to='/' className='mt-4 inline-block'>
-        <span className='opacity-70'>&gt;&nbsp;&nbsp;&nbsp;</span>
-        <span className='underline opacity-70 hover:opacity-100'>cd ..</span>
-      </Link>
     </div>
   );
 }

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -48,17 +48,6 @@ function getDevScopeHint(sessionUser: SessionUser | null | undefined): string {
   return '当前身份：member；可见范围：public/member';
 }
 
-const CN_DIGITS = ['〇', '一', '二', '三', '四', '五', '六', '七', '八', '九'];
-
-/** TOC page number in Chinese digits, zero-padded to 3 (〇一六). */
-function tocNumber(n: number): string {
-  return String(n)
-    .padStart(3, '0')
-    .split('')
-    .map((d) => CN_DIGITS[Number(d)])
-    .join('');
-}
-
 const NOTE_CLASS: Record<PostSummary['visibility'], string> = {
   public: '',
   member: 'j-note mem',
@@ -68,10 +57,10 @@ const NOTE_CLASS: Record<PostSummary['visibility'], string> = {
 };
 const NOTE_TEXT: Record<PostSummary['visibility'], string> = {
   public: '',
-  member: '会员可读',
+  member: '会员',
   vip: 'VIP',
-  admin: '编者',
-  password: '密笈',
+  admin: '仅后台',
+  password: '密码',
 };
 
 export const Route = createFileRoute('/blog/')({
@@ -111,15 +100,15 @@ function BlogListPage() {
 
   return (
     <div className='j-sheet'>
-      <h1 className='j-entry-title text-center'>目　次</h1>
-      <p className='j-entry-meta text-center'>全刊总目 · 按年分卷 · 自新迄旧</p>
+      <h1 className='j-entry-title text-center'>Blog</h1>
+      <p className='j-entry-meta text-center'>按年份归档 · 自新迄旧</p>
 
       {showDevHint ? <div className='j-devhint'>{devScopeHint}</div> : null}
 
       {blogGroups.map((group) => (
         <div key={group.year}>
           <div className='j-juan'>
-            <h2>卷 · {group.year}</h2>
+            <h2 style={{ letterSpacing: '0.18em' }}>{group.year}</h2>
             <span className='sub'>{group.blogs.length} 篇</span>
           </div>
           {group.blogs.map((blog: PostSummary) => {
@@ -137,7 +126,15 @@ function BlogListPage() {
                   </span>
                   <span className='dots' />
                 </Link>
-                <span className='n'>{tocNumber(runningIndex)}</span>
+                <span className='n'>
+                  {new Date(blog.publishedAt).toLocaleDateString('en-US', {
+                    month: 'short',
+                    day: 'numeric',
+                  })}
+                </span>
+                <span className='n' style={{ color: 'var(--j-faint)' }}>
+                  {String(runningIndex).padStart(3, '0')}
+                </span>
               </div>
             );
           })}
@@ -145,23 +142,23 @@ function BlogListPage() {
       ))}
 
       {data.totalPages > 1 ? (
-        <nav className='j-pager' aria-label='翻页'>
+        <nav className='j-pager' aria-label='Pagination'>
           {data.page > 1 ? (
             <Link to='/blog' search={{ page: data.page - 1 }}>
-              上一页
+              ← prev
             </Link>
           ) : (
-            <span>上一页</span>
+            <span>← prev</span>
           )}
           <span>
-            · {data.page} / {data.totalPages} ·
+            page {data.page} / {data.totalPages}
           </span>
           {data.page < data.totalPages ? (
             <Link to='/blog' search={{ page: data.page + 1 }}>
-              下一页
+              next →
             </Link>
           ) : (
-            <span>下一页</span>
+            <span>next →</span>
           )}
         </nav>
       ) : null}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,35 +1,38 @@
+import type { PostSummary } from '@blog/shared';
 import { createFileRoute, Link } from '@tanstack/react-router';
+import { getBlogListServerFn } from '../lib/blog-service.js';
+import { PROJECTS } from '../lib/projects.js';
 
 export const Route = createFileRoute('/')({
   head: () => ({
     meta: [{ title: "Home | PerfectPan's Blog" }],
   }),
+  loader: async () => {
+    // Guest-scoped first page powers the LATEST panel.
+    return getBlogListServerFn({ data: { page: 1 } });
+  },
   component: HomePage,
 });
 
 function HomePage() {
+  const data = Route.useLoaderData();
+  const latest = data.posts.slice(0, 5);
+
   return (
     <div className='j-sheet'>
-      <aside className='j-spine' aria-hidden='true'>
-        PerfectPan's Blog · perfectpan.org
-      </aside>
-      <div className='j-frontispiece'>
-        <div className='j-vertical' aria-hidden='true'>
-          PerfectPan
-          <small>BLOG · SINCE 2019</small>
-        </div>
+      <div className='j-home'>
         <div>
-          <h1 className='j-entry-title'>是个什么都不会的废物.jpg</h1>
+          <h1>是个什么都不会的废物.jpg</h1>
           <p className='j-tagline'>
             算法竞赛退役选手，现在的兴趣在前端工程、类型体操和把东西跑在
             Cloudflare 免费额度上。这里收着题解、笔记和一些随想。
           </p>
           <div className='j-facts'>
-            <span>16 篇文章</span>
+            <span>{data.total} 篇文章</span>
             <span>2019 — 2023</span>
-            <span>Cloudflare · $0/月</span>
+            <span>{PROJECTS.length} 个开源项目</span>
           </div>
-          <div className='mt-9 flex flex-wrap gap-4'>
+          <div className='j-home-cta'>
             <Link to='/blog' className='j-btn j-btn-red'>
               Blog
             </Link>
@@ -37,24 +40,33 @@ function HomePage() {
               Projects
             </Link>
           </div>
-          <div className='mt-11 flex items-center gap-4'>
+          <div className='j-home-seal'>
             <span className='j-seal' aria-hidden='true'>
               潘
             </span>
-            <div
-              className='text-xs'
-              style={{
-                fontFamily: 'var(--j-sans)',
-                color: 'var(--j-faint)',
-                letterSpacing: '0.2em',
-                lineHeight: 1.9,
-              }}
-            >
+            <div className='sign'>
               PerfectPan
               <br />
               perfectpan.org
             </div>
           </div>
+        </div>
+        <div className='j-home-panel'>
+          <div className='j-blockhead'>最 近 文 章</div>
+          {latest.map((post: PostSummary) => (
+            <div className='j-latest-item' key={post.slug}>
+              <Link className='t' to='/blog/$slug' params={{ slug: post.slug }}>
+                {post.title}
+              </Link>
+              <span className='d'>
+                {new Date(post.publishedAt).toLocaleDateString('en-US', {
+                  month: 'short',
+                  day: 'numeric',
+                  year: 'numeric',
+                })}
+              </span>
+            </div>
+          ))}
         </div>
       </div>
     </div>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -9,17 +9,58 @@ export const Route = createFileRoute('/')({
 
 function HomePage() {
   return (
-    <div className='flex flex-col items-center'>
-      <img className='m-0' src='/images/xm.jpg' alt='' />
-      <div className='mt-8 text-[2.5rem] font-black'>
-        是个什么都不会的废物.jpg
-      </div>
-      <div className='flex w-full justify-around'>
-        <div className='mx-1 mt-8 flex-1 rounded-md bg-slate-100 text-center font-semibold uppercase tracking-wider leading-[5rem] shadow-md transition-shadow hover:shadow-lg dark:bg-wash-dark dark:text-white dark:opacity-80'>
-          <Link to='/blog'>Blog</Link>
+    <div className='j-sheet'>
+      <aside className='j-spine' aria-hidden='true'>
+        废墨集 · 创刊于二〇一九 · perfectpan.org
+      </aside>
+      <div className='j-frontispiece'>
+        <div className='j-vertical' aria-hidden='true'>
+          废墨集
+          <small>FEI MO JI · 创刊于二〇一九</small>
         </div>
-        <div className='mx-1 mt-8 flex-1 rounded-md bg-slate-100 text-center font-semibold uppercase tracking-wider leading-[5rem] shadow-md transition-shadow hover:shadow-lg dark:bg-wash-dark dark:text-white dark:opacity-80'>
-          <Link to='/projects'>Projects</Link>
+        <div>
+          <p className='j-tagline'>
+            是个什么都不会的废物.jpg —— 但笔没停过。算法竞赛的旧题解、TypeScript
+            的类型体操、把整站跑在 Cloudflare
+            免费额度上的工程笔记，以及一些不成体统的随想，都收在这本集子里。
+          </p>
+          <div className='j-facts'>
+            <span>
+              收文 <b>十六</b> 篇
+            </span>
+            <span>
+              历时 <b>二〇一九 — 二〇二三</b>
+            </span>
+            <span>
+              栏目 <b>算法 · 类型 · 随笔 · 工程</b>
+            </span>
+          </div>
+          <div className='mt-9 flex flex-wrap gap-4'>
+            <Link to='/blog' className='j-btn j-btn-red'>
+              读 目 次
+            </Link>
+            <Link to='/projects' className='j-btn'>
+              观 器 物 谱
+            </Link>
+          </div>
+          <div className='mt-11 flex items-center gap-4'>
+            <span className='j-seal' aria-hidden='true'>
+              潘
+            </span>
+            <div
+              className='text-xs'
+              style={{
+                fontFamily: 'var(--j-sans)',
+                color: 'var(--j-faint)',
+                letterSpacing: '0.2em',
+                lineHeight: 1.9,
+              }}
+            >
+              PerfectPan 手订
+              <br />
+              全刊运行于 Cloudflare · 每月费用为零
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -11,36 +11,30 @@ function HomePage() {
   return (
     <div className='j-sheet'>
       <aside className='j-spine' aria-hidden='true'>
-        废墨集 · 创刊于二〇一九 · perfectpan.org
+        PerfectPan's Blog · perfectpan.org
       </aside>
       <div className='j-frontispiece'>
         <div className='j-vertical' aria-hidden='true'>
-          废墨集
-          <small>FEI MO JI · 创刊于二〇一九</small>
+          PerfectPan
+          <small>BLOG · SINCE 2019</small>
         </div>
         <div>
+          <h1 className='j-entry-title'>是个什么都不会的废物.jpg</h1>
           <p className='j-tagline'>
-            是个什么都不会的废物.jpg —— 但笔没停过。算法竞赛的旧题解、TypeScript
-            的类型体操、把整站跑在 Cloudflare
-            免费额度上的工程笔记，以及一些不成体统的随想，都收在这本集子里。
+            算法竞赛退役选手，现在的兴趣在前端工程、类型体操和把东西跑在
+            Cloudflare 免费额度上。这里收着题解、笔记和一些随想。
           </p>
           <div className='j-facts'>
-            <span>
-              收文 <b>十六</b> 篇
-            </span>
-            <span>
-              历时 <b>二〇一九 — 二〇二三</b>
-            </span>
-            <span>
-              栏目 <b>算法 · 类型 · 随笔 · 工程</b>
-            </span>
+            <span>16 篇文章</span>
+            <span>2019 — 2023</span>
+            <span>Cloudflare · $0/月</span>
           </div>
           <div className='mt-9 flex flex-wrap gap-4'>
             <Link to='/blog' className='j-btn j-btn-red'>
-              读 目 次
+              Blog
             </Link>
             <Link to='/projects' className='j-btn'>
-              观 器 物 谱
+              Projects
             </Link>
           </div>
           <div className='mt-11 flex items-center gap-4'>
@@ -56,9 +50,9 @@ function HomePage() {
                 lineHeight: 1.9,
               }}
             >
-              PerfectPan 手订
+              PerfectPan
               <br />
-              全刊运行于 Cloudflare · 每月费用为零
+              perfectpan.org
             </div>
           </div>
         </div>

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -35,7 +35,7 @@ function LoginPage() {
   if (sessionData?.user?.id || isSessionPending) {
     return (
       <div className='j-sheet'>
-        <p className='j-aside'>正在核对会籍……</p>
+        <p className='j-aside'>Checking session...</p>
       </div>
     );
   }
@@ -47,10 +47,8 @@ function LoginPage() {
           <span className='j-seal' aria-hidden='true'>
             潘
           </span>
-          <h1>入　会</h1>
-          <p className='sub'>
-            会友可读「会员可读」篇目 · 亦支持 GitHub 介绍入会
-          </p>
+          <h1>登录</h1>
+          <p className='sub'>支持邮箱密码和 GitHub OAuth。</p>
           <form
             method='post'
             onSubmit={(event) => {
@@ -73,7 +71,7 @@ function LoginPage() {
             }}
           >
             <div className='j-field'>
-              <label htmlFor='email'>邮　箱</label>
+              <label htmlFor='email'>Email</label>
               <input
                 id='email'
                 name='email'
@@ -86,7 +84,7 @@ function LoginPage() {
               />
             </div>
             <div className='j-field'>
-              <label htmlFor='password'>口　令</label>
+              <label htmlFor='password'>Password</label>
               <input
                 id='password'
                 name='password'
@@ -104,7 +102,7 @@ function LoginPage() {
                 className='j-btn j-btn-red'
                 disabled={isPending}
               >
-                {isPending ? '登入中…' : '登　入'}
+                {isPending ? 'Signing in...' : 'Sign In'}
               </button>
               <button
                 type='button'
@@ -120,15 +118,15 @@ function LoginPage() {
                   }
                 }}
               >
-                GitHub 入会
+                Continue with GitHub
               </button>
             </div>
             {error ? <p className='j-err mt-4'>{error}</p> : null}
           </form>
           <p className='j-aside'>
-            尚未入会？{' '}
-            <a href='/signup' className='j-aside-link'>
-              注册
+            还没有账号？{' '}
+            <a href='/signup' style={{ color: 'var(--j-red)' }}>
+              Sign Up
             </a>
           </p>
         </div>

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -34,96 +34,105 @@ function LoginPage() {
 
   if (sessionData?.user?.id || isSessionPending) {
     return (
-      <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-        <p className='opacity-70'>Checking session...</p>
-      </section>
+      <div className='j-sheet'>
+        <p className='j-aside'>正在核对会籍……</p>
+      </div>
     );
   }
 
   return (
-    <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>登录</h1>
-      <p className='mb-6 opacity-70'>支持邮箱密码和 GitHub OAuth。</p>
+    <div className='j-sheet'>
+      <div className='j-gate'>
+        <div className='j-gate-card'>
+          <span className='j-seal' aria-hidden='true'>
+            潘
+          </span>
+          <h1>入　会</h1>
+          <p className='sub'>
+            会友可读「会员可读」篇目 · 亦支持 GitHub 介绍入会
+          </p>
+          <form
+            method='post'
+            onSubmit={(event) => {
+              event.preventDefault();
+              setError(null);
+              startTransition(async () => {
+                const result = await authClient.signIn.email({
+                  email,
+                  password,
+                  callbackURL: '/blog',
+                });
 
-      {error ? (
-        <p role='alert' className='mb-4 text-sm text-red-700 dark:text-red-300'>
-          {error}
-        </p>
-      ) : null}
+                if (result.error) {
+                  setError(result.error.message ?? '登录失败');
+                  return;
+                }
 
-      <form
-        className='grid max-w-[420px] gap-3'
-        method='post'
-        onSubmit={(event) => {
-          event.preventDefault();
-          setError(null);
-          startTransition(async () => {
-            const result = await authClient.signIn.email({
-              email,
-              password,
-              callbackURL: '/blog',
-            });
-
-            if (result.error) {
-              setError(result.error.message ?? '登录失败');
-              return;
-            }
-
-            navigate({ to: '/blog' });
-          });
-        }}
-      >
-        <label htmlFor='email' className='font-semibold'>
-          Email
-        </label>
-        <input
-          id='email'
-          name='email'
-          type='email'
-          required
-          autoComplete='email'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-        />
-        <label htmlFor='password' className='font-semibold'>
-          Password
-        </label>
-        <input
-          id='password'
-          name='password'
-          type='password'
-          required
-          autoComplete='current-password'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={password}
-          onChange={(event) => setPassword(event.target.value)}
-        />
-        <button
-          type='submit'
-          className='rounded-md bg-black px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90 dark:bg-neutral-900'
-          disabled={isPending}
-        >
-          {isPending ? 'Signing in...' : 'Sign In'}
-        </button>
-      </form>
-
-      <button
-        type='button'
-        className='mt-3 rounded-md border border-slate-300 px-4 py-2 font-semibold transition-colors hover:bg-gray-100 dark:border-slate-700 dark:hover:bg-slate-800'
-        onClick={async () => {
-          setError(null);
-          const result = await authClient.signIn.social({
-            provider: 'github',
-            callbackURL: '/blog',
-          });
-          if (result.error) {
-            setError(result.error.message ?? 'GitHub 登录失败');
-          }
-        }}
-      >
-        Continue with GitHub
-      </button>
-    </section>
+                navigate({ to: '/blog' });
+              });
+            }}
+          >
+            <div className='j-field'>
+              <label htmlFor='email'>邮　箱</label>
+              <input
+                id='email'
+                name='email'
+                type='email'
+                required
+                autoComplete='email'
+                className='j-input'
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+              />
+            </div>
+            <div className='j-field'>
+              <label htmlFor='password'>口　令</label>
+              <input
+                id='password'
+                name='password'
+                type='password'
+                required
+                autoComplete='current-password'
+                className='j-input'
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+            </div>
+            <div className='j-actions'>
+              <button
+                type='submit'
+                className='j-btn j-btn-red'
+                disabled={isPending}
+              >
+                {isPending ? '登入中…' : '登　入'}
+              </button>
+              <button
+                type='button'
+                className='j-btn'
+                onClick={async () => {
+                  setError(null);
+                  const result = await authClient.signIn.social({
+                    provider: 'github',
+                    callbackURL: '/blog',
+                  });
+                  if (result.error) {
+                    setError(result.error.message ?? 'GitHub 登录失败');
+                  }
+                }}
+              >
+                GitHub 入会
+              </button>
+            </div>
+            {error ? <p className='j-err mt-4'>{error}</p> : null}
+          </form>
+          <p className='j-aside'>
+            尚未入会？{' '}
+            <a href='/signup' className='j-aside-link'>
+              注册
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/routes/projects.tsx
+++ b/apps/web/src/routes/projects.tsx
@@ -1,5 +1,4 @@
-import { createFileRoute, Link } from '@tanstack/react-router';
-import { ExternalLink, Github } from 'lucide-react';
+import { createFileRoute } from '@tanstack/react-router';
 import { PROJECTS, type Project } from '../lib/projects.js';
 
 export const Route = createFileRoute('/projects')({
@@ -11,6 +10,19 @@ export const Route = createFileRoute('/projects')({
   }),
   component: ProjectsPage,
 });
+
+const CN_ORDINALS = [
+  '壹',
+  '贰',
+  '叁',
+  '肆',
+  '伍',
+  '陆',
+  '柒',
+  '捌',
+  '玖',
+  '拾',
+];
 
 function sortProjects(projects: Project[]): Project[] {
   return [...projects].sort((a, b) => {
@@ -25,67 +37,36 @@ function ProjectsPage() {
   const projects = sortProjects(PROJECTS);
 
   return (
-    <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>Projects</h1>
-      <p className='mb-8 opacity-70'>我做过的一些东西，按需更新。</p>
+    <div className='j-sheet'>
+      <h1 className='j-entry-title text-center'>器物谱</h1>
+      <p className='j-entry-meta text-center'>所制之器 · 自兹编次 · 以志不忘</p>
 
-      <div className='grid gap-4 sm:grid-cols-2'>
-        {projects.map((project) => (
-          <article
-            key={project.name}
-            className='flex flex-col rounded-lg border border-slate-200 bg-white/60 p-5 transition-shadow hover:shadow-md dark:border-slate-700 dark:bg-wash-dark'
-          >
-            <div className='mb-1 flex items-center gap-2'>
-              <h2 className='text-lg font-semibold'>{project.name}</h2>
-              {project.featured ? (
-                <span className='rounded-full bg-black px-2 py-[2px] text-[10px] font-semibold text-white dark:bg-neutral-100 dark:text-neutral-900'>
-                  FEATURED
-                </span>
-              ) : null}
-            </div>
-            <p className='mb-4 flex-grow text-sm opacity-70'>
-              {project.description}
-            </p>
-            <div className='mb-4 flex flex-wrap gap-1.5'>
-              {project.tags.map((tag) => (
-                <span
-                  key={tag}
-                  className='rounded-md border border-slate-200 px-2 py-[2px] text-[11px] opacity-70 dark:border-slate-700'
-                >
-                  {tag}
-                </span>
-              ))}
-            </div>
-            <div className='flex items-center gap-4 text-sm'>
-              <a
-                href={project.repo}
-                target='_blank'
-                rel='noreferrer'
-                className='inline-flex items-center gap-1 opacity-70 hover:opacity-100'
-              >
-                <Github size={15} />
-                Code
+      {projects.map((project, index) => (
+        <div className='j-ware' key={project.name}>
+          <div className='no'>
+            {CN_ORDINALS[index] ?? index + 1}
+            {project.featured ? <small>FEATURED</small> : null}
+          </div>
+          <div>
+            <h2>
+              {project.name}
+              {project.featured ? <span className='feat'>精选</span> : null}
+            </h2>
+            <p>{project.description}</p>
+            <div className='tags'>{project.tags.join('　')}</div>
+            <div className='wlinks'>
+              <a href={project.repo} target='_blank' rel='noreferrer'>
+                源码 ↗
               </a>
               {project.demo ? (
-                <a
-                  href={project.demo}
-                  target='_blank'
-                  rel='noreferrer'
-                  className='inline-flex items-center gap-1 opacity-70 hover:opacity-100'
-                >
-                  <ExternalLink size={15} />
-                  Demo
+                <a href={project.demo} target='_blank' rel='noreferrer'>
+                  在线 ↗
                 </a>
               ) : null}
             </div>
-          </article>
-        ))}
-      </div>
-
-      <Link to='/' className='mt-8 inline-block'>
-        <span className='opacity-70'>&gt;&nbsp;&nbsp;&nbsp;</span>
-        <span className='underline opacity-70 hover:opacity-100'>cd ..</span>
-      </Link>
+          </div>
+        </div>
+      ))}
     </div>
   );
 }

--- a/apps/web/src/routes/projects.tsx
+++ b/apps/web/src/routes/projects.tsx
@@ -11,19 +11,6 @@ export const Route = createFileRoute('/projects')({
   component: ProjectsPage,
 });
 
-const CN_ORDINALS = [
-  '壹',
-  '贰',
-  '叁',
-  '肆',
-  '伍',
-  '陆',
-  '柒',
-  '捌',
-  '玖',
-  '拾',
-];
-
 function sortProjects(projects: Project[]): Project[] {
   return [...projects].sort((a, b) => {
     if (Boolean(a.featured) === Boolean(b.featured)) {
@@ -38,29 +25,26 @@ function ProjectsPage() {
 
   return (
     <div className='j-sheet'>
-      <h1 className='j-entry-title text-center'>器物谱</h1>
-      <p className='j-entry-meta text-center'>所制之器 · 自兹编次 · 以志不忘</p>
+      <h1 className='j-entry-title text-center'>Projects</h1>
+      <p className='j-entry-meta text-center'>我做过的一些东西，按需更新。</p>
 
       {projects.map((project, index) => (
         <div className='j-ware' key={project.name}>
           <div className='no'>
-            {CN_ORDINALS[index] ?? index + 1}
+            {String(index + 1).padStart(2, '0')}
             {project.featured ? <small>FEATURED</small> : null}
           </div>
           <div>
-            <h2>
-              {project.name}
-              {project.featured ? <span className='feat'>精选</span> : null}
-            </h2>
+            <h2>{project.name}</h2>
             <p>{project.description}</p>
             <div className='tags'>{project.tags.join('　')}</div>
             <div className='wlinks'>
               <a href={project.repo} target='_blank' rel='noreferrer'>
-                源码 ↗
+                Code ↗
               </a>
               {project.demo ? (
                 <a href={project.demo} target='_blank' rel='noreferrer'>
-                  在线 ↗
+                  Demo ↗
                 </a>
               ) : null}
             </div>

--- a/apps/web/src/routes/signup.tsx
+++ b/apps/web/src/routes/signup.tsx
@@ -35,93 +35,111 @@ function SignUpPage() {
 
   if (sessionData?.user?.id || isSessionPending) {
     return (
-      <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-        <p className='opacity-70'>Checking session...</p>
-      </section>
+      <div className='j-sheet'>
+        <p className='j-aside'>正在核对会籍……</p>
+      </div>
     );
   }
 
   return (
-    <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>注册</h1>
-      <p className='mb-6 opacity-70'>注册后默认角色为 member，可在后台升权。</p>
+    <div className='j-sheet'>
+      <div className='j-gate'>
+        <div className='j-gate-card'>
+          <span className='j-seal' aria-hidden='true'>
+            潘
+          </span>
+          <h1>注　册</h1>
+          <p className='sub'>注册即成为会友（member）</p>
+          <form
+            method='post'
+            onSubmit={(event) => {
+              event.preventDefault();
+              setError(null);
+              startTransition(async () => {
+                const result = await authClient.signUp.email({
+                  email,
+                  password,
+                  name,
+                  callbackURL: '/blog',
+                });
 
-      {error ? (
-        <p role='alert' className='mb-4 text-sm text-red-700 dark:text-red-300'>
-          {error}
-        </p>
-      ) : null}
+                if (result.error) {
+                  setError(result.error.message ?? '注册失败');
+                  return;
+                }
 
-      <form
-        className='grid max-w-[420px] gap-3'
-        method='post'
-        onSubmit={(event) => {
-          event.preventDefault();
-          setError(null);
-          startTransition(async () => {
-            const result = await authClient.signUp.email({
-              email,
-              password,
-              name,
-              callbackURL: '/blog',
-            });
-
-            if (result.error) {
-              setError(result.error.message ?? '注册失败');
-              return;
-            }
-
-            navigate({ to: '/blog' });
-          });
-        }}
-      >
-        <label htmlFor='name' className='font-semibold'>
-          Name
-        </label>
-        <input
-          id='name'
-          name='name'
-          type='text'
-          required
-          autoComplete='name'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={name}
-          onChange={(event) => setName(event.target.value)}
-        />
-        <label htmlFor='email' className='font-semibold'>
-          Email
-        </label>
-        <input
-          id='email'
-          name='email'
-          type='email'
-          required
-          autoComplete='email'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-        />
-        <label htmlFor='password' className='font-semibold'>
-          Password
-        </label>
-        <input
-          id='password'
-          name='password'
-          type='password'
-          required
-          autoComplete='new-password'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={password}
-          onChange={(event) => setPassword(event.target.value)}
-        />
-        <button
-          type='submit'
-          className='rounded-md bg-black px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90 dark:bg-neutral-900'
-          disabled={isPending}
-        >
-          {isPending ? 'Creating account...' : 'Sign Up'}
-        </button>
-      </form>
-    </section>
+                navigate({ to: '/blog' });
+              });
+            }}
+          >
+            <div className='j-field'>
+              <label htmlFor='name'>名　号</label>
+              <input
+                id='name'
+                name='name'
+                type='text'
+                required
+                autoComplete='name'
+                className='j-input'
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+              />
+            </div>
+            <div className='j-field'>
+              <label htmlFor='email'>邮　箱</label>
+              <input
+                id='email'
+                name='email'
+                type='email'
+                required
+                autoComplete='email'
+                className='j-input'
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+              />
+            </div>
+            <div className='j-field'>
+              <label htmlFor='password'>口　令</label>
+              <input
+                id='password'
+                name='password'
+                type='password'
+                required
+                autoComplete='new-password'
+                className='j-input'
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+            </div>
+            <div className='j-actions'>
+              <button
+                type='submit'
+                className='j-btn j-btn-red'
+                disabled={isPending}
+              >
+                {isPending ? '建立中…' : '立 会 籍'}
+              </button>
+              <button
+                type='button'
+                className='j-btn'
+                onClick={async () => {
+                  setError(null);
+                  const result = await authClient.signIn.social({
+                    provider: 'github',
+                    callbackURL: '/blog',
+                  });
+                  if (result.error) {
+                    setError(result.error.message ?? 'GitHub 注册失败');
+                  }
+                }}
+              >
+                GitHub 注册
+              </button>
+            </div>
+            {error ? <p className='j-err mt-4'>{error}</p> : null}
+          </form>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/routes/signup.tsx
+++ b/apps/web/src/routes/signup.tsx
@@ -36,7 +36,7 @@ function SignUpPage() {
   if (sessionData?.user?.id || isSessionPending) {
     return (
       <div className='j-sheet'>
-        <p className='j-aside'>正在核对会籍……</p>
+        <p className='j-aside'>Checking session...</p>
       </div>
     );
   }
@@ -48,8 +48,8 @@ function SignUpPage() {
           <span className='j-seal' aria-hidden='true'>
             潘
           </span>
-          <h1>注　册</h1>
-          <p className='sub'>注册即成为会友（member）</p>
+          <h1>注册</h1>
+          <p className='sub'>注册后默认角色为 member，可在后台升权。</p>
           <form
             method='post'
             onSubmit={(event) => {
@@ -73,7 +73,7 @@ function SignUpPage() {
             }}
           >
             <div className='j-field'>
-              <label htmlFor='name'>名　号</label>
+              <label htmlFor='name'>Name</label>
               <input
                 id='name'
                 name='name'
@@ -86,7 +86,7 @@ function SignUpPage() {
               />
             </div>
             <div className='j-field'>
-              <label htmlFor='email'>邮　箱</label>
+              <label htmlFor='email'>Email</label>
               <input
                 id='email'
                 name='email'
@@ -99,7 +99,7 @@ function SignUpPage() {
               />
             </div>
             <div className='j-field'>
-              <label htmlFor='password'>口　令</label>
+              <label htmlFor='password'>Password</label>
               <input
                 id='password'
                 name='password'
@@ -117,23 +117,7 @@ function SignUpPage() {
                 className='j-btn j-btn-red'
                 disabled={isPending}
               >
-                {isPending ? '建立中…' : '立 会 籍'}
-              </button>
-              <button
-                type='button'
-                className='j-btn'
-                onClick={async () => {
-                  setError(null);
-                  const result = await authClient.signIn.social({
-                    provider: 'github',
-                    callbackURL: '/blog',
-                  });
-                  if (result.error) {
-                    setError(result.error.message ?? 'GitHub 注册失败');
-                  }
-                }}
-              >
-                GitHub 注册
+                {isPending ? 'Creating account...' : 'Sign Up'}
               </button>
             </div>
             {error ? <p className='j-err mt-4'>{error}</p> : null}

--- a/apps/web/src/routes/unlock/$slug.tsx
+++ b/apps/web/src/routes/unlock/$slug.tsx
@@ -78,48 +78,45 @@ function UnlockPage() {
     search.error === 'missing'
       ? '请输入访问密码'
       : search.error === 'invalid'
-        ? '密码错误，请重试'
+        ? '口令有误，请再试'
         : undefined;
 
   return (
-    <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>输入文章访问密码</h1>
-      <p className='mb-6 opacity-70'>这篇文章使用了单文密码保护。</p>
-
-      {errorLabel ? (
-        <p role='alert' className='mb-4 text-sm text-red-700 dark:text-red-300'>
-          {errorLabel}
-        </p>
-      ) : null}
-
-      <form method='post' className='grid max-w-[420px] gap-3'>
-        <label htmlFor='password' className='font-semibold'>
-          Password
-        </label>
-        <input
-          id='password'
-          name='password'
-          type='password'
-          required
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-        />
-        <button
-          type='submit'
-          className='rounded-md bg-black px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90 dark:bg-neutral-900'
-        >
-          Unlock
-        </button>
-      </form>
-
-      <p className='mt-4'>
-        <Link
-          to='/blog/$slug'
-          params={{ slug }}
-          className='opacity-70 hover:opacity-100'
-        >
-          返回文章页
-        </Link>
-      </p>
-    </section>
+    <div className='j-sheet'>
+      <div className='j-gate'>
+        <div className='j-gate-card text-center'>
+          <div className='j-lockmark' aria-hidden='true'>
+            密
+          </div>
+          <h1>密　笺</h1>
+          <p className='sub'>此篇以单文口令封缄 · 验后廿四小时内免复输入</p>
+          <form method='post' className='text-left'>
+            <div className='j-field'>
+              <label htmlFor='password'>篇目口令</label>
+              <input
+                id='password'
+                name='password'
+                type='password'
+                required
+                className='j-input'
+              />
+            </div>
+            {errorLabel ? (
+              <p className='j-err text-center'>{errorLabel}</p>
+            ) : null}
+            <div className='j-actions justify-center'>
+              <button type='submit' className='j-btn j-btn-red'>
+                启　封
+              </button>
+            </div>
+          </form>
+          <p className='j-aside'>
+            <Link to='/blog/$slug' params={{ slug }}>
+              ← 返回篇目
+            </Link>
+          </p>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/routes/unlock/$slug.tsx
+++ b/apps/web/src/routes/unlock/$slug.tsx
@@ -78,7 +78,7 @@ function UnlockPage() {
     search.error === 'missing'
       ? '请输入访问密码'
       : search.error === 'invalid'
-        ? '口令有误，请再试'
+        ? '密码错误，请重试'
         : undefined;
 
   return (
@@ -86,13 +86,13 @@ function UnlockPage() {
       <div className='j-gate'>
         <div className='j-gate-card text-center'>
           <div className='j-lockmark' aria-hidden='true'>
-            密
+            锁
           </div>
-          <h1>密　笺</h1>
-          <p className='sub'>此篇以单文口令封缄 · 验后廿四小时内免复输入</p>
+          <h1>输入文章访问密码</h1>
+          <p className='sub'>这篇文章使用了单文密码保护。</p>
           <form method='post' className='text-left'>
             <div className='j-field'>
-              <label htmlFor='password'>篇目口令</label>
+              <label htmlFor='password'>Password</label>
               <input
                 id='password'
                 name='password'
@@ -106,13 +106,17 @@ function UnlockPage() {
             ) : null}
             <div className='j-actions justify-center'>
               <button type='submit' className='j-btn j-btn-red'>
-                启　封
+                Unlock
               </button>
             </div>
           </form>
           <p className='j-aside'>
-            <Link to='/blog/$slug' params={{ slug }}>
-              ← 返回篇目
+            <Link
+              to='/blog/$slug'
+              params={{ slug }}
+              style={{ color: 'var(--j-indigo)' }}
+            >
+              返回文章页
             </Link>
           </p>
         </div>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -144,3 +144,899 @@ html.dark ::-webkit-scrollbar-thumb {
 html.dark ::-webkit-scrollbar-thumb:hover {
   background: rgb(148 163 184 / 0.55);
 }
+
+/* =====================================================================
+ * THEME B — Literary Journal 《废墨集》 (UX redesign direction B)
+ * Paper-native Chinese literary journal: serif display, seal red,
+ * vertical spine label, TOC dot leaders, drop caps. Light-only.
+ * =================================================================== */
+:root {
+  /* shadcn token layer → paper palette (search palette & dialogs) */
+  --background: 45 30% 94%;
+  --foreground: 30 6% 14%;
+  --card: 45 27% 96%;
+  --card-foreground: 30 6% 14%;
+  --popover: 45 27% 96%;
+  --popover-foreground: 30 6% 14%;
+  --primary: 8 58% 42%;
+  --primary-foreground: 40 33% 94%;
+  --secondary: 45 22% 90%;
+  --secondary-foreground: 30 6% 14%;
+  --muted: 45 22% 90%;
+  --muted-foreground: 40 8% 42%;
+  --accent: 45 22% 88%;
+  --accent-foreground: 30 6% 14%;
+  --destructive: 8 58% 42%;
+  --destructive-foreground: 40 33% 94%;
+  --border: 44 18% 80%;
+  --input: 44 18% 80%;
+  --ring: 8 58% 42%;
+  --radius: 0.125rem;
+
+  --j-paper: #f6f3ec;
+  --j-paper2: #efeae0;
+  --j-ink: #262523;
+  --j-faded: #6e6a60;
+  --j-faint: #a29c8e;
+  --j-red: #a63a2b;
+  --j-indigo: #2e4a68;
+  --j-rule: #dad4c6;
+  --j-serif:
+    "Songti SC", "Noto Serif SC", "Source Han Serif SC", "SimSun", serif;
+  --j-sans:
+    "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", system-ui, sans-serif;
+  --j-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}
+
+html {
+  background-color: var(--j-paper);
+  scrollbar-color: #cfc8b8 var(--j-paper);
+}
+
+html body {
+  font-family: var(--j-serif);
+  background-color: var(--j-paper);
+  color: var(--j-ink);
+  font-size: 16.5px;
+  line-height: 2;
+}
+
+::selection {
+  background: rgba(166, 58, 43, 0.16);
+}
+
+/* ---------- masthead ---------- */
+.j-masthead {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 30px 24px 0;
+  display: flex;
+  align-items: flex-end;
+  gap: 24px;
+}
+.j-brand {
+  font-size: 30px;
+  font-weight: 900;
+  letter-spacing: 0.22em;
+  white-space: nowrap;
+}
+.j-brand a {
+  color: var(--j-ink);
+}
+.j-brand a:hover {
+  color: var(--j-ink);
+  text-decoration: none;
+}
+.j-brand .j-dot {
+  color: var(--j-red);
+}
+.j-masthead nav {
+  display: flex;
+  gap: 26px;
+  font-family: var(--j-sans);
+  font-size: 13.5px;
+  letter-spacing: 0.28em;
+  margin-left: auto;
+}
+.j-masthead nav a,
+.j-masthead nav button {
+  color: var(--j-faded);
+  font-family: var(--j-sans);
+  font-size: 13.5px;
+  letter-spacing: 0.28em;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  padding: 0;
+}
+.j-masthead nav a:hover,
+.j-masthead nav button:hover {
+  color: var(--j-red);
+  text-decoration: none;
+}
+.j-headrule {
+  max-width: 960px;
+  margin: 14px auto 0;
+  padding: 0 24px;
+}
+.j-headrule hr {
+  border: 0;
+  border-top: 2.5px solid var(--j-ink);
+  position: relative;
+}
+.j-headrule hr::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 3px;
+  border-top: 1px solid var(--j-ink);
+}
+
+/* ---------- shell ---------- */
+.j-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+}
+.j-main {
+  flex: 1;
+  overflow-y: auto;
+}
+.j-sheet {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 40px 24px 60px;
+  position: relative;
+}
+.j-spine {
+  position: absolute;
+  left: -54px;
+  top: 6px;
+  writing-mode: vertical-rl;
+  letter-spacing: 0.5em;
+  font-size: 13px;
+  color: var(--j-faint);
+  border-right: 1px solid var(--j-rule);
+  padding-right: 10px;
+  height: 320px;
+  user-select: none;
+}
+@media (max-width: 860px) {
+  .j-spine {
+    display: none;
+  }
+}
+
+.j-colophon {
+  border-top: 2.5px solid var(--j-ink);
+  position: relative;
+  margin: 48px auto 0;
+  max-width: 960px;
+  padding: 18px 24px 26px;
+  text-align: center;
+  font-family: var(--j-sans);
+  font-size: 12px;
+  color: var(--j-faint);
+  letter-spacing: 0.2em;
+}
+.j-colophon::before {
+  content: "";
+  position: absolute;
+  left: 24px;
+  right: 24px;
+  top: 3px;
+  border-top: 1px solid var(--j-ink);
+}
+.j-colophon a {
+  color: var(--j-indigo);
+}
+
+/* ---------- seal & notes ---------- */
+.j-seal {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 46px;
+  height: 46px;
+  background: var(--j-red);
+  color: #f8f4ea;
+  font-size: 24px;
+  font-weight: 900;
+  border-radius: 7px;
+  box-shadow:
+    inset 0 0 0 2px rgba(248, 244, 234, 0.55),
+    inset 0 0 0 4px var(--j-red);
+  transform: rotate(-4deg);
+}
+.j-note {
+  font-family: var(--j-sans);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  color: var(--j-faded);
+  border: 1px solid var(--j-rule);
+  border-radius: 2px;
+  padding: 0 6px;
+  margin-left: 10px;
+  white-space: nowrap;
+  vertical-align: 2px;
+}
+.j-note.vip,
+.j-note.mem {
+  color: var(--j-indigo);
+  border-color: #c9d4df;
+}
+.j-note.pw {
+  color: var(--j-red);
+  border-color: #dfc0ba;
+}
+.j-note.adm {
+  color: var(--j-faded);
+}
+
+/* ---------- 扉页 home ---------- */
+.j-frontispiece {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 48px;
+  align-items: start;
+}
+.j-vertical {
+  writing-mode: vertical-rl;
+  font-size: 78px;
+  font-weight: 900;
+  letter-spacing: 0.18em;
+  line-height: 1.15;
+  border-left: 3px solid var(--j-ink);
+  padding-left: 26px;
+  height: 440px;
+  user-select: none;
+}
+.j-vertical small {
+  font-size: 15px;
+  font-weight: 400;
+  color: var(--j-faded);
+  letter-spacing: 0.4em;
+  margin-top: 18px;
+}
+@media (max-width: 760px) {
+  .j-frontispiece {
+    grid-template-columns: 1fr;
+  }
+  .j-vertical {
+    height: auto;
+    writing-mode: horizontal-tb;
+    font-size: 44px;
+    border-left: 0;
+    border-bottom: 3px solid var(--j-ink);
+    padding: 0 0 16px;
+  }
+  .j-vertical small {
+    margin: 8px 0 0 10px;
+    display: block;
+  }
+}
+.j-tagline {
+  font-size: 19px;
+  line-height: 2.1;
+  max-width: 34ch;
+}
+.j-facts {
+  margin-top: 26px;
+  font-family: var(--j-sans);
+  font-size: 13px;
+  color: var(--j-faded);
+  display: flex;
+  gap: 22px;
+  flex-wrap: wrap;
+  letter-spacing: 0.1em;
+}
+.j-facts b {
+  color: var(--j-ink);
+  font-weight: 600;
+}
+.j-blockhead {
+  font-family: var(--j-sans);
+  font-size: 12.5px;
+  letter-spacing: 0.42em;
+  color: var(--j-red);
+  margin-bottom: 8px;
+  font-weight: 600;
+}
+.j-btn {
+  font-family: var(--j-sans);
+  font-size: 13.5px;
+  letter-spacing: 0.2em;
+  cursor: pointer;
+  padding: 10px 26px;
+  border-radius: 2px;
+  border: 1.5px solid var(--j-ink);
+  background: transparent;
+  color: var(--j-ink);
+  transition: all 0.15s;
+  display: inline-block;
+}
+.j-btn:hover {
+  background: var(--j-ink);
+  color: var(--j-paper);
+  text-decoration: none;
+}
+.j-btn-red {
+  border-color: var(--j-red);
+  color: var(--j-red);
+}
+.j-btn-red:hover {
+  background: var(--j-red);
+  color: var(--j-paper);
+}
+
+/* ---------- 目次 TOC ---------- */
+.j-entry-title {
+  font-size: 32px;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+}
+.j-entry-meta {
+  font-family: var(--j-sans);
+  font-size: 13px;
+  color: var(--j-indigo);
+  letter-spacing: 0.06em;
+  margin-top: 10px;
+}
+.j-juan {
+  display: flex;
+  align-items: baseline;
+  gap: 18px;
+  margin: 40px 0 8px;
+}
+.j-juan h2 {
+  font-size: 24px;
+  font-weight: 900;
+  letter-spacing: 0.3em;
+}
+.j-juan .sub {
+  font-family: var(--j-sans);
+  font-size: 12px;
+  color: var(--j-faint);
+  letter-spacing: 0.2em;
+}
+.j-juan::after {
+  content: "";
+  flex: 1;
+  border-bottom: 1px solid var(--j-rule);
+  transform: translateY(-6px);
+}
+.j-toc-line {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 8px 0;
+  font-size: 17px;
+}
+.j-toc-line a {
+  display: flex;
+  flex: 1;
+  align-items: baseline;
+  gap: 10px;
+  color: var(--j-ink);
+}
+.j-toc-line a:hover {
+  text-decoration: none;
+}
+.j-toc-line .t {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.j-toc-line a:hover .t {
+  color: var(--j-red);
+}
+.j-toc-line .dots {
+  flex: 1;
+  border-bottom: 2px dotted var(--j-faint);
+  transform: translateY(-5px);
+  min-width: 24px;
+}
+.j-toc-line .n {
+  font-family: var(--j-mono);
+  font-size: 12.5px;
+  color: var(--j-faded);
+  white-space: nowrap;
+}
+.j-pager {
+  display: flex;
+  justify-content: center;
+  gap: 30px;
+  margin-top: 50px;
+  font-family: var(--j-sans);
+  font-size: 13px;
+  letter-spacing: 0.15em;
+  color: var(--j-faded);
+}
+.j-pager a {
+  color: var(--j-red);
+}
+.j-devhint {
+  font-family: var(--j-sans);
+  border: 1px dashed var(--j-rule);
+  background: var(--j-paper2);
+  color: var(--j-faded);
+  border-radius: 3px;
+  padding: 8px 14px;
+  font-size: 13px;
+  margin-bottom: 18px;
+}
+
+/* ---------- 正文 article ---------- */
+.j-article {
+  max-width: 46em;
+  margin: 0 auto;
+}
+.j-running-head {
+  font-family: var(--j-sans);
+  font-size: 11.5px;
+  color: var(--j-faint);
+  letter-spacing: 0.3em;
+  text-align: center;
+  margin-bottom: 26px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--j-rule);
+}
+.j-article .j-entry-title,
+.j-article .j-entry-meta {
+  text-align: center;
+}
+.j-article .j-entry-meta {
+  margin: 14px 0 34px;
+}
+.j-backlink {
+  text-align: center;
+  margin-top: 54px;
+  font-family: var(--j-sans);
+  font-size: 13px;
+  letter-spacing: 0.3em;
+}
+.j-backlink a {
+  color: var(--j-faded);
+}
+.j-backlink a:hover {
+  color: var(--j-red);
+}
+
+.md p {
+  margin: 18px 0;
+  text-align: justify;
+}
+.md > p:first-of-type::first-letter,
+.md > p:first-child::first-letter {
+  font-size: 3em;
+  font-weight: 900;
+  float: left;
+  line-height: 1;
+  margin: 8px 12px 0 0;
+  color: var(--j-red);
+}
+.md h2 {
+  font-size: 21px;
+  font-weight: 900;
+  margin: 40px 0 14px;
+  letter-spacing: 0.08em;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  scroll-margin-top: 20px;
+}
+.md h2::before,
+.md h2::after {
+  content: "";
+  height: 1px;
+  background: var(--j-rule);
+  flex: 1;
+}
+.md h2 a {
+  color: inherit;
+}
+.md ul {
+  padding-left: 0;
+  list-style: none;
+  margin: 16px 0;
+}
+.md ul li {
+  padding-left: 1.6em;
+  position: relative;
+  margin: 8px 0;
+}
+.md ul li::before {
+  content: "—";
+  position: absolute;
+  left: 0;
+  color: var(--j-red);
+}
+.md a {
+  color: var(--j-indigo);
+}
+.md a:hover {
+  color: var(--j-red);
+}
+.md blockquote {
+  margin: 26px 0;
+  padding: 14px 22px;
+  background: var(--j-paper2);
+  border-left: 3px solid var(--j-red);
+  color: var(--j-faded);
+  font-size: 15.5px;
+}
+.md :where(code.j-inline) {
+  font-family: var(--j-mono);
+  font-size: 0.84em;
+  background: var(--j-paper2);
+  border: 1px solid var(--j-rule);
+  border-radius: 2px;
+  padding: 1px 6px;
+  color: var(--j-red);
+}
+
+/* code panel: ink-dark paper (force shiki dark palette without html.dark) */
+.j-code {
+  position: relative;
+  margin: 24px 0;
+}
+.j-code-copy {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  z-index: 10;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid #4a463e;
+  background: rgba(43, 41, 38, 0.9);
+  color: #b5ae9f;
+  border-radius: 3px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-family: var(--j-mono);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.j-code:hover .j-code-copy,
+.j-code-copy:focus-visible {
+  opacity: 1;
+}
+@media not (hover: hover) {
+  .j-code-copy {
+    opacity: 0.75;
+  }
+}
+.md pre.j-pre {
+  font-family: var(--j-mono);
+  font-size: 13px;
+  line-height: 1.8;
+  background: #2b2926;
+  color: #e8e2d5;
+  border-radius: 4px;
+  padding: 20px 22px;
+  overflow-x: auto;
+  margin: 0;
+}
+.md pre.j-pre {
+  /* biome-ignore lint/complexity/noImportantStyles: shiki writes an inline light bg; the journal uses an ink panel. */
+  background: #2b2926 !important;
+}
+.md pre.j-pre span {
+  /* biome-ignore lint/complexity/noImportantStyles: force shiki dark tokens without html.dark. */
+  color: var(--shiki-dark) !important;
+}
+.md .j-pre code {
+  background: none;
+  padding: 0;
+}
+
+/* ---------- 读者来函 comments ---------- */
+.j-letters {
+  max-width: 46em;
+  margin: 60px auto 0;
+}
+.j-letter {
+  border: 1px solid var(--j-rule);
+  border-radius: 3px;
+  padding: 18px 22px;
+  margin: 14px 0;
+  background: rgba(255, 255, 255, 0.45);
+}
+.j-letter-reply {
+  margin-left: 44px;
+  background: var(--j-paper2);
+}
+.j-lhead {
+  font-family: var(--j-sans);
+  font-size: 12.5px;
+  color: var(--j-indigo);
+  letter-spacing: 0.08em;
+  margin-bottom: 6px;
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+.j-lhead .who {
+  color: var(--j-ink);
+  font-weight: 600;
+}
+.j-lhead .when {
+  color: var(--j-faint);
+}
+.j-lhead .badge {
+  background: var(--j-red);
+  color: #f6f3ec;
+  font-size: 10px;
+  border-radius: 2px;
+  padding: 0 6px;
+  letter-spacing: 0.12em;
+}
+.j-lbody p {
+  font-size: 15.5px;
+  line-height: 1.95;
+  margin: 0 0 6px;
+}
+.j-lbody p:last-child {
+  margin-bottom: 0;
+}
+.j-lbody :where(code) {
+  font-family: var(--j-mono);
+  font-size: 0.85em;
+  background: var(--j-paper2);
+  border: 1px solid var(--j-rule);
+  border-radius: 2px;
+  padding: 0 5px;
+  color: var(--j-red);
+}
+.j-lbody blockquote {
+  border-left: 2px solid var(--j-rule);
+  padding-left: 12px;
+  color: var(--j-faded);
+}
+.j-lops {
+  display: flex;
+  gap: 16px;
+  font-family: var(--j-sans);
+  font-size: 12px;
+  margin-top: 8px;
+}
+.j-lops :where(button) {
+  color: var(--j-faded);
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font-family: var(--j-sans);
+  font-size: 12px;
+  padding: 0;
+  letter-spacing: 0.1em;
+}
+.j-lops :where(button):hover {
+  color: var(--j-red);
+}
+.j-cmt-form textarea {
+  width: 100%;
+  resize: vertical;
+  font-family: var(--j-serif);
+  font-size: 15.5px;
+  color: var(--j-ink);
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid var(--j-rule);
+  border-radius: 3px;
+  padding: 10px 14px;
+}
+.j-cmt-form textarea:focus {
+  outline: none;
+  border-color: var(--j-red);
+  box-shadow: 0 0 0 2px rgba(166, 58, 43, 0.12);
+}
+.j-cmt-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 8px;
+}
+.j-cmt-hint {
+  font-family: var(--j-sans);
+  font-size: 12px;
+  color: var(--j-faint);
+}
+.j-cmt-hint :where(.j-err) {
+  color: var(--j-red);
+  margin-left: 8px;
+}
+.j-err {
+  font-family: var(--j-sans);
+  font-size: 13px;
+  color: var(--j-red);
+}
+
+/* ---------- 器物谱 projects ---------- */
+.j-ware {
+  display: grid;
+  grid-template-columns: 72px 1fr;
+  gap: 0 26px;
+  padding: 26px 0;
+  border-bottom: 1px solid var(--j-rule);
+}
+.j-ware .no {
+  font-size: 26px;
+  font-weight: 900;
+  color: var(--j-faint);
+}
+.j-ware .no small {
+  display: block;
+  font-size: 11px;
+  font-family: var(--j-sans);
+  letter-spacing: 0.2em;
+  margin-top: 4px;
+  color: var(--j-red);
+}
+.j-ware h2 {
+  font-size: 21px;
+  font-weight: 900;
+  letter-spacing: 0.04em;
+}
+.j-ware h2 .feat {
+  color: var(--j-red);
+  font-size: 13px;
+  margin-left: 10px;
+  letter-spacing: 0.2em;
+  font-family: var(--j-sans);
+}
+.j-ware p {
+  color: var(--j-faded);
+  font-size: 15.5px;
+  margin-top: 6px;
+}
+.j-ware .wlinks {
+  margin-top: 10px;
+  font-family: var(--j-sans);
+  font-size: 13px;
+  display: flex;
+  gap: 20px;
+}
+.j-ware .wlinks a {
+  color: var(--j-indigo);
+  border-bottom: 1px solid #c9d4df;
+}
+.j-ware .tags {
+  margin-top: 8px;
+  font-family: var(--j-sans);
+  font-size: 12px;
+  color: var(--j-faint);
+  letter-spacing: 0.1em;
+}
+@media (max-width: 640px) {
+  .j-ware {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ---------- forms ---------- */
+.j-gate {
+  max-width: 460px;
+  margin: 30px auto 0;
+}
+.j-gate-card {
+  border: 1.5px solid var(--j-ink);
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.5);
+  padding: 38px 40px 40px;
+  position: relative;
+  box-shadow: 6px 6px 0 rgba(38, 37, 35, 0.08);
+}
+.j-gate-card .j-seal {
+  position: absolute;
+  right: 26px;
+  top: -23px;
+}
+.j-gate h1 {
+  font-size: 26px;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+}
+.j-gate .sub {
+  font-family: var(--j-sans);
+  font-size: 13px;
+  color: var(--j-faded);
+  margin: 8px 0 26px;
+  letter-spacing: 0.08em;
+}
+.j-field {
+  margin: 16px 0;
+}
+.j-field label {
+  display: block;
+  font-family: var(--j-sans);
+  font-size: 12.5px;
+  letter-spacing: 0.24em;
+  color: var(--j-faded);
+  margin-bottom: 6px;
+}
+.j-input {
+  width: 100%;
+  font-family: var(--j-serif);
+  font-size: 15.5px;
+  color: var(--j-ink);
+  background: var(--j-paper);
+  border: 1px solid var(--j-rule);
+  border-radius: 2px;
+  padding: 10px 14px;
+}
+.j-input:focus {
+  outline: none;
+  border-color: var(--j-red);
+  box-shadow: 0 0 0 2px rgba(166, 58, 43, 0.12);
+}
+.j-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 26px;
+  flex-wrap: wrap;
+}
+.j-aside {
+  text-align: center;
+  margin-top: 22px;
+  font-family: var(--j-sans);
+  font-size: 13px;
+  color: var(--j-faded);
+}
+.j-aside a {
+  color: var(--j-red);
+}
+.j-lockmark {
+  width: 54px;
+  height: 54px;
+  border: 2px solid var(--j-red);
+  border-radius: 4px;
+  color: var(--j-red);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 26px;
+  font-weight: 900;
+  margin: 0 auto 20px;
+  transform: rotate(3deg);
+}
+
+/* ---------- 404 ---------- */
+.j-nf {
+  text-align: center;
+  padding: 90px 0 40px;
+}
+.j-nf .zh {
+  font-size: 40px;
+  font-weight: 900;
+  letter-spacing: 0.3em;
+}
+.j-nf p {
+  font-family: var(--j-sans);
+  font-size: 14px;
+  color: var(--j-faded);
+  margin-top: 18px;
+  letter-spacing: 0.15em;
+}
+
+/* journal masthead user chip */
+.j-user-chip {
+  align-items: baseline;
+  gap: 8px;
+  font-family: var(--j-sans);
+  font-size: 12px;
+  color: var(--j-faded);
+  letter-spacing: 0.08em;
+}
+.j-user-role {
+  border: 1px solid var(--j-rule);
+  border-radius: 2px;
+  padding: 0 6px;
+  font-size: 10px;
+  color: var(--j-indigo);
+  letter-spacing: 0.12em;
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -207,7 +207,7 @@ html body {
 
 /* ---------- masthead ---------- */
 .j-masthead {
-  max-width: 960px;
+  max-width: 1120px;
   margin: 0 auto;
   padding: 30px 24px 0;
   display: flex;
@@ -255,7 +255,7 @@ html body {
   text-decoration: none;
 }
 .j-headrule {
-  max-width: 960px;
+  max-width: 1120px;
   margin: 14px auto 0;
   padding: 0 24px;
 }
@@ -284,35 +284,16 @@ html body {
   overflow-y: auto;
 }
 .j-sheet {
-  max-width: 960px;
+  max-width: 1120px;
   margin: 0 auto;
   padding: 40px 24px 60px;
   position: relative;
 }
-.j-spine {
-  position: absolute;
-  left: -54px;
-  top: 6px;
-  writing-mode: vertical-rl;
-  letter-spacing: 0.5em;
-  font-size: 13px;
-  color: var(--j-faint);
-  border-right: 1px solid var(--j-rule);
-  padding-right: 10px;
-  height: 320px;
-  user-select: none;
-}
-@media (max-width: 860px) {
-  .j-spine {
-    display: none;
-  }
-}
-
 .j-colophon {
   border-top: 2.5px solid var(--j-ink);
   position: relative;
   margin: 48px auto 0;
-  max-width: 960px;
+  max-width: 1120px;
   padding: 18px 24px 26px;
   text-align: center;
   font-family: var(--j-sans);
@@ -374,55 +355,28 @@ html body {
   color: var(--j-faded);
 }
 
-/* ---------- 扉页 home ---------- */
-.j-frontispiece {
+/* ---------- home: wide two-column ---------- */
+.j-home {
   display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 48px;
+  grid-template-columns: 1.15fr 1fr;
+  gap: 56px;
   align-items: start;
+  padding-top: 44px;
 }
-.j-vertical {
-  writing-mode: vertical-rl;
-  font-size: 78px;
+.j-home h1 {
+  font-family: var(--j-serif);
+  font-size: clamp(30px, 3.4vw, 44px);
   font-weight: 900;
-  letter-spacing: 0.18em;
-  line-height: 1.15;
-  border-left: 3px solid var(--j-ink);
-  padding-left: 26px;
-  height: 440px;
-  user-select: none;
-}
-.j-vertical small {
-  font-size: 15px;
-  font-weight: 400;
-  color: var(--j-faded);
-  letter-spacing: 0.4em;
-  margin-top: 18px;
-}
-@media (max-width: 760px) {
-  .j-frontispiece {
-    grid-template-columns: 1fr;
-  }
-  .j-vertical {
-    height: auto;
-    writing-mode: horizontal-tb;
-    font-size: 44px;
-    border-left: 0;
-    border-bottom: 3px solid var(--j-ink);
-    padding: 0 0 16px;
-  }
-  .j-vertical small {
-    margin: 8px 0 0 10px;
-    display: block;
-  }
+  line-height: 1.55;
+  letter-spacing: 0.04em;
 }
 .j-tagline {
-  font-size: 19px;
-  line-height: 2.1;
-  max-width: 34ch;
+  font-size: 17px;
+  line-height: 2.05;
+  max-width: 40ch;
 }
 .j-facts {
-  margin-top: 26px;
+  margin-top: 24px;
   font-family: var(--j-sans);
   font-size: 13px;
   color: var(--j-faded);
@@ -435,39 +389,62 @@ html body {
   color: var(--j-ink);
   font-weight: 600;
 }
-.j-blockhead {
-  font-family: var(--j-sans);
-  font-size: 12.5px;
-  letter-spacing: 0.42em;
-  color: var(--j-red);
-  margin-bottom: 8px;
-  font-weight: 600;
+.j-home-cta {
+  margin-top: 30px;
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
 }
-.j-btn {
+.j-home-seal {
+  margin-top: 36px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.j-home-seal .sign {
   font-family: var(--j-sans);
-  font-size: 13.5px;
+  font-size: 12px;
+  color: var(--j-faint);
   letter-spacing: 0.2em;
-  cursor: pointer;
-  padding: 10px 26px;
-  border-radius: 2px;
-  border: 1.5px solid var(--j-ink);
-  background: transparent;
-  color: var(--j-ink);
-  transition: all 0.15s;
-  display: inline-block;
+  line-height: 1.9;
 }
-.j-btn:hover {
-  background: var(--j-ink);
-  color: var(--j-paper);
+.j-home-panel {
+  border: 1px solid var(--j-rule);
+  background: rgba(255, 255, 255, 0.45);
+  padding: 26px 30px 30px;
+}
+.j-latest-item {
+  display: flex;
+  gap: 12px;
+  padding: 9px 0;
+  border-bottom: 1px dotted var(--j-rule);
+  align-items: baseline;
+}
+.j-latest-item:last-child {
+  border-bottom: 0;
+}
+.j-latest-item .t {
+  flex: 1;
+  color: var(--j-ink);
+  font-weight: 600;
+  font-size: 15px;
+}
+.j-latest-item .t:hover {
+  color: var(--j-red);
   text-decoration: none;
 }
-.j-btn-red {
-  border-color: var(--j-red);
-  color: var(--j-red);
+.j-latest-item .d {
+  font-family: var(--j-mono);
+  font-size: 11.5px;
+  color: var(--j-faint);
+  white-space: nowrap;
 }
-.j-btn-red:hover {
-  background: var(--j-red);
-  color: var(--j-paper);
+@media (max-width: 860px) {
+  .j-home {
+    grid-template-columns: 1fr;
+    gap: 34px;
+    padding-top: 28px;
+  }
 }
 
 /* ---------- 目次 TOC ---------- */

--- a/tests/e2e/admin-flow.spec.ts
+++ b/tests/e2e/admin-flow.spec.ts
@@ -19,7 +19,7 @@ test('admin can create a post that appears on the blog', async ({ page }) => {
   await page.locator('#password').fill(ADMIN_PASSWORD);
   await page.locator('form button[type="submit"]').click();
 
-  const loggedIn = page.getByRole('link', { name: /logout/i });
+  const loggedIn = page.getByTestId('nav-logout');
   try {
     await expect(loggedIn).toBeVisible({ timeout: 8000 });
   } catch {

--- a/tests/e2e/auth-logout.spec.ts
+++ b/tests/e2e/auth-logout.spec.ts
@@ -8,18 +8,20 @@ function createUniqueEmail(): string {
 test('signup then logout returns to guest header state', async ({ page }) => {
   await page.goto('/signup', { waitUntil: 'domcontentloaded' });
 
-  await page.getByLabel('Name').fill('E2E Logout');
-  await page.getByLabel('Email').fill(createUniqueEmail());
-  await page.getByLabel('Password').fill('Playwright!12345');
-  await page.getByRole('button', { name: 'Sign Up' }).click();
+  // Form anchors are theme-stable: field ids on /signup + the submit button.
+  // Header anchors use data-testid because each UX theme words them
+  // differently (login / 入会 / SIGN IN …).
+  await page.locator('#name').fill('E2E Logout');
+  await page.locator('#email').fill(createUniqueEmail());
+  await page.locator('#password').fill('Playwright!12345');
+  await page.locator('form button[type="submit"]').click();
 
   await page.waitForURL('**/blog');
-  await expect(page.getByRole('link', { name: 'Logout' })).toBeVisible();
+  await expect(page.getByTestId('nav-logout')).toBeVisible();
 
-  await page.getByRole('link', { name: 'Logout' }).click();
+  await page.getByTestId('nav-logout').click();
 
   await page.waitForURL('**/blog');
-  await expect(page.getByRole('link', { name: 'Login' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Sign Up' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Logout' })).toHaveCount(0);
+  await expect(page.getByTestId('nav-login')).toBeVisible();
+  await expect(page.getByTestId('nav-logout')).toHaveCount(0);
 });


### PR DESCRIPTION
## What — UX 改版方向 B「文学集刊《废墨集》」落地

把原型 `prototypes/b-journal.html` 落到真实应用：整站做成一本中文个人集刊。

- **刊头**：品牌「废墨集。」+ 双线分隔 + 栏目导航（目次 / 器物 / 编辑部）
- **扉页**：竖排刊名 + 创刊信息 + 统计 + **朱砂印章「潘」**
- **博客列表 = 目次**：按年分「卷」，标题—点线引导—中文数字编号（〇一六），可见性标注为「会员可读 / VIP / 密笈」小注
- **文章页 = 正文**：居中眉批 + 居中标题 + **首字下沉朱字**、二级标题两侧短横线、深色代码块（墨色面板）；评论区 =「读者来函」
- **项目页 = 器物谱**（壹贰叁…序号）；**登录 = 入会**（印章卡片）；**解锁 = 密笺**；**404 = 此页未收**
- 纸色亮色原生（隐藏主题切换），shadcn tokens 重皮肤为纸墨配色，⌘K 面板同套色

## 不变的东西

路由 / loader / 鉴权 / 评论 / 搜索逻辑全部未动，仅视觉层。Admin 沿用现有亮色样式。

## 验证

- [x] `pnpm typecheck` / `pnpm lint`（0 warning）/ `pnpm test`（36 passed）
- [x] build + 体积守门：**gzip 1024.78 KiB / 3072 KiB**
- [x] 本地 dev 冒烟 + DOM/CSS 断言：纸色背景、宋体、竖排刊名、印章、目次点线（20 条）、墨色代码块（rgb(43,41,38)）全部命中

> 7 个候选方向之一（A–G），最终只合并一个或全部关闭。预览用 Workers Builds preview URL。