### PR TITLE
feat(web): apply swiss data-grid theme (UX direction C)

### DIFF
--- a/apps/web/src/components/comments.tsx
+++ b/apps/web/src/components/comments.tsx
@@ -20,14 +20,6 @@ type CommentsProps = {
 
 const PAGE_SIZE = 20;
 
-function getInitials(name: string): string {
-  const trimmed = name.trim();
-  if (!trimmed) {
-    return '?';
-  }
-  return trimmed.slice(0, 1).toUpperCase();
-}
-
 function formatRelative(iso: string): string {
   const then = new Date(iso).getTime();
   if (Number.isNaN(then)) {
@@ -54,24 +46,6 @@ function formatRelative(iso: string): string {
     day: 'numeric',
     year: 'numeric',
   });
-}
-
-function Avatar({ name, image }: { name: string; image: string | null }) {
-  if (image) {
-    return (
-      <img
-        src={image}
-        alt={name}
-        loading='lazy'
-        className='h-8 w-8 shrink-0 rounded-full bg-zinc-100 dark:bg-zinc-800'
-      />
-    );
-  }
-  return (
-    <div className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-zinc-200 text-xs font-semibold text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300'>
-      {getInitials(name)}
-    </div>
-  );
 }
 
 type ComposerProps = {
@@ -107,29 +81,37 @@ function Composer({
   }
 
   return (
-    <form onSubmit={handleSubmit} className='flex flex-col gap-2'>
-      <textarea
-        value={body}
-        onChange={(event) => setBody(event.target.value)}
-        placeholder={placeholder}
-        rows={compact ? 2 : 3}
-        maxLength={2000}
-        className='w-full resize-y rounded-md border border-zinc-300 bg-transparent px-3 py-2 text-sm outline-none transition-colors focus:border-zinc-400 dark:border-zinc-600 dark:focus:border-zinc-400'
-      />
-      <div className='flex items-center justify-between gap-2'>
-        <span className='text-xs opacity-50'>
-          {remaining < 200 ? `${remaining} 字剩余` : '支持 Markdown'}
-          {error ? <span className='ml-2 text-red-500'>{error}</span> : null}
-        </span>
+    <div>
+      <form onSubmit={handleSubmit} className='c-cmt-form'>
+        <textarea
+          value={body}
+          onChange={(event) => setBody(event.target.value)}
+          placeholder={placeholder}
+          rows={compact ? 2 : 3}
+          maxLength={2000}
+        />
         <button
           type='submit'
           disabled={submitting || !body.trim()}
-          className='rounded-md bg-black px-3 py-1 text-xs font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-neutral-900'
+          style={{
+            borderLeft: '1px solid var(--c-ink)',
+            background: 'var(--c-ink)',
+            color: 'var(--c-bg)',
+            fontFamily: 'var(--c-sans)',
+            fontSize: 13,
+            fontWeight: 600,
+            padding: '0 24px',
+            cursor: 'pointer',
+          }}
         >
-          {submitting ? '发送中…' : '发送'}
+          {submitting ? '发送中…' : '评论 →'}
         </button>
-      </div>
-    </form>
+      </form>
+      <p className='c-cmt-hint mt-2 text-right'>
+        {error ? <span className='err'>{error}</span> : null}
+        {remaining < 200 ? `${remaining} 字剩余` : '支持 Markdown'}
+      </p>
+    </div>
   );
 }
 
@@ -191,7 +173,7 @@ function CommentItem({
       ) : null}
 
       {thread.replies.length > 0 ? (
-        <ul className='ml-10 flex flex-col gap-2 border-l border-zinc-200 pl-4 dark:border-zinc-700'>
+        <ul className='flex flex-col'>
           {thread.replies.map((reply) => {
             const replyCanAct =
               sessionUser != null &&
@@ -201,6 +183,7 @@ function CommentItem({
                 key={reply.id}
                 comment={reply}
                 canAct={replyCanAct}
+                canReply={false}
                 onReply={undefined}
                 onDelete={async () => {
                   if (!window.confirm('删除这条回复？')) {
@@ -232,50 +215,40 @@ function CommentView({
   onReply,
   onDelete,
 }: CommentViewProps) {
+  const isReply = comment.parentId !== null;
+
   return (
-    <div className='flex gap-3'>
-      <Avatar name={comment.author.name} image={comment.author.image} />
-      <div className='min-w-0 flex-1'>
-        <div className='flex flex-wrap items-center gap-x-2 gap-y-0.5'>
-          <span className='text-sm font-semibold'>{comment.author.name}</span>
-          {comment.author.role === 'admin' ? (
-            <span className='rounded bg-zinc-900 px-1.5 py-0.5 text-[10px] font-semibold text-white dark:bg-white dark:text-zinc-900'>
-              Author
-            </span>
-          ) : null}
-          {comment.status !== 'visible' ? (
-            <span className='rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'>
-              {comment.status}
-            </span>
-          ) : null}
-          <span className='text-xs opacity-50'>
-            {formatRelative(comment.createdAt)}
-          </span>
-        </div>
-        <div className='mt-1'>
-          <CommentMarkdown content={comment.body} />
-        </div>
-        <div className='mt-1 flex gap-3 text-xs'>
-          {canReply && onReply ? (
-            <button
-              type='button'
-              onClick={onReply}
-              className='opacity-50 transition-opacity hover:opacity-100'
-            >
-              回复
-            </button>
-          ) : null}
+    <div className={isReply ? 'c-cmt reply' : 'c-cmt'}>
+      <div className='c-cmt-h'>
+        <span className='who'>{comment.author.name}</span>
+        {comment.author.role === 'admin' ? <span>AUTHOR</span> : null}
+        {comment.status !== 'visible' ? (
+          <span style={{ color: 'var(--c-accent)' }}>{comment.status}</span>
+        ) : null}
+        <span>{formatRelative(comment.createdAt)}</span>
+      </div>
+      <div className='c-cmt-b'>
+        <CommentMarkdown content={comment.body} />
+      </div>
+      {canReply && onReply ? (
+        <div className='c-cmt-ops'>
+          <button type='button' onClick={onReply}>
+            回复
+          </button>
           {canAct ? (
-            <button
-              type='button'
-              onClick={() => onDelete()}
-              className='text-red-500/70 transition-colors hover:text-red-500'
-            >
+            <button type='button' className='del' onClick={() => onDelete()}>
               删除
             </button>
           ) : null}
         </div>
-      </div>
+      ) : null}
+      {!(canReply && onReply) && canAct ? (
+        <div className='c-cmt-ops'>
+          <button type='button' className='del' onClick={() => onDelete()}>
+            删除
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -316,7 +289,7 @@ export function Comments({
     setReplySubmitting((prev) => new Set(prev).add(parentId));
     try {
       const { comment } = await createCommentServerFn({
-        data: { slug, parentId, body },
+        data: { slug, body, parentId },
       });
       setThreads((prev) =>
         prev.map((thread) =>
@@ -375,11 +348,7 @@ export function Comments({
   }
 
   return (
-    <section className='mt-12'>
-      <h2 className='mb-4 text-lg font-black'>
-        评论 {total > 0 ? <span className='opacity-50'>({total})</span> : null}
-      </h2>
-
+    <section className='mt-2'>
       {sessionUser ? (
         <div className='mb-6'>
           <Composer
@@ -389,8 +358,8 @@ export function Comments({
           />
         </div>
       ) : (
-        <p className='mb-6 text-sm opacity-60'>
-          <Link to='/login' className='underline hover:opacity-100'>
+        <p className='mb-6 text-sm' style={{ color: 'var(--c-dim)' }}>
+          <Link to='/login' className='underline'>
             登录
           </Link>{' '}
           后即可评论。
@@ -398,28 +367,36 @@ export function Comments({
       )}
 
       {topError ? (
-        <p className='mb-4 text-sm text-red-500'>{topError}</p>
+        <p className='c-err mb-4' style={{ marginTop: 0 }}>
+          {topError}
+        </p>
       ) : null}
 
       {threads.length === 0 ? (
-        <p className='py-8 text-center text-sm opacity-50'>
+        <p
+          className='py-8 text-center text-sm'
+          style={{ color: 'var(--c-faint)' }}
+        >
           还没有评论，来抢沙发。
         </p>
       ) : (
-        <ul className='flex flex-col gap-5'>
-          {threads.map((thread) => (
-            <CommentItem
-              key={thread.id}
-              thread={thread}
-              sessionUser={sessionUser}
-              onReply={handleReply}
-              onDelete={handleDelete}
-              replyingTo={replyingTo}
-              setReplyingTo={setReplyingTo}
-              replySubmitting={replySubmitting}
-            />
-          ))}
-        </ul>
+        <>
+          <p className='c-sec-label mb-2'>TOTAL — {total}</p>
+          <ul className='flex flex-col'>
+            {threads.map((thread) => (
+              <CommentItem
+                key={thread.id}
+                thread={thread}
+                sessionUser={sessionUser}
+                onReply={handleReply}
+                onDelete={handleDelete}
+                replyingTo={replyingTo}
+                setReplyingTo={setReplyingTo}
+                replySubmitting={replySubmitting}
+              />
+            ))}
+          </ul>
+        </>
       )}
 
       {hasMore ? (
@@ -428,9 +405,9 @@ export function Comments({
             type='button'
             onClick={handleLoadMore}
             disabled={loadingMore}
-            className='text-sm opacity-60 transition-opacity hover:opacity-100 disabled:opacity-40'
+            className='c-btn c-btn-ghost'
           >
-            {loadingMore ? '加载中…' : '加载更多'}
+            {loadingMore ? '加载中…' : '加载更多 ↓'}
           </button>
         </div>
       ) : null}

--- a/apps/web/src/components/dark-mode.tsx
+++ b/apps/web/src/components/dark-mode.tsx
@@ -13,14 +13,9 @@ export function DarkMode() {
   const ref = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
-    if (isDarkMode) {
-      document.documentElement.classList.add('dark');
-      document.body.classList.add('dark:bg-wash-dark', 'dark:text-white');
-      return;
-    }
-
-    document.documentElement.classList.remove('dark');
-    document.body.classList.remove('dark:bg-wash-dark', 'dark:text-white');
+    // The swiss theme carries its own dark palette via html.dark custom
+    // properties; no legacy body utility classes are needed.
+    document.documentElement.classList.toggle('dark', isDarkMode);
   }, [isDarkMode]);
 
   const onTrigger = async () => {

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -1,9 +1,18 @@
+import { Link } from '@tanstack/react-router';
+
 export function Footer() {
   return (
-    <footer className='p-6 text-center'>
-      © {new Date().getFullYear()}, Built with{' '}
-      <a className='text-blue-500' href='https://tanstack.com/start/latest'>
-        TanStack Start
+    <footer className='c-foot'>
+      <span>PERFECTPAN.ORG — {new Date().getFullYear()}</span>
+      <span>
+        <Link to='/blog'>/BLOG</Link>
+      </span>
+      <span>
+        <Link to='/projects'>/PROJECTS</Link>
+      </span>
+      <a href='/rss.xml'>RSS ↗</a>
+      <a href='https://github.com/PerfectPan' target='_blank' rel='noreferrer'>
+        GITHUB ↗
       </a>
     </footer>
   );

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -2,7 +2,6 @@ import { Link } from '@tanstack/react-router';
 import { Github, LogOut, Rss, Search, UserRound } from 'lucide-react';
 import { authClient } from '../lib/auth-client.js';
 import { DarkMode } from './dark-mode.js';
-import { MenuLink } from './menu.js';
 import { searchPalette } from './search-palette-store.js';
 
 function getRoleLabel(role?: string | null): string {
@@ -17,53 +16,58 @@ function getRoleLabel(role?: string | null): string {
   return 'MEMBER';
 }
 
+/** Swiss keyline header: logo + nav with active underline + tools. */
 export function Header() {
   const { data: sessionData } = authClient.useSession();
   const sessionUser = sessionData?.user ?? null;
 
   return (
-    <header className='border-b border-slate-200 bg-white shadow-md dark:border-slate-300/10 dark:bg-slate-900'>
-      <div className='mx-4 flex h-16 items-center sm:mx-6'>
-        <Link
-          to='/'
-          className='rounded-md border-10 border-black bg-black px-1 font-bold text-white dark:border-neutral-900 dark:bg-neutral-900'
-        >
-          PerfectPan
+    <header className='c-head'>
+      <div className='c-head-in'>
+        <Link to='/' className='c-logo'>
+          PERFECTPAN
+          <span className='cursor' aria-hidden='true' />
         </Link>
-        <div className='m-0 flex list-none items-center pl-1'>
-          <MenuLink href='/' name='Home' />
-          <MenuLink href='/blog' name='Blog' />
-          <MenuLink href='/projects' name='Projects' />
+        <nav aria-label='主导航'>
+          <Link
+            to='/'
+            activeOptions={{ exact: true }}
+            activeProps={{ className: 'on' }}
+          >
+            Home
+          </Link>
+          <Link to='/blog' activeProps={{ className: 'on' }}>
+            Blog
+          </Link>
+          <Link to='/projects' activeProps={{ className: 'on' }}>
+            Projects
+          </Link>
           {sessionUser?.role === 'admin' ? (
-            <MenuLink href='/admin' name='Admin' />
+            <Link to='/admin' activeProps={{ className: 'on' }}>
+              Admin
+            </Link>
           ) : null}
-        </div>
-        <div className='ml-auto flex items-center gap-2 sm:gap-3'>
+        </nav>
+        <div className='c-tools'>
           {sessionUser ? (
-            <div className='hidden items-center gap-2 rounded-full border border-slate-300 px-3 py-1 text-xs text-gray-700 md:flex dark:border-slate-600 dark:text-slate-200'>
-              <UserRound size={14} className='opacity-70' />
-              <span className='max-w-[220px] truncate'>
+            <span className='c-user'>
+              <UserRound size={13} aria-hidden='true' />
+              <span className='max-w-[180px] truncate'>
                 {sessionUser.email}
               </span>
-              <span className='rounded-full bg-black px-2 py-[2px] text-[10px] font-semibold text-white dark:bg-neutral-100 dark:text-neutral-900'>
-                {getRoleLabel(sessionUser.role)}
-              </span>
-            </div>
+              <span className='c-role'>{getRoleLabel(sessionUser.role)}</span>
+            </span>
           ) : null}
           {sessionUser ? (
-            <Link
-              to='/logout'
-              className='inline-flex items-center gap-1 rounded-md border border-slate-300 px-2 py-1 text-sm opacity-85 transition-opacity hover:opacity-100 dark:border-slate-600'
-            >
-              <LogOut size={14} />
-              <span className='hidden sm:inline'>Logout</span>
+            <Link to='/logout' className='c-tool' aria-label='Logout'>
+              <LogOut size={15} aria-hidden='true' />
             </Link>
           ) : (
             <>
-              <Link to='/login' className='opacity-70 hover:opacity-100'>
+              <Link to='/login' className='c-tool'>
                 Login
               </Link>
-              <Link to='/signup' className='opacity-70 hover:opacity-100'>
+              <Link to='/signup' className='c-tool'>
                 Sign Up
               </Link>
             </>
@@ -72,21 +76,28 @@ export function Header() {
             type='button'
             aria-label='Search posts (Cmd+K)'
             onClick={() => searchPalette.open()}
-            className='inline-flex items-center opacity-70 transition-opacity hover:opacity-100'
+            className='c-tool'
           >
-            <Search size={22} />
+            <Search size={15} aria-hidden='true' />
           </button>
           <DarkMode />
           <a
             href='https://github.com/PerfectPan'
             target='_blank'
             rel='noreferrer'
-            className='flex items-center'
+            aria-label='GitHub'
+            className='c-tool'
           >
-            <Github size={22} className='opacity-70 hover:opacity-100' />
+            <Github size={15} aria-hidden='true' />
           </a>
-          <a href='/rss.xml' target='_blank' rel='noreferrer'>
-            <Rss size={24} className='opacity-70 hover:opacity-100' />
+          <a
+            href='/rss.xml'
+            target='_blank'
+            rel='noreferrer'
+            aria-label='RSS'
+            className='c-tool'
+          >
+            <Rss size={15} aria-hidden='true' />
           </a>
         </div>
       </div>

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -59,15 +59,20 @@ export function Header() {
             </span>
           ) : null}
           {sessionUser ? (
-            <Link to='/logout' className='c-tool' aria-label='Logout'>
+            <Link
+              to='/logout'
+              data-testid='nav-logout'
+              className='c-tool'
+              aria-label='Logout'
+            >
               <LogOut size={15} aria-hidden='true' />
             </Link>
           ) : (
             <>
-              <Link to='/login' className='c-tool'>
+              <Link to='/login' data-testid='nav-login' className='c-tool'>
                 Login
               </Link>
-              <Link to='/signup' className='c-tool'>
+              <Link to='/signup' data-testid='nav-signup' className='c-tool'>
                 Sign Up
               </Link>
             </>

--- a/apps/web/src/components/layout.tsx
+++ b/apps/web/src/components/layout.tsx
@@ -7,21 +7,18 @@ type AppLayoutProps = {
 };
 
 /**
- * App shell. The header sits OUTSIDE the scroll container (`main`), so page
- * overscroll only rubber-bands the content — the pinned header never moves
- * (no macOS "fixed header drags on overscroll"). Window doesn't scroll; route
- * scroll reset/restore for `main` is handled by TanStack via
- * `scrollToTopSelectors: ['main']` in router.tsx.
+ * App shell (swiss theme). The keyline header sits OUTSIDE the scroll
+ * container (`main`), so page overscroll only rubber-bands the content.
+ * Window doesn't scroll; route scroll reset/restore for `main` is handled by
+ * TanStack via `scrollToTopSelectors: ['main']` in router.tsx.
  */
 export function AppLayout({ children }: AppLayoutProps) {
   return (
-    <div className='flex h-dvh flex-col'>
+    <div className='c-shell'>
       <Header />
-      <main className='flex-1 overflow-y-auto'>
+      <main className='c-main'>
         <div className='flex min-h-full flex-col'>
-          <div className='flex flex-grow items-center justify-center px-6 *:min-h-64 *:min-w-64'>
-            {children}
-          </div>
+          <div className='flex-grow'>{children}</div>
           <Footer />
         </div>
       </main>

--- a/apps/web/src/components/markdown.tsx
+++ b/apps/web/src/components/markdown.tsx
@@ -78,20 +78,17 @@ function CodeBlock({ children }: { children?: ReactNode }) {
   }, []);
 
   return (
-    <div className='group relative mb-2'>
+    <div className='c-code group relative'>
       <button
         type='button'
         onClick={onCopy}
         aria-label='Copy code'
-        className='absolute right-2 top-2 z-10 inline-flex items-center gap-1 rounded border border-slate-300 bg-white/70 px-1.5 py-0.5 text-xs opacity-0 backdrop-blur transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100 hover-none:opacity-70 dark:border-slate-700 dark:bg-slate-900/70'
+        className='c-code-copy'
       >
         {copied ? <Check size={12} /> : <Copy size={12} />}
         {copied ? 'Copied' : 'Copy'}
       </button>
-      <pre
-        ref={preRef}
-        className='shiki w-full overflow-x-auto whitespace-pre-wrap rounded-md bg-zinc-50 p-4 dark:bg-shiki-dark'
-      >
+      <pre ref={preRef} className='shiki c-pre w-full overflow-x-auto'>
         {children}
       </pre>
     </div>
@@ -112,7 +109,7 @@ export function Markdown({ content }: MarkdownProps) {
   }, []);
 
   return (
-    <article>
+    <article className='md'>
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkMath]}
         rehypePlugins={[
@@ -133,10 +130,7 @@ export function Markdown({ content }: MarkdownProps) {
             const id = typeof children === 'string' ? children : '';
 
             return (
-              <h2
-                id={id}
-                className='mb-6 mt-14 scroll-mt-20 text-balance text-2xl leading-none font-black first:mt-0'
-              >
+              <h2 id={id} className='scroll-mt-20'>
                 <a
                   href={`#${id}`}
                   onClick={(event) => {
@@ -150,24 +144,21 @@ export function Markdown({ content }: MarkdownProps) {
               </h2>
             );
           },
-          p: ({ children }) => <p className='mb-6 leading-7'>{children}</p>,
+          p: ({ children }) => <p>{children}</p>,
           a: ({ href, children }) => (
-            <a
-              href={href}
-              className='text-blue-700/80 transition-colors duration-300 ease-in-out hover:text-blue-700'
-              target='_blank'
-              rel='noreferrer'
-            >
+            <a href={href} target='_blank' rel='noreferrer'>
               {children}
             </a>
           ),
-          strong: ({ children }) => (
-            <b className='font-extrabold'>{children}</b>
-          ),
-          ul: ({ children }) => (
-            <ul className='mb-4 ml-4 list-disc'>{children}</ul>
-          ),
+          strong: ({ children }) => <b className='font-bold'>{children}</b>,
+          ul: ({ children }) => <ul>{children}</ul>,
           pre: ({ children }) => <CodeBlock>{children}</CodeBlock>,
+          code: ({ className, children }) =>
+            /language-/.test(className ?? '') ? (
+              <code className={className}>{children}</code>
+            ) : (
+              <code className='c-inline'>{children}</code>
+            ),
         }}
       >
         {content}

--- a/apps/web/src/lib/post-index.ts
+++ b/apps/web/src/lib/post-index.ts
@@ -1,0 +1,30 @@
+/** Site founding date — day offsets from this date are the stable post index. */
+const EPOCH = new Date('2019-01-01T00:00:00Z').getTime();
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Stable per-post index number (№): whole days since 2019-01-01. Monotonic
+ * with publish date, so the blog list (desc) and the article rail agree.
+ */
+export function postIndex(publishedAt: string): number {
+  return Math.floor((new Date(publishedAt).getTime() - EPOCH) / DAY_MS);
+}
+
+/** Deterministic rating-palette color for an arbitrary tag. */
+const RATING_COLORS = [
+  '#98a0a6',
+  '#3f9e4c',
+  '#2fa8b8',
+  '#3d6be8',
+  '#8f5ae8',
+  '#e8973d',
+  '#e5484d',
+];
+
+export function tagColor(tag: string): string {
+  let hash = 0;
+  for (let i = 0; i < tag.length; i += 1) {
+    hash = (hash * 31 + tag.charCodeAt(i)) % 997;
+  }
+  return RATING_COLORS[hash % RATING_COLORS.length];
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -26,7 +26,7 @@ export const Route = createRootRoute({
       },
       {
         name: 'theme-color',
-        content: '#000000',
+        content: '#FFFFFF',
       },
     ],
     links: [

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -38,12 +38,19 @@ export const Route = createRootRoute({
   errorComponent: ({ error }) => (
     <RootDocument>
       <AppLayout>
-        <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-          <h2 className='mb-4 text-3xl'>Request Failed</h2>
-          <p className='mb-4 opacity-70'>{String(error)}</p>
-          <Link to='/blog' className='opacity-70 hover:opacity-100'>
-            Back to blog
-          </Link>
+        <div className='c-page'>
+          <div className='c-nf'>
+            <div className='c-sec-label'>ERROR — REQUEST FAILED</div>
+            <div className='code'>
+              5<b>0</b>0
+            </div>
+            <p>{String(error)}</p>
+            <div style={{ marginTop: 26 }}>
+              <Link to='/blog' className='c-btn'>
+                ← 返回博客
+              </Link>
+            </div>
+          </div>
         </div>
       </AppLayout>
     </RootDocument>
@@ -51,12 +58,21 @@ export const Route = createRootRoute({
   notFoundComponent: () => (
     <RootDocument>
       <AppLayout>
-        <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-          <h2 className='mb-4 text-3xl'>404 Not Found</h2>
-          <p className='mb-4 opacity-70'>你闯入了无人之境...</p>
-          <Link to='/blog' className='opacity-70 hover:opacity-100'>
-            Back to blog
-          </Link>
+        <div className='c-page'>
+          <div className='c-nf'>
+            <div className='c-sec-label' style={{ marginBottom: 10 }}>
+              ERROR — NOT FOUND
+            </div>
+            <div className='code'>
+              4<b>0</b>4
+            </div>
+            <p>你闯入了无人之境。</p>
+            <div style={{ marginTop: 26 }}>
+              <Link to='/blog' className='c-btn'>
+                ← 返回博客
+              </Link>
+            </div>
+          </div>
         </div>
       </AppLayout>
     </RootDocument>

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -1,14 +1,11 @@
 import { type CommentThread, canAccessVisibility } from '@blog/shared';
-import {
-  createFileRoute,
-  Link,
-  notFound,
-  redirect,
-} from '@tanstack/react-router';
+import { createFileRoute, notFound, redirect } from '@tanstack/react-router';
+import type { CSSProperties } from 'react';
 import { Comments } from '../../components/comments.js';
 import { Markdown } from '../../components/markdown.js';
 import { getBlogPostServerFn } from '../../lib/blog-service.js';
 import { getCommentsServerFn } from '../../lib/comments-service.js';
+import { postIndex, tagColor } from '../../lib/post-index.js';
 
 export const Route = createFileRoute('/blog/$slug')({
   head: () => ({
@@ -70,31 +67,58 @@ function BlogDetailPage() {
     return null;
   }
 
-  const date = new Date(post.publishedAt).toLocaleDateString('en-US', {
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
-  });
+  const date = new Date(post.publishedAt).toISOString().slice(0, 10);
 
   return (
-    <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <div className='m-auto mb-8 flex flex-col gap-2'>
-        <div className='text-3xl font-black'>{post.title}</div>
-        <div className='opacity-60'>{date}</div>
+    <div className='c-page'>
+      <div className='c-art'>
+        <aside className='c-rail'>
+          <div className='bigno'>
+            №<b>{String(postIndex(post.publishedAt)).padStart(4, '0')}</b>
+          </div>
+          <dl>
+            <dt>DATE</dt>
+            <dd>{date}</dd>
+            <dt>VISIBILITY</dt>
+            <dd>{post.visibility.toUpperCase()}</dd>
+            {post.tags.length > 0 ? (
+              <>
+                <dt>TAGS</dt>
+                <dd className='flex flex-wrap gap-1.5 pt-1'>
+                  {post.tags.map((tag: string) => (
+                    <span
+                      key={tag}
+                      className='c-chip'
+                      style={{ '--c-c': tagColor(tag) } as CSSProperties}
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </dd>
+              </>
+            ) : null}
+          </dl>
+        </aside>
+        <article>
+          <div className='c-art-title'>
+            <h1>{post.title}</h1>
+            <div className='bar' />
+          </div>
+          <Markdown content={post.contentMdx} />
+          <div className='c-cmt-head'>
+            <h2>COMMENTS</h2>
+            <span className='n'>{data.comments.total}</span>
+          </div>
+          <Comments
+            key={post.slug}
+            slug={post.slug}
+            initialComments={data.comments.comments}
+            initialHasMore={data.comments.hasMore}
+            initialTotal={data.comments.total}
+            sessionUser={data.sessionUser}
+          />
+        </article>
       </div>
-      <Markdown content={post.contentMdx} />
-      <Link to='/blog' className='mt-4 inline-block'>
-        <span className='opacity-70'>&gt;&nbsp;&nbsp;&nbsp;</span>
-        <span className='underline opacity-70 hover:opacity-100'>cd ..</span>
-      </Link>
-      <Comments
-        key={post.slug}
-        slug={post.slug}
-        initialComments={data.comments.comments}
-        initialHasMore={data.comments.hasMore}
-        initialTotal={data.comments.total}
-        sessionUser={data.sessionUser}
-      />
     </div>
   );
 }

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -1,9 +1,10 @@
 import type { PostSummary, SessionUser } from '@blog/shared';
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import type { CSSProperties } from 'react';
 import { useEffect } from 'react';
 import { z } from 'zod';
 import { getBlogListServerFn } from '../../lib/blog-service.js';
+import { postIndex, tagColor } from '../../lib/post-index.js';
 
 type BlogGroup = {
   year: string;
@@ -49,6 +50,21 @@ function getDevScopeHint(sessionUser: SessionUser | null | undefined): string {
   return '当前身份：member；可见范围：public/member';
 }
 
+const VIS_CLASS: Record<PostSummary['visibility'], string> = {
+  public: 'c-vis',
+  member: 'c-vis mem',
+  vip: 'c-vis vip',
+  admin: 'c-vis adm',
+  password: 'c-vis pw',
+};
+const VIS_TEXT: Record<PostSummary['visibility'], string> = {
+  public: 'PUBLIC',
+  member: 'MEMBER',
+  vip: 'VIP',
+  admin: 'ADMIN',
+  password: 'PASSWORD',
+};
+
 export const Route = createFileRoute('/blog/')({
   head: () => ({
     meta: [
@@ -77,88 +93,89 @@ function BlogListPage() {
   const devScopeHint = getDevScopeHint(data.sessionUser);
 
   // Conventional blog pagination: the page scrolls naturally; jump back to the
-  // top on each page change so the new page starts at its first post. (Without
-  // this, clicking "next" while scrolled to the bottom leaves the reader past a
-  // shorter page — the original "bounce".)
+  // top on each page change so the new page starts at its first post.
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-run on page change, value unused in body on purpose
   useEffect(() => {
     document.querySelector('main')?.scrollTo({ top: 0 });
   }, [data.page]);
 
   return (
-    <div className='mx-auto flex w-full max-w-[80ch] flex-col gap-8 self-start pt-8'>
-      <div className='w-full'>
-        {showDevHint ? (
-          <div className='mb-8 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900'>
-            {devScopeHint}
-          </div>
-        ) : null}
+    <div className='c-page'>
+      <div className='c-list-head'>
+        <h1>Blog</h1>
+        <span className='count c-no'>
+          — {data.total} entries / {data.totalPages} pages
+        </span>
+      </div>
+
+      {showDevHint ? <div className='c-devhint'>{devScopeHint}</div> : null}
+
+      <div className='c-rowlist'>
         {blogGroups.map((group) => (
           <div key={group.year}>
-            <div className='mb-4 text-3xl'>{group.year}</div>
+            <div className='c-year'>{group.year}</div>
             {group.blogs.map((blog: PostSummary) => (
-              <div
+              <Link
                 key={blog.slug}
-                className='mt-2 mb-6 opacity-70 hover:opacity-100'
+                to='/blog/$slug'
+                params={{ slug: blog.slug }}
+                className='c-row'
               >
-                <Link
-                  to='/blog/$slug'
-                  params={{ slug: blog.slug }}
-                  className='flex items-center gap-2'
-                >
-                  <span className='text-lg leading-[1.2em]'>{blog.title}</span>
-                  <span className='text-sm opacity-50'>
-                    {new Date(blog.publishedAt).toLocaleDateString('en-US', {
-                      month: 'short',
-                      day: 'numeric',
-                    })}
-                  </span>
-                </Link>
-              </div>
+                <span className='c-no'>
+                  №{String(postIndex(blog.publishedAt)).padStart(4, '0')}
+                </span>
+                <span className='t'>
+                  {blog.title}
+                  {blog.visibility !== 'public' ? (
+                    <span className={VIS_CLASS[blog.visibility]}>
+                      {VIS_TEXT[blog.visibility]}
+                    </span>
+                  ) : null}
+                </span>
+                <span className='tags'>
+                  {blog.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className='c-chip'
+                      style={{ '--c-c': tagColor(tag) } as CSSProperties}
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </span>
+                <span className='d'>
+                  {new Date(blog.publishedAt)
+                    .toISOString()
+                    .slice(5, 10)
+                    .replace('-', '/')}
+                </span>
+              </Link>
             ))}
           </div>
         ))}
       </div>
+
       {data.totalPages > 1 ? (
-        <nav
-          className='flex w-full items-center justify-center gap-4 text-sm sm:gap-6'
-          aria-label='Pagination'
-        >
+        <nav className='c-pager' aria-label='Pagination'>
           {data.page > 1 ? (
-            <Link
-              to='/blog'
-              search={{ page: data.page - 1 }}
-              className='inline-flex items-center gap-1 opacity-60 hover:opacity-100'
-            >
-              <ChevronLeft size={14} /> prev
+            <Link to='/blog' search={{ page: data.page - 1 }}>
+              ← prev
             </Link>
           ) : (
-            <span className='inline-flex items-center gap-1 opacity-30'>
-              <ChevronLeft size={14} /> prev
-            </span>
+            <span style={{ opacity: 0.4 }}>← prev</span>
           )}
-          <span className='opacity-60'>
-            page {data.page} / {data.totalPages}
+          <span className='cur'>
+            {data.page} / {data.totalPages}
           </span>
           {data.page < data.totalPages ? (
-            <Link
-              to='/blog'
-              search={{ page: data.page + 1 }}
-              className='inline-flex items-center gap-1 opacity-60 hover:opacity-100'
-            >
-              next <ChevronRight size={14} />
+            <Link to='/blog' search={{ page: data.page + 1 }}>
+              next →
             </Link>
           ) : (
-            <span className='inline-flex items-center gap-1 opacity-30'>
-              next <ChevronRight size={14} />
-            </span>
+            <span style={{ opacity: 0.4 }}>next →</span>
           )}
         </nav>
       ) : null}
-      <Link to='/' className='mt-4 inline-block'>
-        <span className='opacity-70'>&gt;&nbsp;&nbsp;&nbsp;</span>
-        <span className='underline opacity-70 hover:opacity-100'>cd ..</span>
-      </Link>
     </div>
   );
 }

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,25 +1,90 @@
+import type { PostSummary } from '@blog/shared';
 import { createFileRoute, Link } from '@tanstack/react-router';
+import { getBlogListServerFn } from '../lib/blog-service.js';
+import { postIndex } from '../lib/post-index.js';
+import { PROJECTS } from '../lib/projects.js';
 
 export const Route = createFileRoute('/')({
   head: () => ({
     meta: [{ title: "Home | PerfectPan's Blog" }],
   }),
+  loader: async () => {
+    // Guest-scoped first page powers the LATEST / DATA columns.
+    return getBlogListServerFn({ data: { page: 1 } });
+  },
   component: HomePage,
 });
 
 function HomePage() {
+  const data = Route.useLoaderData();
+  const latest = data.posts.slice(0, 4);
+  const featured = PROJECTS.filter((p) => p.featured).slice(0, 3);
+  const otherProjects = PROJECTS.filter((p) => !p.featured).slice(0, 2);
+  const year = new Date().getFullYear();
+
   return (
-    <div className='flex flex-col items-center'>
-      <img className='m-0' src='/images/xm.jpg' alt='' />
-      <div className='mt-8 text-[2.5rem] font-black'>
-        是个什么都不会的废物.jpg
-      </div>
-      <div className='flex w-full justify-around'>
-        <div className='mx-1 mt-8 flex-1 rounded-md bg-slate-100 text-center font-semibold uppercase tracking-wider leading-[5rem] shadow-md transition-shadow hover:shadow-lg dark:bg-wash-dark dark:text-white dark:opacity-80'>
-          <Link to='/blog'>Blog</Link>
+    <div className='c-page'>
+      <div className='c-hero'>
+        <div className='kicker'>
+          <span className='c-sec-label'>Personal Index — Since 2019</span>
+          <span className='c-no'>/ perfectpan.org</span>
         </div>
-        <div className='mx-1 mt-8 flex-1 rounded-md bg-slate-100 text-center font-semibold uppercase tracking-wider leading-[5rem] shadow-md transition-shadow hover:shadow-lg dark:bg-wash-dark dark:text-white dark:opacity-80'>
-          <Link to='/projects'>Projects</Link>
+        <h1>
+          <span className='hollow'>PERFECT</span>PAN
+          <span className='dot'>.</span>
+        </h1>
+        <p className='sub'>
+          算法竞赛退役选手、前端工程师。写类型体操、Cloudflare 上的 $0
+          工程实践，以及一些随想。是个什么都不会的废物.jpg —— 但文档还在更新。
+        </p>
+      </div>
+      <div className='c-home-cols'>
+        <div className='c-home-col'>
+          <h3>LATEST / 最新</h3>
+          {latest.map((post: PostSummary) => (
+            <div className='c-latest' key={post.slug}>
+              <span className='c-no'>
+                {String(postIndex(post.publishedAt)).padStart(4, '0')}
+              </span>
+              <Link className='t' to='/blog/$slug' params={{ slug: post.slug }}>
+                {post.title}
+              </Link>
+              <span className='d'>
+                {new Date(post.publishedAt).toISOString().slice(0, 7)}
+              </span>
+            </div>
+          ))}
+        </div>
+        <div className='c-home-col'>
+          <h3>WORK / 项目</h3>
+          {[...featured, ...otherProjects].map((project) => (
+            <div className='c-latest' key={project.name}>
+              <a
+                className='t'
+                href={project.repo}
+                target='_blank'
+                rel='noreferrer'
+              >
+                {project.name}
+              </a>
+              <span className='d'>{project.featured ? '★' : ''}</span>
+            </div>
+          ))}
+        </div>
+        <div className='c-home-col'>
+          <h3>DATA / 数据</h3>
+          <div className='c-stat'>
+            <b className='red'>{data.total}</b>
+            <span>篇文章</span>
+          </div>
+          <div className='c-stat'>
+            <b>{PROJECTS.length}</b>
+            <span>个开源项目</span>
+          </div>
+          <div className='c-stat'>
+            <b>{year - 2019 + 1}</b>
+            <span>个年份卷宗</span>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -34,96 +34,99 @@ function LoginPage() {
 
   if (sessionData?.user?.id || isSessionPending) {
     return (
-      <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-        <p className='opacity-70'>Checking session...</p>
-      </section>
+      <div className='c-page'>
+        <p className='c-sec-label'>Checking session…</p>
+      </div>
     );
   }
 
   return (
-    <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>登录</h1>
-      <p className='mb-6 opacity-70'>支持邮箱密码和 GitHub OAuth。</p>
+    <div className='c-page'>
+      <div className='c-auth'>
+        <div className='c-auth-head'>
+          <h1>登录</h1>
+          <span className='c-no'>AUTH / 01</span>
+        </div>
+        <div className='c-auth-card'>
+          <form
+            method='post'
+            onSubmit={(event) => {
+              event.preventDefault();
+              setError(null);
+              startTransition(async () => {
+                const result = await authClient.signIn.email({
+                  email,
+                  password,
+                  callbackURL: '/blog',
+                });
 
-      {error ? (
-        <p role='alert' className='mb-4 text-sm text-red-700 dark:text-red-300'>
-          {error}
-        </p>
-      ) : null}
+                if (result.error) {
+                  setError(result.error.message ?? '登录失败');
+                  return;
+                }
 
-      <form
-        className='grid max-w-[420px] gap-3'
-        method='post'
-        onSubmit={(event) => {
-          event.preventDefault();
-          setError(null);
-          startTransition(async () => {
-            const result = await authClient.signIn.email({
-              email,
-              password,
-              callbackURL: '/blog',
-            });
-
-            if (result.error) {
-              setError(result.error.message ?? '登录失败');
-              return;
-            }
-
-            navigate({ to: '/blog' });
-          });
-        }}
-      >
-        <label htmlFor='email' className='font-semibold'>
-          Email
-        </label>
-        <input
-          id='email'
-          name='email'
-          type='email'
-          required
-          autoComplete='email'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-        />
-        <label htmlFor='password' className='font-semibold'>
-          Password
-        </label>
-        <input
-          id='password'
-          name='password'
-          type='password'
-          required
-          autoComplete='current-password'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={password}
-          onChange={(event) => setPassword(event.target.value)}
-        />
-        <button
-          type='submit'
-          className='rounded-md bg-black px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90 dark:bg-neutral-900'
-          disabled={isPending}
-        >
-          {isPending ? 'Signing in...' : 'Sign In'}
-        </button>
-      </form>
-
-      <button
-        type='button'
-        className='mt-3 rounded-md border border-slate-300 px-4 py-2 font-semibold transition-colors hover:bg-gray-100 dark:border-slate-700 dark:hover:bg-slate-800'
-        onClick={async () => {
-          setError(null);
-          const result = await authClient.signIn.social({
-            provider: 'github',
-            callbackURL: '/blog',
-          });
-          if (result.error) {
-            setError(result.error.message ?? 'GitHub 登录失败');
-          }
-        }}
-      >
-        Continue with GitHub
-      </button>
-    </section>
+                navigate({ to: '/blog' });
+              });
+            }}
+          >
+            <div className='c-field'>
+              <label htmlFor='email'>Email</label>
+              <input
+                id='email'
+                name='email'
+                type='email'
+                required
+                autoComplete='email'
+                className='c-input'
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+              />
+            </div>
+            <div className='c-field'>
+              <label htmlFor='password'>Password</label>
+              <input
+                id='password'
+                name='password'
+                type='password'
+                required
+                autoComplete='current-password'
+                className='c-input'
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+            </div>
+            <div className='c-actions'>
+              <button
+                type='submit'
+                className='c-btn c-btn-solid'
+                disabled={isPending}
+              >
+                {isPending ? '登录中…' : '登录'}
+              </button>
+              <button
+                type='button'
+                className='c-btn c-btn-ghost'
+                onClick={async () => {
+                  setError(null);
+                  const result = await authClient.signIn.social({
+                    provider: 'github',
+                    callbackURL: '/blog',
+                  });
+                  if (result.error) {
+                    setError(result.error.message ?? 'GitHub 登录失败');
+                  }
+                }}
+              >
+                GitHub 登录
+              </button>
+            </div>
+            {error ? <p className='c-err'>{error}</p> : null}
+          </form>
+          <p className='c-aside'>
+            登录后可读 member 篇目 · <a href='/signup'>没有账号？注册</a>
+          </p>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/routes/projects.tsx
+++ b/apps/web/src/routes/projects.tsx
@@ -1,5 +1,6 @@
-import { createFileRoute, Link } from '@tanstack/react-router';
-import { ExternalLink, Github } from 'lucide-react';
+import { createFileRoute } from '@tanstack/react-router';
+import type { CSSProperties } from 'react';
+import { tagColor } from '../lib/post-index.js';
 import { PROJECTS, type Project } from '../lib/projects.js';
 
 export const Route = createFileRoute('/projects')({
@@ -25,67 +26,49 @@ function ProjectsPage() {
   const projects = sortProjects(PROJECTS);
 
   return (
-    <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>Projects</h1>
-      <p className='mb-8 opacity-70'>我做过的一些东西，按需更新。</p>
-
-      <div className='grid gap-4 sm:grid-cols-2'>
-        {projects.map((project) => (
-          <article
-            key={project.name}
-            className='flex flex-col rounded-lg border border-slate-200 bg-white/60 p-5 transition-shadow hover:shadow-md dark:border-slate-700 dark:bg-wash-dark'
-          >
-            <div className='mb-1 flex items-center gap-2'>
-              <h2 className='text-lg font-semibold'>{project.name}</h2>
-              {project.featured ? (
-                <span className='rounded-full bg-black px-2 py-[2px] text-[10px] font-semibold text-white dark:bg-neutral-100 dark:text-neutral-900'>
-                  FEATURED
-                </span>
-              ) : null}
+    <div className='c-page'>
+      <div className='c-list-head'>
+        <h1>Projects</h1>
+        <span className='count c-no'>
+          — {PROJECTS.length} works /{' '}
+          {projects.filter((p) => p.featured).length} featured
+        </span>
+      </div>
+      <div className='c-proj'>
+        {projects.map((project, index) => (
+          <div className='c-proj-row' key={project.name}>
+            <div className='idx'>
+              {String(index + 1).padStart(2, '0')}
+              {project.featured ? <span className='feat'>FEATURED</span> : null}
             </div>
-            <p className='mb-4 flex-grow text-sm opacity-70'>
-              {project.description}
-            </p>
-            <div className='mb-4 flex flex-wrap gap-1.5'>
+            <div>
+              <h2>{project.name}</h2>
+              <p>{project.description}</p>
+            </div>
+            <div className='ptags'>
               {project.tags.map((tag) => (
                 <span
                   key={tag}
-                  className='rounded-md border border-slate-200 px-2 py-[2px] text-[11px] opacity-70 dark:border-slate-700'
+                  className='c-chip'
+                  style={{ '--c-c': tagColor(tag) } as CSSProperties}
                 >
                   {tag}
                 </span>
               ))}
             </div>
-            <div className='flex items-center gap-4 text-sm'>
-              <a
-                href={project.repo}
-                target='_blank'
-                rel='noreferrer'
-                className='inline-flex items-center gap-1 opacity-70 hover:opacity-100'
-              >
-                <Github size={15} />
-                Code
+            <div className='plinks'>
+              <a href={project.repo} target='_blank' rel='noreferrer'>
+                CODE ↗
               </a>
               {project.demo ? (
-                <a
-                  href={project.demo}
-                  target='_blank'
-                  rel='noreferrer'
-                  className='inline-flex items-center gap-1 opacity-70 hover:opacity-100'
-                >
-                  <ExternalLink size={15} />
-                  Demo
+                <a href={project.demo} target='_blank' rel='noreferrer'>
+                  DEMO ↗
                 </a>
               ) : null}
             </div>
-          </article>
+          </div>
         ))}
       </div>
-
-      <Link to='/' className='mt-8 inline-block'>
-        <span className='opacity-70'>&gt;&nbsp;&nbsp;&nbsp;</span>
-        <span className='underline opacity-70 hover:opacity-100'>cd ..</span>
-      </Link>
     </div>
   );
 }

--- a/apps/web/src/routes/signup.tsx
+++ b/apps/web/src/routes/signup.tsx
@@ -35,93 +35,110 @@ function SignUpPage() {
 
   if (sessionData?.user?.id || isSessionPending) {
     return (
-      <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-        <p className='opacity-70'>Checking session...</p>
-      </section>
+      <div className='c-page'>
+        <p className='c-sec-label'>Checking session…</p>
+      </div>
     );
   }
 
   return (
-    <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>注册</h1>
-      <p className='mb-6 opacity-70'>注册后默认角色为 member，可在后台升权。</p>
+    <div className='c-page'>
+      <div className='c-auth'>
+        <div className='c-auth-head'>
+          <h1>注册</h1>
+          <span className='c-no'>AUTH / 02</span>
+        </div>
+        <div className='c-auth-card'>
+          <form
+            method='post'
+            onSubmit={(event) => {
+              event.preventDefault();
+              setError(null);
+              startTransition(async () => {
+                const result = await authClient.signUp.email({
+                  email,
+                  password,
+                  name,
+                  callbackURL: '/blog',
+                });
 
-      {error ? (
-        <p role='alert' className='mb-4 text-sm text-red-700 dark:text-red-300'>
-          {error}
-        </p>
-      ) : null}
+                if (result.error) {
+                  setError(result.error.message ?? '注册失败');
+                  return;
+                }
 
-      <form
-        className='grid max-w-[420px] gap-3'
-        method='post'
-        onSubmit={(event) => {
-          event.preventDefault();
-          setError(null);
-          startTransition(async () => {
-            const result = await authClient.signUp.email({
-              email,
-              password,
-              name,
-              callbackURL: '/blog',
-            });
-
-            if (result.error) {
-              setError(result.error.message ?? '注册失败');
-              return;
-            }
-
-            navigate({ to: '/blog' });
-          });
-        }}
-      >
-        <label htmlFor='name' className='font-semibold'>
-          Name
-        </label>
-        <input
-          id='name'
-          name='name'
-          type='text'
-          required
-          autoComplete='name'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={name}
-          onChange={(event) => setName(event.target.value)}
-        />
-        <label htmlFor='email' className='font-semibold'>
-          Email
-        </label>
-        <input
-          id='email'
-          name='email'
-          type='email'
-          required
-          autoComplete='email'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-        />
-        <label htmlFor='password' className='font-semibold'>
-          Password
-        </label>
-        <input
-          id='password'
-          name='password'
-          type='password'
-          required
-          autoComplete='new-password'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={password}
-          onChange={(event) => setPassword(event.target.value)}
-        />
-        <button
-          type='submit'
-          className='rounded-md bg-black px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90 dark:bg-neutral-900'
-          disabled={isPending}
-        >
-          {isPending ? 'Creating account...' : 'Sign Up'}
-        </button>
-      </form>
-    </section>
+                navigate({ to: '/blog' });
+              });
+            }}
+          >
+            <div className='c-field'>
+              <label htmlFor='name'>Name</label>
+              <input
+                id='name'
+                name='name'
+                type='text'
+                required
+                autoComplete='name'
+                className='c-input'
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+              />
+            </div>
+            <div className='c-field'>
+              <label htmlFor='email'>Email</label>
+              <input
+                id='email'
+                name='email'
+                type='email'
+                required
+                autoComplete='email'
+                className='c-input'
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+              />
+            </div>
+            <div className='c-field'>
+              <label htmlFor='password'>Password</label>
+              <input
+                id='password'
+                name='password'
+                type='password'
+                required
+                autoComplete='new-password'
+                className='c-input'
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+            </div>
+            <div className='c-actions'>
+              <button
+                type='submit'
+                className='c-btn c-btn-solid'
+                disabled={isPending}
+              >
+                {isPending ? '创建中…' : '创建账号'}
+              </button>
+              <button
+                type='button'
+                className='c-btn c-btn-ghost'
+                onClick={async () => {
+                  setError(null);
+                  const result = await authClient.signIn.social({
+                    provider: 'github',
+                    callbackURL: '/blog',
+                  });
+                  if (result.error) {
+                    setError(result.error.message ?? 'GitHub 注册失败');
+                  }
+                }}
+              >
+                GitHub 注册
+              </button>
+            </div>
+            {error ? <p className='c-err'>{error}</p> : null}
+          </form>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/routes/unlock/$slug.tsx
+++ b/apps/web/src/routes/unlock/$slug.tsx
@@ -78,48 +78,46 @@ function UnlockPage() {
     search.error === 'missing'
       ? '请输入访问密码'
       : search.error === 'invalid'
-        ? '密码错误，请重试'
+        ? '密码错误，请重试（连续失败会触发限流）'
         : undefined;
 
   return (
-    <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>输入文章访问密码</h1>
-      <p className='mb-6 opacity-70'>这篇文章使用了单文密码保护。</p>
-
-      {errorLabel ? (
-        <p role='alert' className='mb-4 text-sm text-red-700 dark:text-red-300'>
-          {errorLabel}
-        </p>
-      ) : null}
-
-      <form method='post' className='grid max-w-[420px] gap-3'>
-        <label htmlFor='password' className='font-semibold'>
-          Password
-        </label>
-        <input
-          id='password'
-          name='password'
-          type='password'
-          required
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-        />
-        <button
-          type='submit'
-          className='rounded-md bg-black px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90 dark:bg-neutral-900'
-        >
-          Unlock
-        </button>
-      </form>
-
-      <p className='mt-4'>
-        <Link
-          to='/blog/$slug'
-          params={{ slug }}
-          className='opacity-70 hover:opacity-100'
-        >
-          返回文章页
-        </Link>
-      </p>
-    </section>
+    <div className='c-page'>
+      <div className='c-auth'>
+        <div className='c-auth-head'>
+          <h1>解锁文章</h1>
+          <span className='c-no'>AUTH / 03</span>
+        </div>
+        <div className='c-auth-card'>
+          <div className='c-lockline'>LOCKED ENTRY</div>
+          <form method='post'>
+            <div className='c-field'>
+              <label htmlFor='password'>单文密码</label>
+              <input
+                id='password'
+                name='password'
+                type='password'
+                required
+                className='c-input'
+              />
+            </div>
+            {errorLabel ? <p className='c-err'>{errorLabel}</p> : null}
+            <div className='c-actions'>
+              <button type='submit' className='c-btn c-btn-solid'>
+                解锁
+              </button>
+              <Link
+                to='/blog/$slug'
+                params={{ slug }}
+                className='c-btn c-btn-ghost'
+              >
+                ← 返回文章
+              </Link>
+            </div>
+          </form>
+          <p className='c-aside'>验证后 24 小时内免密阅读本篇。</p>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -144,3 +144,1043 @@ html.dark ::-webkit-scrollbar-thumb {
 html.dark ::-webkit-scrollbar-thumb:hover {
   background: rgb(148 163 184 / 0.55);
 }
+
+/* =====================================================================
+ * THEME C — Swiss Data Grid × rating colors (UX redesign direction C)
+ * Strict keyline grid, mono index numbers (№), competitive-programming
+ * rating palette for tags. Dual theme: tokens swap under html.dark.
+ * =================================================================== */
+:root {
+  --c-bg: #ffffff;
+  --c-surface: #f5f5f3;
+  --c-ink: #16181d;
+  --c-dim: #6d717a;
+  --c-faint: #a6aab2;
+  --c-line: #e4e5e7;
+  --c-line-strong: #16181d;
+  --c-accent: #e5484d;
+  --c-accent-soft: rgba(229, 72, 77, 0.08);
+  /* rating palette */
+  --c-r0: #98a0a6;
+  --c-r1: #3f9e4c;
+  --c-r2: #2fa8b8;
+  --c-r3: #3d6be8;
+  --c-r4: #8f5ae8;
+  --c-r5: #e8973d;
+  --c-r6: #e5484d;
+  --c-sans:
+    "Helvetica Neue", Helvetica, Inter, "PingFang SC", "Hiragino Sans GB",
+    "Microsoft YaHei", system-ui, sans-serif;
+  --c-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
+  /* shadcn tokens → swiss light */
+  --background: 0 0% 100%;
+  --foreground: 230 12% 10%;
+  --card: 60 8% 96%;
+  --card-foreground: 230 12% 10%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 230 12% 10%;
+  --primary: 359 74% 59%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 60 8% 94%;
+  --secondary-foreground: 230 12% 10%;
+  --muted: 60 8% 94%;
+  --muted-foreground: 226 8% 44%;
+  --accent: 60 8% 92%;
+  --accent-foreground: 230 12% 10%;
+  --destructive: 359 74% 59%;
+  --destructive-foreground: 0 0% 100%;
+  --border: 220 9% 89%;
+  --input: 220 9% 89%;
+  --ring: 359 74% 59%;
+  --radius: 0.125rem;
+}
+
+html.dark {
+  --c-bg: #0e0f12;
+  --c-surface: #16181d;
+  --c-ink: #edeef0;
+  --c-dim: #8b8f98;
+  --c-faint: #565a63;
+  --c-line: #24262c;
+  --c-line-strong: #edeef0;
+  --c-accent-soft: rgba(229, 72, 77, 0.14);
+
+  --background: 230 14% 7%;
+  --foreground: 220 14% 93%;
+  --card: 228 12% 11%;
+  --card-foreground: 220 14% 93%;
+  --popover: 228 12% 9%;
+  --popover-foreground: 220 14% 93%;
+  --secondary: 228 12% 13%;
+  --secondary-foreground: 220 14% 93%;
+  --muted: 228 12% 13%;
+  --muted-foreground: 224 9% 57%;
+  --accent: 228 12% 15%;
+  --accent-foreground: 220 14% 93%;
+  --border: 228 8% 16%;
+  --input: 228 8% 16%;
+}
+
+html,
+html.dark {
+  background-color: var(--c-bg);
+}
+
+html body {
+  font-family: var(--c-sans);
+  background-color: var(--c-bg);
+  color: var(--c-ink);
+  font-size: 15px;
+  line-height: 1.75;
+}
+
+::selection {
+  background: var(--c-accent);
+  color: #fff;
+}
+
+/* ---------- header ---------- */
+.c-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+}
+.c-main {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.c-head {
+  border-bottom: 2px solid var(--c-line-strong);
+  background: var(--c-bg);
+}
+.c-head-in {
+  max-width: 1160px;
+  margin: 0 auto;
+  padding: 0 28px;
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  height: 58px;
+}
+.c-logo {
+  display: flex;
+  align-items: center;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  font-size: 15.5px;
+  border-right: 1px solid var(--c-line);
+  padding-right: 22px;
+  color: var(--c-ink);
+}
+.c-logo:hover {
+  color: var(--c-ink);
+  text-decoration: none;
+}
+.c-logo .cursor {
+  display: inline-block;
+  width: 9px;
+  height: 1.05em;
+  background: var(--c-accent);
+  margin-left: 4px;
+  animation: c-blink 1.1s steps(1) infinite;
+}
+@keyframes c-blink {
+  50% {
+    opacity: 0;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .c-logo .cursor {
+    animation: none;
+  }
+}
+
+.c-head nav {
+  display: flex;
+}
+.c-head nav a {
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  font-size: 13.5px;
+  color: var(--c-dim);
+  letter-spacing: 0.04em;
+  border-right: 1px solid var(--c-line);
+  position: relative;
+}
+.c-head nav a:hover {
+  color: var(--c-ink);
+  text-decoration: none;
+}
+.c-head nav a.on {
+  color: var(--c-ink);
+  font-weight: 700;
+}
+.c-head nav a.on::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -2px;
+  height: 3px;
+  background: var(--c-accent);
+}
+.c-tools {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.c-tool {
+  font-family: var(--c-sans);
+  font-size: 12.5px;
+  color: var(--c-dim);
+  background: none;
+  border: 0;
+  padding: 6px 10px;
+  cursor: pointer;
+  letter-spacing: 0.04em;
+}
+.c-tool:hover {
+  color: var(--c-ink);
+}
+a.c-tool:hover {
+  text-decoration: none;
+  color: var(--c-accent);
+}
+.c-user {
+  display: none;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--c-dim);
+  border: 1px solid var(--c-line);
+  padding: 3px 10px;
+}
+@media (min-width: 768px) {
+  .c-user {
+    display: inline-flex;
+  }
+}
+.c-role {
+  font-family: var(--c-mono);
+  font-size: 10px;
+  background: var(--c-ink);
+  color: var(--c-bg);
+  padding: 1px 7px;
+  letter-spacing: 0.08em;
+}
+
+/* ---------- footer ---------- */
+.c-foot {
+  border-top: 1px solid var(--c-line);
+  padding: 18px 28px;
+  font-family: var(--c-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  color: var(--c-faint);
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.c-foot :where(a) {
+  color: var(--c-dim);
+}
+.c-foot :where(a):hover {
+  color: var(--c-accent);
+}
+
+/* ---------- shared ---------- */
+.c-page {
+  max-width: 1160px;
+  margin: 0 auto;
+  padding: 0 28px 80px;
+}
+.c-sec-label {
+  font-family: var(--c-mono);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  color: var(--c-faint);
+  text-transform: uppercase;
+}
+.c-no {
+  font-family: var(--c-mono);
+  font-size: 12px;
+  color: var(--c-faint);
+  letter-spacing: 0.05em;
+}
+.c-btn {
+  font-family: var(--c-sans);
+  font-size: 13.5px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 10px 22px;
+  border: 1px solid var(--c-ink);
+  background: transparent;
+  color: var(--c-ink);
+  transition:
+    background 0.12s,
+    color 0.12s;
+}
+.c-btn:hover {
+  background: var(--c-ink);
+  color: var(--c-bg);
+}
+.c-btn-solid {
+  background: var(--c-accent);
+  border-color: var(--c-accent);
+  color: #fff;
+}
+.c-btn-solid:hover {
+  background: #c93a3f;
+  border-color: #c93a3f;
+  color: #fff;
+}
+.c-btn-ghost {
+  border-color: var(--c-line);
+}
+.c-btn-ghost:hover {
+  border-color: var(--c-ink);
+  background: var(--c-surface);
+  color: var(--c-ink);
+}
+
+/* rating chip: color injected via --c-c inline var */
+.c-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--c-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  border: 1px solid var(--c-line);
+  padding: 1px 8px;
+  color: var(--c-dim);
+  white-space: nowrap;
+}
+.c-chip::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--c-c, var(--c-r0));
+}
+.c-vis {
+  font-family: var(--c-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  color: var(--c-faint);
+  margin-left: 12px;
+}
+.c-vis::before {
+  content: "● ";
+  font-size: 8px;
+  vertical-align: 2px;
+}
+.c-vis.mem {
+  color: var(--c-r3);
+}
+.c-vis.vip {
+  color: var(--c-r4);
+}
+.c-vis.pw {
+  color: var(--c-accent);
+}
+.c-vis.adm {
+  color: var(--c-dim);
+}
+
+/* ---------- home ---------- */
+.c-hero {
+  padding: 60px 0 44px;
+}
+.c-hero .kicker {
+  display: flex;
+  gap: 14px;
+  align-items: baseline;
+  margin-bottom: 18px;
+}
+.c-hero h1 {
+  font-size: clamp(46px, 9vw, 104px);
+  font-weight: 800;
+  letter-spacing: -0.045em;
+  line-height: 0.98;
+}
+.c-hero .hollow {
+  color: transparent;
+  -webkit-text-stroke: 1.5px var(--c-ink);
+}
+.c-hero .dot {
+  color: var(--c-accent);
+}
+.c-hero .sub {
+  color: var(--c-dim);
+  margin-top: 20px;
+  max-width: 56ch;
+  font-size: 15.5px;
+}
+.c-home-cols {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1fr;
+  border: 1px solid var(--c-line);
+  border-top: 2px solid var(--c-line-strong);
+}
+.c-home-col {
+  padding: 22px 24px 26px;
+  border-right: 1px solid var(--c-line);
+}
+.c-home-col:last-child {
+  border-right: 0;
+}
+.c-home-col h3 {
+  font-size: 12px;
+  letter-spacing: 0.2em;
+  font-family: var(--c-mono);
+  color: var(--c-faint);
+  font-weight: 500;
+  margin-bottom: 14px;
+}
+.c-latest {
+  display: flex;
+  gap: 12px;
+  padding: 9px 0;
+  border-bottom: 1px solid var(--c-line);
+  align-items: baseline;
+}
+.c-latest:last-child {
+  border-bottom: 0;
+}
+.c-latest .t {
+  flex: 1;
+  font-weight: 600;
+  font-size: 14.5px;
+  color: var(--c-ink);
+}
+.c-latest .t:hover {
+  color: var(--c-accent);
+  text-decoration: none;
+}
+.c-latest .d {
+  font-family: var(--c-mono);
+  font-size: 11px;
+  color: var(--c-faint);
+  white-space: nowrap;
+}
+.c-stat {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--c-line);
+}
+.c-stat:last-child {
+  border-bottom: 0;
+}
+.c-stat b {
+  font-family: var(--c-mono);
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+.c-stat b.red {
+  color: var(--c-accent);
+}
+.c-stat :where(span) {
+  font-size: 12.5px;
+  color: var(--c-dim);
+}
+@media (max-width: 900px) {
+  .c-home-cols {
+    grid-template-columns: 1fr;
+  }
+  .c-home-col {
+    border-right: 0;
+    border-bottom: 1px solid var(--c-line);
+  }
+}
+
+/* ---------- blog list ---------- */
+.c-list-head {
+  display: flex;
+  align-items: baseline;
+  gap: 18px;
+  padding: 44px 0 14px;
+}
+.c-list-head h1 {
+  font-size: 40px;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+.c-list-head .count {
+  font-family: var(--c-mono);
+  font-size: 12px;
+  color: var(--c-faint);
+}
+.c-rowlist {
+  border-top: 2px solid var(--c-line-strong);
+}
+.c-row {
+  display: grid;
+  grid-template-columns: 64px 1fr auto 92px;
+  gap: 20px;
+  padding: 15px 10px;
+  border-bottom: 1px solid var(--c-line);
+  align-items: center;
+  position: relative;
+}
+a.c-row {
+  color: inherit;
+}
+a.c-row:hover {
+  background: var(--c-accent-soft);
+  text-decoration: none;
+}
+a.c-row:hover::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--c-accent);
+}
+.c-row .t {
+  font-weight: 600;
+  font-size: 16px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.c-row .tags {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.c-row .d {
+  font-family: var(--c-mono);
+  font-size: 11.5px;
+  color: var(--c-faint);
+  text-align: right;
+}
+.c-year {
+  font-family: var(--c-mono);
+  font-size: 12px;
+  color: var(--c-faint);
+  letter-spacing: 0.2em;
+  padding: 26px 10px 6px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.c-year::after {
+  content: "";
+  flex: 1;
+  border-top: 1px solid var(--c-line);
+}
+.c-pager {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  padding: 36px 0 0;
+}
+.c-pager :where(a),
+.c-pager :where(span) {
+  font-family: var(--c-mono);
+  font-size: 12px;
+  padding: 6px 14px;
+  border: 1px solid var(--c-line);
+  color: var(--c-dim);
+}
+.c-pager .cur {
+  background: var(--c-ink);
+  color: var(--c-bg);
+  border-color: var(--c-ink);
+}
+.c-pager :where(a):hover {
+  border-color: var(--c-ink);
+  color: var(--c-ink);
+  text-decoration: none;
+}
+.c-devhint {
+  font-family: var(--c-mono);
+  font-size: 12px;
+  color: var(--c-faint);
+  border: 1px dashed var(--c-line);
+  padding: 8px 14px;
+  margin: 14px 0;
+}
+@media (max-width: 720px) {
+  .c-row {
+    grid-template-columns: 48px 1fr;
+  }
+  .c-row .tags,
+  .c-row .d {
+    display: none;
+  }
+}
+
+/* ---------- article ---------- */
+.c-art {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 48px;
+  padding-top: 44px;
+}
+.c-rail {
+  position: sticky;
+  top: 20px;
+  align-self: start;
+}
+.c-rail .bigno {
+  font-family: var(--c-mono);
+  font-size: 44px;
+  font-weight: 300;
+  color: var(--c-faint);
+  letter-spacing: -0.02em;
+}
+.c-rail .bigno b {
+  color: var(--c-accent);
+  font-weight: 300;
+}
+.c-rail dt {
+  font-family: var(--c-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.18em;
+  color: var(--c-faint);
+  margin-top: 12px;
+}
+.c-rail dd {
+  font-size: 13.5px;
+}
+.c-art-title h1 {
+  font-size: clamp(28px, 4.4vw, 42px);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  line-height: 1.25;
+}
+.c-art-title .bar {
+  height: 4px;
+  background: linear-gradient(
+    90deg,
+    var(--c-accent) 0 64px,
+    var(--c-line) 64px
+  );
+  margin: 18px 0 8px;
+}
+
+.md {
+  max-width: 68ch;
+  font-size: 16px;
+}
+.md p {
+  margin: 18px 0;
+}
+.md h2 {
+  font-size: 22px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  margin: 40px 0 12px;
+  padding-top: 18px;
+  border-top: 1px solid var(--c-line);
+  scroll-margin-top: 20px;
+}
+.md h2 a {
+  color: inherit;
+}
+.md ul {
+  margin: 14px 0;
+  list-style: none;
+}
+.md ul li {
+  padding: 6px 0 6px 24px;
+  position: relative;
+}
+.md ul li::before {
+  content: "→";
+  position: absolute;
+  left: 0;
+  color: var(--c-accent);
+  font-family: var(--c-mono);
+}
+.md :where(a):not(:hover) {
+  color: var(--c-r3);
+}
+html.dark .md a {
+  color: #7ea3f5;
+}
+.md blockquote {
+  border-left: 3px solid var(--c-accent);
+  padding: 10px 20px;
+  margin: 20px 0;
+  background: var(--c-surface);
+  color: var(--c-dim);
+}
+.md :where(code.c-inline) {
+  font-family: var(--c-mono);
+  font-size: 0.85em;
+  background: var(--c-surface);
+  border: 1px solid var(--c-line);
+  padding: 1px 6px;
+}
+
+.c-code {
+  position: relative;
+  margin: 22px 0;
+}
+.c-code-copy {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  z-index: 10;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid #3a3d45;
+  background: rgba(20, 22, 26, 0.85);
+  color: #9aa0aa;
+  border-radius: 3px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-family: var(--c-mono);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.c-code:hover .c-code-copy,
+.c-code-copy:focus-visible {
+  opacity: 1;
+}
+@media not (hover: hover) {
+  .c-code-copy {
+    opacity: 0.75;
+  }
+}
+.md pre.c-pre {
+  font-family: var(--c-mono);
+  font-size: 13px;
+  line-height: 1.75;
+  background: var(--c-surface);
+  border: 1px solid var(--c-line);
+  border-left: 3px solid var(--c-ink);
+  padding: 18px 20px;
+  overflow-x: auto;
+  margin: 0;
+}
+.md pre.c-pre code {
+  background: none;
+  padding: 0;
+}
+
+/* ---------- comments ---------- */
+.c-cmt-head {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  margin: 56px 0 6px;
+}
+.c-cmt-head h2 {
+  font-size: 14px;
+  letter-spacing: 0.16em;
+  font-family: var(--c-mono);
+  font-weight: 600;
+}
+.c-cmt-head .n {
+  font-family: var(--c-mono);
+  font-size: 11px;
+  color: var(--c-accent);
+}
+.c-cmt {
+  border: 1px solid var(--c-line);
+  margin-top: -1px;
+  padding: 14px 18px;
+}
+.c-cmt.reply {
+  margin: 0 0 -1px 44px;
+  border-left: 3px solid var(--c-line);
+  background: var(--c-surface);
+}
+.c-cmt-h {
+  display: flex;
+  gap: 12px;
+  font-size: 12px;
+  color: var(--c-dim);
+  margin-bottom: 6px;
+  font-family: var(--c-mono);
+}
+.c-cmt-h .who {
+  color: var(--c-ink);
+  font-weight: 600;
+}
+.c-cmt-b p {
+  margin: 0 0 6px;
+  font-size: 14.5px;
+}
+.c-cmt-b p:last-child {
+  margin-bottom: 0;
+}
+.c-cmt-b :where(code) {
+  font-family: var(--c-mono);
+  font-size: 0.85em;
+  background: var(--c-surface);
+  border: 1px solid var(--c-line);
+  padding: 0 5px;
+}
+.c-cmt-b blockquote {
+  border-left: 2px solid var(--c-line);
+  padding-left: 12px;
+  color: var(--c-dim);
+}
+.c-cmt-ops {
+  display: flex;
+  gap: 14px;
+  font-family: var(--c-mono);
+  font-size: 11.5px;
+  margin-top: 8px;
+}
+.c-cmt-ops :where(button) {
+  color: var(--c-dim);
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font-family: var(--c-mono);
+  font-size: 11.5px;
+  padding: 0;
+}
+.c-cmt-ops :where(button):hover {
+  color: var(--c-ink);
+}
+.c-cmt-ops .del:hover {
+  color: var(--c-accent);
+}
+.c-cmt-form {
+  display: flex;
+  gap: 0;
+  margin-top: 18px;
+  border: 1px solid var(--c-ink);
+}
+.c-cmt-form textarea {
+  flex: 1;
+  border: 0;
+  padding: 12px 16px;
+  font-family: var(--c-sans);
+  font-size: 14px;
+  background: var(--c-bg);
+  color: var(--c-ink);
+  resize: vertical;
+}
+.c-cmt-form textarea:focus {
+  outline: none;
+}
+.c-cmt-form button {
+  border: 0;
+  border-left: 1px solid var(--c-ink);
+  background: var(--c-ink);
+  color: var(--c-bg);
+  font-family: var(--c-sans);
+  font-size: 13px;
+  font-weight: 600;
+  padding: 0 24px;
+  cursor: pointer;
+}
+.c-cmt-form button:hover {
+  background: var(--c-accent);
+  border-color: var(--c-accent);
+  color: #fff;
+}
+.c-cmt-hint {
+  font-size: 12px;
+  color: var(--c-faint);
+}
+.c-cmt-hint .err {
+  color: var(--c-accent);
+  margin-left: 8px;
+}
+
+/* ---------- projects ---------- */
+.c-proj {
+  border-top: 2px solid var(--c-line-strong);
+}
+.c-proj-row {
+  display: grid;
+  grid-template-columns: 130px 1.2fr 1fr auto;
+  gap: 24px;
+  padding: 24px 10px;
+  border-bottom: 1px solid var(--c-line);
+  align-items: start;
+}
+.c-proj-row:hover {
+  background: var(--c-surface);
+}
+.c-proj-row .idx {
+  font-family: var(--c-mono);
+  font-size: 26px;
+  font-weight: 300;
+  color: var(--c-faint);
+}
+.c-proj-row .idx .feat {
+  display: block;
+  font-size: 9.5px;
+  letter-spacing: 0.24em;
+  color: var(--c-accent);
+  margin-top: 2px;
+}
+.c-proj-row h2 {
+  font-size: 18px;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+}
+.c-proj-row p {
+  font-size: 13.5px;
+  color: var(--c-dim);
+  margin-top: 6px;
+}
+.c-proj-row .ptags {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  padding-top: 4px;
+}
+.c-proj-row .plinks {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-family: var(--c-mono);
+  font-size: 12px;
+  text-align: right;
+}
+.c-proj-row .plinks a {
+  color: var(--c-dim);
+  border-bottom: 1px solid var(--c-line);
+  padding-bottom: 1px;
+}
+.c-proj-row .plinks a:hover {
+  color: var(--c-accent);
+  border-color: var(--c-accent);
+  text-decoration: none;
+}
+@media (max-width: 900px) {
+  .c-proj-row {
+    grid-template-columns: 70px 1fr;
+  }
+  .c-proj-row .plinks {
+    flex-direction: row;
+    grid-column: 2;
+    text-align: left;
+    gap: 18px;
+  }
+}
+
+/* ---------- auth ---------- */
+.c-auth {
+  max-width: 440px;
+  margin: 50px auto 0;
+}
+.c-auth-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding-bottom: 10px;
+}
+.c-auth-head h1 {
+  font-size: 24px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+.c-auth-card {
+  border: 1px solid var(--c-ink);
+  padding: 30px 30px 34px;
+  position: relative;
+}
+.c-auth-card::before {
+  content: "";
+  display: block;
+  height: 4px;
+  background: var(--c-accent);
+  margin: -30px -30px 26px;
+}
+.c-field {
+  margin: 16px 0;
+}
+.c-field label {
+  display: block;
+  font-family: var(--c-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.2em;
+  color: var(--c-faint);
+  margin-bottom: 6px;
+  text-transform: uppercase;
+}
+.c-input {
+  width: 100%;
+  font-family: var(--c-sans);
+  font-size: 14.5px;
+  color: var(--c-ink);
+  background: var(--c-bg);
+  border: 1px solid var(--c-line);
+  padding: 10px 13px;
+}
+.c-input:focus {
+  outline: none;
+  border-color: var(--c-ink);
+}
+.c-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 24px;
+  flex-wrap: wrap;
+}
+.c-aside {
+  margin-top: 18px;
+  font-size: 13px;
+  color: var(--c-dim);
+}
+.c-aside :where(a) {
+  color: var(--c-accent);
+}
+.c-err {
+  margin-top: 16px;
+  font-size: 13px;
+  color: var(--c-accent);
+  border: 1px solid rgba(229, 72, 77, 0.35);
+  background: var(--c-accent-soft);
+  padding: 8px 12px;
+}
+.c-lockline {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--c-mono);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  color: var(--c-accent);
+  margin-bottom: 14px;
+}
+.c-lockline::after {
+  content: "";
+  flex: 1;
+  border-top: 1px solid rgba(229, 72, 77, 0.4);
+}
+
+/* ---------- 404 ---------- */
+.c-nf {
+  padding: 70px 0 30px;
+}
+.c-nf .code {
+  font-family: var(--c-mono);
+  font-size: clamp(90px, 18vw, 190px);
+  font-weight: 300;
+  letter-spacing: -0.05em;
+  line-height: 1;
+}
+.c-nf .code b {
+  color: var(--c-accent);
+  font-weight: 300;
+}
+.c-nf p {
+  color: var(--c-dim);
+  margin-top: 14px;
+}

--- a/tests/e2e/admin-flow.spec.ts
+++ b/tests/e2e/admin-flow.spec.ts
@@ -19,7 +19,7 @@ test('admin can create a post that appears on the blog', async ({ page }) => {
   await page.locator('#password').fill(ADMIN_PASSWORD);
   await page.locator('form button[type="submit"]').click();
 
-  const loggedIn = page.getByRole('link', { name: /logout/i });
+  const loggedIn = page.getByTestId('nav-logout');
   try {
     await expect(loggedIn).toBeVisible({ timeout: 8000 });
   } catch {

--- a/tests/e2e/auth-logout.spec.ts
+++ b/tests/e2e/auth-logout.spec.ts
@@ -8,18 +8,20 @@ function createUniqueEmail(): string {
 test('signup then logout returns to guest header state', async ({ page }) => {
   await page.goto('/signup', { waitUntil: 'domcontentloaded' });
 
-  await page.getByLabel('Name').fill('E2E Logout');
-  await page.getByLabel('Email').fill(createUniqueEmail());
-  await page.getByLabel('Password').fill('Playwright!12345');
-  await page.getByRole('button', { name: 'Sign Up' }).click();
+  // Form anchors are theme-stable: field ids on /signup + the submit button.
+  // Header anchors use data-testid because each UX theme words them
+  // differently (login / 入会 / SIGN IN …).
+  await page.locator('#name').fill('E2E Logout');
+  await page.locator('#email').fill(createUniqueEmail());
+  await page.locator('#password').fill('Playwright!12345');
+  await page.locator('form button[type="submit"]').click();
 
   await page.waitForURL('**/blog');
-  await expect(page.getByRole('link', { name: 'Logout' })).toBeVisible();
+  await expect(page.getByTestId('nav-logout')).toBeVisible();
 
-  await page.getByRole('link', { name: 'Logout' }).click();
+  await page.getByTestId('nav-logout').click();
 
   await page.waitForURL('**/blog');
-  await expect(page.getByRole('link', { name: 'Login' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Sign Up' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Logout' })).toHaveCount(0);
+  await expect(page.getByTestId('nav-login')).toBeVisible();
+  await expect(page.getByTestId('nav-logout')).toHaveCount(0);
 });


### PR DESCRIPTION
## What — UX 改版方向 C「瑞士网格 × 评级色」落地

把原型 `prototypes/c-swiss.html` 落到真实应用：冷静、高信息密度的数据网格美学。

- **壳**：键线导航条（黑粗底边 + 当前页红色下划线 + logo 红色光标块），全站 1px 键线分隔
- **编号系统**：每篇文章有稳定编号 `№0858`（按发布日期距 2019-01-01 的天数），列表页与文章页共享同一编号
- **评级色标签**：标签用竞赛评级色系（灰→绿→青→蓝→紫→橙→红，按标签名确定性映射），列表行 hover 红色左标线
- **首页**：巨大词标（PERFECT 空心描边）+ 三栏数据面板（最新/项目/统计，来自真实 loader 数据）
- **文章页**：左侧粘性元信息栏（大编号 + DATE/VISIBILITY/TAGS）
- **登录/解锁**：红条认证卡（AUTH / 01-03）；**404** = 巨型 4⚡4
- **唯一保留亮暗双主题的方向**（tokens 在 html.dark 下整体翻转），DarkMode 组件去掉旧主题的 body 工具类

## 不变的东西

路由 / loader / 鉴权 / 评论 / 搜索逻辑未动；首页新增一个只读 loader（复用现有公开列表 server fn）。Admin 沿用现有样式（双主题变体可用）。

## 验证

- [x] typecheck / lint（0 error）/ test 36 passed / build + 体积 **1025.5 KiB gzip**
- [x] 本地 dev 冒烟 7 页 + 暗色切换实测（body #0e0f12、键线翻转）
- [x] DOM/CSS 断言：三栏 3、列表行 20、chips 30（含 --c-c 评级色）、文章栏 №、404

> 7 个候选方向之一（A–G）。预览用 Workers Builds preview URL。