### PR TITLE
feat(web): apply zen whitespace theme (UX direction D)

### DIFF
--- a/apps/web/src/components/comments.tsx
+++ b/apps/web/src/components/comments.tsx
@@ -20,14 +20,6 @@ type CommentsProps = {
 
 const PAGE_SIZE = 20;
 
-function getInitials(name: string): string {
-  const trimmed = name.trim();
-  if (!trimmed) {
-    return '?';
-  }
-  return trimmed.slice(0, 1).toUpperCase();
-}
-
 function formatRelative(iso: string): string {
   const then = new Date(iso).getTime();
   if (Number.isNaN(then)) {
@@ -54,24 +46,6 @@ function formatRelative(iso: string): string {
     day: 'numeric',
     year: 'numeric',
   });
-}
-
-function Avatar({ name, image }: { name: string; image: string | null }) {
-  if (image) {
-    return (
-      <img
-        src={image}
-        alt={name}
-        loading='lazy'
-        className='h-8 w-8 shrink-0 rounded-full bg-zinc-100 dark:bg-zinc-800'
-      />
-    );
-  }
-  return (
-    <div className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-zinc-200 text-xs font-semibold text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300'>
-      {getInitials(name)}
-    </div>
-  );
 }
 
 type ComposerProps = {
@@ -107,26 +81,27 @@ function Composer({
   }
 
   return (
-    <form onSubmit={handleSubmit} className='flex flex-col gap-2'>
+    <form onSubmit={handleSubmit} className='z-cmt-form'>
       <textarea
         value={body}
         onChange={(event) => setBody(event.target.value)}
         placeholder={placeholder}
         rows={compact ? 2 : 3}
         maxLength={2000}
-        className='w-full resize-y rounded-md border border-zinc-300 bg-transparent px-3 py-2 text-sm outline-none transition-colors focus:border-zinc-400 dark:border-zinc-600 dark:focus:border-zinc-400'
       />
-      <div className='flex items-center justify-between gap-2'>
-        <span className='text-xs opacity-50'>
-          {remaining < 200 ? `${remaining} 字剩余` : '支持 Markdown'}
-          {error ? <span className='ml-2 text-red-500'>{error}</span> : null}
+      <div className='z-cmt-foot'>
+        <span className='z-hint'>
+          {remaining < 200
+            ? `${remaining} 字剩余`
+            : '静かに一言どうぞ（Markdown 可）'}
+          {error ? <span className='err'>{error}</span> : null}
         </span>
         <button
           type='submit'
           disabled={submitting || !body.trim()}
-          className='rounded-md bg-black px-3 py-1 text-xs font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-neutral-900'
+          className='z-btn z-btn-fill'
         >
-          {submitting ? '发送中…' : '发送'}
+          {submitting ? '投递中…' : '投　稿'}
         </button>
       </div>
     </form>
@@ -191,7 +166,7 @@ function CommentItem({
       ) : null}
 
       {thread.replies.length > 0 ? (
-        <ul className='ml-10 flex flex-col gap-2 border-l border-zinc-200 pl-4 dark:border-zinc-700'>
+        <ul className='ml-10 flex flex-col'>
           {thread.replies.map((reply) => {
             const replyCanAct =
               sessionUser != null &&
@@ -233,49 +208,28 @@ function CommentView({
   onDelete,
 }: CommentViewProps) {
   return (
-    <div className='flex gap-3'>
-      <Avatar name={comment.author.name} image={comment.author.image} />
-      <div className='min-w-0 flex-1'>
-        <div className='flex flex-wrap items-center gap-x-2 gap-y-0.5'>
-          <span className='text-sm font-semibold'>{comment.author.name}</span>
-          {comment.author.role === 'admin' ? (
-            <span className='rounded bg-zinc-900 px-1.5 py-0.5 text-[10px] font-semibold text-white dark:bg-white dark:text-zinc-900'>
-              Author
-            </span>
-          ) : null}
-          {comment.status !== 'visible' ? (
-            <span className='rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'>
-              {comment.status}
-            </span>
-          ) : null}
-          <span className='text-xs opacity-50'>
-            {formatRelative(comment.createdAt)}
-          </span>
-        </div>
-        <div className='mt-1'>
-          <CommentMarkdown content={comment.body} />
-        </div>
-        <div className='mt-1 flex gap-3 text-xs'>
+    <div className={comment.parentId !== null ? 'z-cmt reply' : 'z-cmt'}>
+      <div className='z-cmt-h'>
+        <span className='who'>{comment.author.name}</span>
+        {comment.author.role === 'admin' ? <span>・ 作者</span> : null}
+        {comment.status !== 'visible' ? <span>・ {comment.status}</span> : null}
+        <span> ・ {formatRelative(comment.createdAt)}</span>
+      </div>
+      <CommentMarkdown content={comment.body} />
+      {(canReply && onReply) || canAct ? (
+        <div className='z-cmt-ops'>
           {canReply && onReply ? (
-            <button
-              type='button'
-              onClick={onReply}
-              className='opacity-50 transition-opacity hover:opacity-100'
-            >
-              回复
+            <button type='button' onClick={onReply}>
+              返信
             </button>
           ) : null}
           {canAct ? (
-            <button
-              type='button'
-              onClick={() => onDelete()}
-              className='text-red-500/70 transition-colors hover:text-red-500'
-            >
-              删除
+            <button type='button' onClick={() => onDelete()}>
+              削除
             </button>
           ) : null}
         </div>
-      </div>
+      ) : null}
     </div>
   );
 }
@@ -375,10 +329,8 @@ export function Comments({
   }
 
   return (
-    <section className='mt-12'>
-      <h2 className='mb-4 text-lg font-black'>
-        评论 {total > 0 ? <span className='opacity-50'>({total})</span> : null}
-      </h2>
+    <section className='mt-2'>
+      <div className='z-label'>読 者 の 声 {total > 0 ? `(${total})` : ''}</div>
 
       {sessionUser ? (
         <div className='mb-6'>
@@ -389,24 +341,20 @@ export function Comments({
           />
         </div>
       ) : (
-        <p className='mb-6 text-sm opacity-60'>
-          <Link to='/login' className='underline hover:opacity-100'>
-            登录
+        <p className='z-hint mb-6'>
+          <Link to='/login' className='z-link'>
+            登録
           </Link>{' '}
-          后即可评论。
+          後にコメントできます。
         </p>
       )}
 
-      {topError ? (
-        <p className='mb-4 text-sm text-red-500'>{topError}</p>
-      ) : null}
+      {topError ? <p className='z-err mb-4'>{topError}</p> : null}
 
       {threads.length === 0 ? (
-        <p className='py-8 text-center text-sm opacity-50'>
-          还没有评论，来抢沙发。
-        </p>
+        <p className='z-hint py-8 text-center'>まだコメントはありません。</p>
       ) : (
-        <ul className='flex flex-col gap-5'>
+        <ul className='flex flex-col'>
           {threads.map((thread) => (
             <CommentItem
               key={thread.id}
@@ -428,9 +376,9 @@ export function Comments({
             type='button'
             onClick={handleLoadMore}
             disabled={loadingMore}
-            className='text-sm opacity-60 transition-opacity hover:opacity-100 disabled:opacity-40'
+            className='z-btn'
           >
-            {loadingMore ? '加载中…' : '加载更多'}
+            {loadingMore ? '読み込み中…' : 'もっと見る'}
           </button>
         </div>
       ) : null}

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -1,10 +1,10 @@
+import { Link } from '@tanstack/react-router';
+
 export function Footer() {
   return (
-    <footer className='p-6 text-center'>
-      © {new Date().getFullYear()}, Built with{' '}
-      <a className='text-blue-500' href='https://tanstack.com/start/latest'>
-        TanStack Start
-      </a>
+    <footer className='z-foot'>
+      PERFECTPAN ・ {new Date().getFullYear()} ・ <Link to='/blog'>読</Link> ・{' '}
+      <a href='/rss.xml'>RSS</a>
     </footer>
   );
 }

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -1,8 +1,6 @@
 import { Link } from '@tanstack/react-router';
 import { Github, LogOut, Rss, Search, UserRound } from 'lucide-react';
 import { authClient } from '../lib/auth-client.js';
-import { DarkMode } from './dark-mode.js';
-import { MenuLink } from './menu.js';
 import { searchPalette } from './search-palette-store.js';
 
 function getRoleLabel(role?: string | null): string {
@@ -17,79 +15,72 @@ function getRoleLabel(role?: string | null): string {
   return 'MEMBER';
 }
 
+/** Zen header: journal mark + minimal nav + tools. Light-only theme. */
 export function Header() {
   const { data: sessionData } = authClient.useSession();
   const sessionUser = sessionData?.user ?? null;
 
   return (
-    <header className='border-b border-slate-200 bg-white shadow-md dark:border-slate-300/10 dark:bg-slate-900'>
-      <div className='mx-4 flex h-16 items-center sm:mx-6'>
-        <Link
-          to='/'
-          className='rounded-md border-10 border-black bg-black px-1 font-bold text-white dark:border-neutral-900 dark:bg-neutral-900'
-        >
-          PerfectPan
+    <div>
+      <header className='z-head'>
+        <Link to='/' className='mark'>
+          字纸篓
         </Link>
-        <div className='m-0 flex list-none items-center pl-1'>
-          <MenuLink href='/' name='Home' />
-          <MenuLink href='/blog' name='Blog' />
-          <MenuLink href='/projects' name='Projects' />
-          {sessionUser?.role === 'admin' ? (
-            <MenuLink href='/admin' name='Admin' />
-          ) : null}
-        </div>
-        <div className='ml-auto flex items-center gap-2 sm:gap-3'>
+        <nav aria-label='主导航'>
+          <Link to='/blog'>读</Link>
+          <Link to='/projects'>物</Link>
+          {sessionUser?.role === 'admin' ? <Link to='/admin'>理</Link> : null}
+        </nav>
+        <div className='z-tools ml-auto'>
           {sessionUser ? (
-            <div className='hidden items-center gap-2 rounded-full border border-slate-300 px-3 py-1 text-xs text-gray-700 md:flex dark:border-slate-600 dark:text-slate-200'>
-              <UserRound size={14} className='opacity-70' />
-              <span className='max-w-[220px] truncate'>
+            <span className='z-user'>
+              <UserRound size={12} aria-hidden='true' />
+              <span className='max-w-[160px] truncate'>
                 {sessionUser.email}
               </span>
-              <span className='rounded-full bg-black px-2 py-[2px] text-[10px] font-semibold text-white dark:bg-neutral-100 dark:text-neutral-900'>
+              <span
+                style={{
+                  border: '1px solid var(--z-line)',
+                  borderRadius: 8,
+                  padding: '0 6px',
+                  fontSize: 9.5,
+                  letterSpacing: '0.12em',
+                }}
+              >
                 {getRoleLabel(sessionUser.role)}
               </span>
-            </div>
+            </span>
           ) : null}
           {sessionUser ? (
-            <Link
-              to='/logout'
-              className='inline-flex items-center gap-1 rounded-md border border-slate-300 px-2 py-1 text-sm opacity-85 transition-opacity hover:opacity-100 dark:border-slate-600'
-            >
-              <LogOut size={14} />
-              <span className='hidden sm:inline'>Logout</span>
+            <Link to='/logout' aria-label='Logout'>
+              <LogOut size={15} />
             </Link>
           ) : (
-            <>
-              <Link to='/login' className='opacity-70 hover:opacity-100'>
-                Login
-              </Link>
-              <Link to='/signup' className='opacity-70 hover:opacity-100'>
-                Sign Up
-              </Link>
-            </>
+            <Link to='/login'>入</Link>
           )}
           <button
             type='button'
-            aria-label='Search posts (Cmd+K)'
+            aria-label='検索 (Cmd+K)'
             onClick={() => searchPalette.open()}
-            className='inline-flex items-center opacity-70 transition-opacity hover:opacity-100'
           >
-            <Search size={22} />
+            <Search size={15} />
           </button>
-          <DarkMode />
           <a
             href='https://github.com/PerfectPan'
             target='_blank'
             rel='noreferrer'
-            className='flex items-center'
+            aria-label='GitHub'
           >
-            <Github size={22} className='opacity-70 hover:opacity-100' />
+            <Github size={15} />
           </a>
-          <a href='/rss.xml' target='_blank' rel='noreferrer'>
-            <Rss size={24} className='opacity-70 hover:opacity-100' />
+          <a href='/rss.xml' target='_blank' rel='noreferrer' aria-label='RSS'>
+            <Rss size={15} />
           </a>
         </div>
-      </div>
-    </header>
+      </header>
+      <aside className='z-margin-note' aria-hidden='true'>
+        字纸篓 ・ PERFECTPAN ・ 静々と更新中
+      </aside>
+    </div>
   );
 }

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -52,11 +52,13 @@ export function Header() {
             </span>
           ) : null}
           {sessionUser ? (
-            <Link to='/logout' aria-label='Logout'>
+            <Link to='/logout' data-testid='nav-logout' aria-label='Logout'>
               <LogOut size={15} />
             </Link>
           ) : (
-            <Link to='/login'>入</Link>
+            <Link to='/login' data-testid='nav-login'>
+              入
+            </Link>
           )}
           <button
             type='button'

--- a/apps/web/src/components/layout.tsx
+++ b/apps/web/src/components/layout.tsx
@@ -7,21 +7,17 @@ type AppLayoutProps = {
 };
 
 /**
- * App shell. The header sits OUTSIDE the scroll container (`main`), so page
- * overscroll only rubber-bands the content — the pinned header never moves
- * (no macOS "fixed header drags on overscroll"). Window doesn't scroll; route
- * scroll reset/restore for `main` is handled by TanStack via
- * `scrollToTopSelectors: ['main']` in router.tsx.
+ * App shell (zen theme). The quiet header sits OUTSIDE the scroll container
+ * (`main`). Window doesn't scroll; route scroll reset/restore for `main` is
+ * handled by TanStack via `scrollToTopSelectors: ['main']` in router.tsx.
  */
 export function AppLayout({ children }: AppLayoutProps) {
   return (
-    <div className='flex h-dvh flex-col'>
+    <div className='z-shell'>
       <Header />
-      <main className='flex-1 overflow-y-auto'>
+      <main className='z-main'>
         <div className='flex min-h-full flex-col'>
-          <div className='flex flex-grow items-center justify-center px-6 *:min-h-64 *:min-w-64'>
-            {children}
-          </div>
+          <div className='flex-grow'>{children}</div>
           <Footer />
         </div>
       </main>

--- a/apps/web/src/components/markdown.tsx
+++ b/apps/web/src/components/markdown.tsx
@@ -78,20 +78,17 @@ function CodeBlock({ children }: { children?: ReactNode }) {
   }, []);
 
   return (
-    <div className='group relative mb-2'>
+    <div className='z-code group relative'>
       <button
         type='button'
         onClick={onCopy}
         aria-label='Copy code'
-        className='absolute right-2 top-2 z-10 inline-flex items-center gap-1 rounded border border-slate-300 bg-white/70 px-1.5 py-0.5 text-xs opacity-0 backdrop-blur transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100 hover-none:opacity-70 dark:border-slate-700 dark:bg-slate-900/70'
+        className='z-code-copy'
       >
         {copied ? <Check size={12} /> : <Copy size={12} />}
         {copied ? 'Copied' : 'Copy'}
       </button>
-      <pre
-        ref={preRef}
-        className='shiki w-full overflow-x-auto whitespace-pre-wrap rounded-md bg-zinc-50 p-4 dark:bg-shiki-dark'
-      >
+      <pre ref={preRef} className='shiki z-pre w-full overflow-x-auto'>
         {children}
       </pre>
     </div>
@@ -112,7 +109,7 @@ export function Markdown({ content }: MarkdownProps) {
   }, []);
 
   return (
-    <article>
+    <article className='md'>
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkMath]}
         rehypePlugins={[
@@ -133,10 +130,7 @@ export function Markdown({ content }: MarkdownProps) {
             const id = typeof children === 'string' ? children : '';
 
             return (
-              <h2
-                id={id}
-                className='mb-6 mt-14 scroll-mt-20 text-balance text-2xl leading-none font-black first:mt-0'
-              >
+              <h2 id={id} className='scroll-mt-20'>
                 <a
                   href={`#${id}`}
                   onClick={(event) => {
@@ -150,24 +144,21 @@ export function Markdown({ content }: MarkdownProps) {
               </h2>
             );
           },
-          p: ({ children }) => <p className='mb-6 leading-7'>{children}</p>,
+          p: ({ children }) => <p>{children}</p>,
           a: ({ href, children }) => (
-            <a
-              href={href}
-              className='text-blue-700/80 transition-colors duration-300 ease-in-out hover:text-blue-700'
-              target='_blank'
-              rel='noreferrer'
-            >
+            <a href={href} target='_blank' rel='noreferrer'>
               {children}
             </a>
           ),
-          strong: ({ children }) => (
-            <b className='font-extrabold'>{children}</b>
-          ),
-          ul: ({ children }) => (
-            <ul className='mb-4 ml-4 list-disc'>{children}</ul>
-          ),
+          strong: ({ children }) => <b className='font-bold'>{children}</b>,
+          ul: ({ children }) => <ul>{children}</ul>,
           pre: ({ children }) => <CodeBlock>{children}</CodeBlock>,
+          code: ({ className, children }) =>
+            /language-/.test(className ?? '') ? (
+              <code className={className}>{children}</code>
+            ) : (
+              <code className='z-inline'>{children}</code>
+            ),
         }}
       >
         {content}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -26,7 +26,7 @@ export const Route = createRootRoute({
       },
       {
         name: 'theme-color',
-        content: '#000000',
+        content: '#F7F8F5',
       },
     ],
     links: [
@@ -38,12 +38,16 @@ export const Route = createRootRoute({
   errorComponent: ({ error }) => (
     <RootDocument>
       <AppLayout>
-        <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-          <h2 className='mb-4 text-3xl'>Request Failed</h2>
-          <p className='mb-4 opacity-70'>{String(error)}</p>
-          <Link to='/blog' className='opacity-70 hover:opacity-100'>
-            Back to blog
-          </Link>
+        <div className='z-page'>
+          <div className='z-nf'>
+            <div className='k'>虚</div>
+            <p>{String(error)}</p>
+            <p style={{ marginTop: 26 }}>
+              <Link to='/blog' className='z-link'>
+                回到目次
+              </Link>
+            </p>
+          </div>
         </div>
       </AppLayout>
     </RootDocument>
@@ -51,12 +55,16 @@ export const Route = createRootRoute({
   notFoundComponent: () => (
     <RootDocument>
       <AppLayout>
-        <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-          <h2 className='mb-4 text-3xl'>404 Not Found</h2>
-          <p className='mb-4 opacity-70'>你闯入了无人之境...</p>
-          <Link to='/blog' className='opacity-70 hover:opacity-100'>
-            Back to blog
-          </Link>
+        <div className='z-page'>
+          <div className='z-nf'>
+            <div className='k'>空</div>
+            <p>此处无文</p>
+            <p style={{ marginTop: 26 }}>
+              <Link to='/blog' className='z-link'>
+                回到目次
+              </Link>
+            </p>
+          </div>
         </div>
       </AppLayout>
     </RootDocument>

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -70,23 +70,23 @@ function BlogDetailPage() {
     return null;
   }
 
-  const date = new Date(post.publishedAt).toLocaleDateString('en-US', {
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
-  });
+  const date = new Date(post.publishedAt).toISOString().slice(0, 10);
 
   return (
-    <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <div className='m-auto mb-8 flex flex-col gap-2'>
-        <div className='text-3xl font-black'>{post.title}</div>
-        <div className='opacity-60'>{date}</div>
+    <div className='z-page'>
+      <div className='z-ma' style={{ paddingTop: 56 }} aria-hidden='true'>
+        <span>間</span>
       </div>
-      <Markdown content={post.contentMdx} />
-      <Link to='/blog' className='mt-4 inline-block'>
-        <span className='opacity-70'>&gt;&nbsp;&nbsp;&nbsp;</span>
-        <span className='underline opacity-70 hover:opacity-100'>cd ..</span>
-      </Link>
+      <article className='z-art'>
+        <h1>{post.title}</h1>
+        <div className='meta'>
+          {date} ・ {post.visibility} ・ {post.tags.join(' ・ ') || '未分類'}
+        </div>
+        <Markdown content={post.contentMdx} />
+      </article>
+      <div className='z-ma' aria-hidden='true'>
+        <span>読 者 の 声</span>
+      </div>
       <Comments
         key={post.slug}
         slug={post.slug}
@@ -95,6 +95,11 @@ function BlogDetailPage() {
         initialTotal={data.comments.total}
         sessionUser={data.sessionUser}
       />
+      <p className='mt-10 text-center'>
+        <Link to='/blog' className='z-link'>
+          ― 目次へ ―
+        </Link>
+      </p>
     </div>
   );
 }

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -1,6 +1,5 @@
 import type { PostSummary, SessionUser } from '@blog/shared';
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useEffect } from 'react';
 import { z } from 'zod';
 import { getBlogListServerFn } from '../../lib/blog-service.js';
@@ -49,6 +48,21 @@ function getDevScopeHint(sessionUser: SessionUser | null | undefined): string {
   return '当前身份：member；可见范围：public/member';
 }
 
+const VIS_CLASS: Record<PostSummary['visibility'], string> = {
+  public: 'z-vis',
+  member: 'z-vis mem',
+  vip: 'z-vis vip',
+  admin: 'z-vis adm',
+  password: 'z-vis pw',
+};
+const VIS_TEXT: Record<PostSummary['visibility'], string> = {
+  public: '',
+  member: '会 员',
+  vip: 'VIP',
+  admin: '编',
+  password: '密',
+};
+
 export const Route = createFileRoute('/blog/')({
   head: () => ({
     meta: [
@@ -77,88 +91,70 @@ function BlogListPage() {
   const devScopeHint = getDevScopeHint(data.sessionUser);
 
   // Conventional blog pagination: the page scrolls naturally; jump back to the
-  // top on each page change so the new page starts at its first post. (Without
-  // this, clicking "next" while scrolled to the bottom leaves the reader past a
-  // shorter page — the original "bounce".)
+  // top on each page change so the new page starts at its first post.
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-run on page change, value unused in body on purpose
   useEffect(() => {
     document.querySelector('main')?.scrollTo({ top: 0 });
   }, [data.page]);
 
   return (
-    <div className='mx-auto flex w-full max-w-[80ch] flex-col gap-8 self-start pt-8'>
-      <div className='w-full'>
-        {showDevHint ? (
-          <div className='mb-8 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900'>
-            {devScopeHint}
-          </div>
-        ) : null}
-        {blogGroups.map((group) => (
-          <div key={group.year}>
-            <div className='mb-4 text-3xl'>{group.year}</div>
-            {group.blogs.map((blog: PostSummary) => (
-              <div
-                key={blog.slug}
-                className='mt-2 mb-6 opacity-70 hover:opacity-100'
-              >
-                <Link
-                  to='/blog/$slug'
-                  params={{ slug: blog.slug }}
-                  className='flex items-center gap-2'
-                >
-                  <span className='text-lg leading-[1.2em]'>{blog.title}</span>
-                  <span className='text-sm opacity-50'>
-                    {new Date(blog.publishedAt).toLocaleDateString('en-US', {
-                      month: 'short',
-                      day: 'numeric',
-                    })}
-                  </span>
-                </Link>
-              </div>
-            ))}
-          </div>
-        ))}
+    <div className='z-page'>
+      <div className='z-ma' style={{ paddingTop: 56 }} aria-hidden='true'>
+        <span>間</span>
       </div>
-      {data.totalPages > 1 ? (
-        <nav
-          className='flex w-full items-center justify-center gap-4 text-sm sm:gap-6'
-          aria-label='Pagination'
-        >
-          {data.page > 1 ? (
+
+      {showDevHint ? <div className='z-devhint'>{devScopeHint}</div> : null}
+
+      {blogGroups.map((group) => (
+        <div key={group.year}>
+          <div className='z-year'>{group.year}</div>
+          {group.blogs.map((blog: PostSummary) => (
             <Link
-              to='/blog'
-              search={{ page: data.page - 1 }}
-              className='inline-flex items-center gap-1 opacity-60 hover:opacity-100'
+              key={blog.slug}
+              to='/blog/$slug'
+              params={{ slug: blog.slug }}
+              className='z-item flex'
             >
-              <ChevronLeft size={14} /> prev
+              <span className='t'>
+                {blog.title}
+                {blog.visibility !== 'public' ? (
+                  <span className={VIS_CLASS[blog.visibility]}>
+                    {VIS_TEXT[blog.visibility]}
+                  </span>
+                ) : null}
+              </span>
+              <span className='d'>
+                {new Date(blog.publishedAt)
+                  .toISOString()
+                  .slice(5, 10)
+                  .replace('-', ' / ')}
+              </span>
             </Link>
-          ) : (
-            <span className='inline-flex items-center gap-1 opacity-30'>
-              <ChevronLeft size={14} /> prev
-            </span>
-          )}
-          <span className='opacity-60'>
-            page {data.page} / {data.totalPages}
+          ))}
+        </div>
+      ))}
+
+      {data.totalPages > 1 ? (
+        <nav className='z-pager' aria-label='翻页'>
+          {data.page > 1 ? (
+            <Link to='/blog' search={{ page: data.page - 1 }}>
+              ← 前
+            </Link>
+          ) : null}
+          <span>
+            {data.page} / {data.totalPages}
           </span>
           {data.page < data.totalPages ? (
-            <Link
-              to='/blog'
-              search={{ page: data.page + 1 }}
-              className='inline-flex items-center gap-1 opacity-60 hover:opacity-100'
-            >
-              next <ChevronRight size={14} />
+            <Link to='/blog' search={{ page: data.page + 1 }}>
+              次 →
             </Link>
-          ) : (
-            <span className='inline-flex items-center gap-1 opacity-30'>
-              next <ChevronRight size={14} />
-            </span>
-          )}
+          ) : null}
         </nav>
       ) : null}
-      <Link to='/' className='mt-4 inline-block'>
-        <span className='opacity-70'>&gt;&nbsp;&nbsp;&nbsp;</span>
-        <span className='underline opacity-70 hover:opacity-100'>cd ..</span>
-      </Link>
+
+      <div className='z-ma' aria-hidden='true'>
+        <span>次 の 頁 へ</span>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,26 +1,61 @@
+import type { PostSummary } from '@blog/shared';
 import { createFileRoute, Link } from '@tanstack/react-router';
+import { getBlogListServerFn } from '../lib/blog-service.js';
 
 export const Route = createFileRoute('/')({
   head: () => ({
     meta: [{ title: "Home | PerfectPan's Blog" }],
   }),
+  loader: async () => {
+    // Guest-scoped first page powers the 近稿 list.
+    return getBlogListServerFn({ data: { page: 1 } });
+  },
   component: HomePage,
 });
 
 function HomePage() {
+  const data = Route.useLoaderData();
+  const latest = data.posts.slice(0, 3);
+
   return (
-    <div className='flex flex-col items-center'>
-      <img className='m-0' src='/images/xm.jpg' alt='' />
-      <div className='mt-8 text-[2.5rem] font-black'>
-        是个什么都不会的废物.jpg
+    <div className='z-page'>
+      <div className='z-hero'>
+        <div className='since'>二〇一九年以来</div>
+        <h1>
+          是个什么都不会的
+          <br />
+          废物.jpg
+        </h1>
+        <p>
+          算法竞赛退役，如今写 TypeScript 与类型体操，把整站跑在 Cloudflare
+          的免费额度上。这里收着题解、笔记和一些不成体统的随想。
+        </p>
       </div>
-      <div className='flex w-full justify-around'>
-        <div className='mx-1 mt-8 flex-1 rounded-md bg-slate-100 text-center font-semibold uppercase tracking-wider leading-[5rem] shadow-md transition-shadow hover:shadow-lg dark:bg-wash-dark dark:text-white dark:opacity-80'>
-          <Link to='/blog'>Blog</Link>
-        </div>
-        <div className='mx-1 mt-8 flex-1 rounded-md bg-slate-100 text-center font-semibold uppercase tracking-wider leading-[5rem] shadow-md transition-shadow hover:shadow-lg dark:bg-wash-dark dark:text-white dark:opacity-80'>
-          <Link to='/projects'>Projects</Link>
-        </div>
+      <div className='z-ma' aria-hidden='true'>
+        <span>間</span>
+      </div>
+      <div className='z-links'>
+        <Link to='/blog'>读文章</Link>
+        <Link to='/projects'>看器物</Link>
+      </div>
+      <div className='z-ma' aria-hidden='true'>
+        <span>間</span>
+      </div>
+      <div>
+        <div className='z-label'>近 稿 三 篇</div>
+        {latest.map((post: PostSummary) => (
+          <Link
+            key={post.slug}
+            to='/blog/$slug'
+            params={{ slug: post.slug }}
+            className='z-item flex'
+          >
+            <span className='t'>{post.title}</span>
+            <span className='d'>
+              {new Date(post.publishedAt).toISOString().slice(0, 7)}
+            </span>
+          </Link>
+        ))}
       </div>
     </div>
   );

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -34,96 +34,98 @@ function LoginPage() {
 
   if (sessionData?.user?.id || isSessionPending) {
     return (
-      <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-        <p className='opacity-70'>Checking session...</p>
-      </section>
+      <div className='z-page'>
+        <p className='z-hint text-center'>正在核对会籍……</p>
+      </div>
     );
   }
 
   return (
-    <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>登录</h1>
-      <p className='mb-6 opacity-70'>支持邮箱密码和 GitHub OAuth。</p>
+    <div className='z-page'>
+      <div className='z-gate'>
+        <h1>登　録</h1>
+        <p className='sub'>会員は「会員可読」の記事を読める</p>
+        <form
+          method='post'
+          onSubmit={(event) => {
+            event.preventDefault();
+            setError(null);
+            startTransition(async () => {
+              const result = await authClient.signIn.email({
+                email,
+                password,
+                callbackURL: '/blog',
+              });
 
-      {error ? (
-        <p role='alert' className='mb-4 text-sm text-red-700 dark:text-red-300'>
-          {error}
-        </p>
-      ) : null}
+              if (result.error) {
+                setError(result.error.message ?? '登录失败');
+                return;
+              }
 
-      <form
-        className='grid max-w-[420px] gap-3'
-        method='post'
-        onSubmit={(event) => {
-          event.preventDefault();
-          setError(null);
-          startTransition(async () => {
-            const result = await authClient.signIn.email({
-              email,
-              password,
-              callbackURL: '/blog',
+              navigate({ to: '/blog' });
             });
-
-            if (result.error) {
-              setError(result.error.message ?? '登录失败');
-              return;
-            }
-
-            navigate({ to: '/blog' });
-          });
-        }}
-      >
-        <label htmlFor='email' className='font-semibold'>
-          Email
-        </label>
-        <input
-          id='email'
-          name='email'
-          type='email'
-          required
-          autoComplete='email'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-        />
-        <label htmlFor='password' className='font-semibold'>
-          Password
-        </label>
-        <input
-          id='password'
-          name='password'
-          type='password'
-          required
-          autoComplete='current-password'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={password}
-          onChange={(event) => setPassword(event.target.value)}
-        />
-        <button
-          type='submit'
-          className='rounded-md bg-black px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90 dark:bg-neutral-900'
-          disabled={isPending}
+          }}
         >
-          {isPending ? 'Signing in...' : 'Sign In'}
-        </button>
-      </form>
-
-      <button
-        type='button'
-        className='mt-3 rounded-md border border-slate-300 px-4 py-2 font-semibold transition-colors hover:bg-gray-100 dark:border-slate-700 dark:hover:bg-slate-800'
-        onClick={async () => {
-          setError(null);
-          const result = await authClient.signIn.social({
-            provider: 'github',
-            callbackURL: '/blog',
-          });
-          if (result.error) {
-            setError(result.error.message ?? 'GitHub 登录失败');
-          }
-        }}
-      >
-        Continue with GitHub
-      </button>
-    </section>
+          <div className='z-field'>
+            <label htmlFor='email'>邮 箱</label>
+            <input
+              id='email'
+              name='email'
+              type='email'
+              required
+              autoComplete='email'
+              className='z-input'
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+            />
+          </div>
+          <div className='z-field'>
+            <label htmlFor='password'>口 令</label>
+            <input
+              id='password'
+              name='password'
+              type='password'
+              required
+              autoComplete='current-password'
+              className='z-input'
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+            />
+          </div>
+          <div className='actions'>
+            <button
+              type='submit'
+              className='z-btn z-btn-fill'
+              disabled={isPending}
+            >
+              {isPending ? '登入中…' : '登　入'}
+            </button>
+            <button
+              type='button'
+              className='z-btn'
+              onClick={async () => {
+                setError(null);
+                const result = await authClient.signIn.social({
+                  provider: 'github',
+                  callbackURL: '/blog',
+                });
+                if (result.error) {
+                  setError(result.error.message ?? 'GitHub 登录失败');
+                }
+              }}
+            >
+              GitHub
+            </button>
+          </div>
+          {error ? <p className='z-err'>{error}</p> : null}
+        </form>
+        <p className='aside'>
+          尚未注册？{' '}
+          <a href='/signup' className='z-link'>
+            注册
+          </a>
+        </p>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/routes/projects.tsx
+++ b/apps/web/src/routes/projects.tsx
@@ -1,5 +1,4 @@
-import { createFileRoute, Link } from '@tanstack/react-router';
-import { ExternalLink, Github } from 'lucide-react';
+import { createFileRoute } from '@tanstack/react-router';
 import { PROJECTS, type Project } from '../lib/projects.js';
 
 export const Route = createFileRoute('/projects')({
@@ -25,67 +24,30 @@ function ProjectsPage() {
   const projects = sortProjects(PROJECTS);
 
   return (
-    <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>Projects</h1>
-      <p className='mb-8 opacity-70'>我做过的一些东西，按需更新。</p>
-
-      <div className='grid gap-4 sm:grid-cols-2'>
-        {projects.map((project) => (
-          <article
-            key={project.name}
-            className='flex flex-col rounded-lg border border-slate-200 bg-white/60 p-5 transition-shadow hover:shadow-md dark:border-slate-700 dark:bg-wash-dark'
-          >
-            <div className='mb-1 flex items-center gap-2'>
-              <h2 className='text-lg font-semibold'>{project.name}</h2>
-              {project.featured ? (
-                <span className='rounded-full bg-black px-2 py-[2px] text-[10px] font-semibold text-white dark:bg-neutral-100 dark:text-neutral-900'>
-                  FEATURED
-                </span>
-              ) : null}
-            </div>
-            <p className='mb-4 flex-grow text-sm opacity-70'>
-              {project.description}
-            </p>
-            <div className='mb-4 flex flex-wrap gap-1.5'>
-              {project.tags.map((tag) => (
-                <span
-                  key={tag}
-                  className='rounded-md border border-slate-200 px-2 py-[2px] text-[11px] opacity-70 dark:border-slate-700'
-                >
-                  {tag}
-                </span>
-              ))}
-            </div>
-            <div className='flex items-center gap-4 text-sm'>
-              <a
-                href={project.repo}
-                target='_blank'
-                rel='noreferrer'
-                className='inline-flex items-center gap-1 opacity-70 hover:opacity-100'
-              >
-                <Github size={15} />
-                Code
-              </a>
-              {project.demo ? (
-                <a
-                  href={project.demo}
-                  target='_blank'
-                  rel='noreferrer'
-                  className='inline-flex items-center gap-1 opacity-70 hover:opacity-100'
-                >
-                  <ExternalLink size={15} />
-                  Demo
-                </a>
-              ) : null}
-            </div>
-          </article>
-        ))}
+    <div className='z-page'>
+      <div className='z-ma' style={{ paddingTop: 56 }} aria-hidden='true'>
+        <span>間</span>
       </div>
-
-      <Link to='/' className='mt-8 inline-block'>
-        <span className='opacity-70'>&gt;&nbsp;&nbsp;&nbsp;</span>
-        <span className='underline opacity-70 hover:opacity-100'>cd ..</span>
-      </Link>
+      <div className='z-label'>器 物</div>
+      {projects.map((project) => (
+        <div className='z-ware' key={project.name}>
+          <div className='name'>
+            {project.name}
+            {project.featured ? <span className='feat'>代 表 作</span> : null}
+          </div>
+          <p>{project.description}</p>
+          <div className='wlinks'>
+            <a href={project.repo} target='_blank' rel='noreferrer'>
+              source ↗
+            </a>
+            {project.demo ? (
+              <a href={project.demo} target='_blank' rel='noreferrer'>
+                live ↗
+              </a>
+            ) : null}
+          </div>
+        </div>
+      ))}
     </div>
   );
 }

--- a/apps/web/src/routes/signup.tsx
+++ b/apps/web/src/routes/signup.tsx
@@ -35,93 +35,106 @@ function SignUpPage() {
 
   if (sessionData?.user?.id || isSessionPending) {
     return (
-      <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-        <p className='opacity-70'>Checking session...</p>
-      </section>
+      <div className='z-page'>
+        <p className='z-hint text-center'>正在核对会籍……</p>
+      </div>
     );
   }
 
   return (
-    <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>注册</h1>
-      <p className='mb-6 opacity-70'>注册后默认角色为 member，可在后台升权。</p>
+    <div className='z-page'>
+      <div className='z-gate'>
+        <h1>注　冊</h1>
+        <p className='sub'>登録すると member になる</p>
+        <form
+          method='post'
+          onSubmit={(event) => {
+            event.preventDefault();
+            setError(null);
+            startTransition(async () => {
+              const result = await authClient.signUp.email({
+                email,
+                password,
+                name,
+                callbackURL: '/blog',
+              });
 
-      {error ? (
-        <p role='alert' className='mb-4 text-sm text-red-700 dark:text-red-300'>
-          {error}
-        </p>
-      ) : null}
+              if (result.error) {
+                setError(result.error.message ?? '注册失败');
+                return;
+              }
 
-      <form
-        className='grid max-w-[420px] gap-3'
-        method='post'
-        onSubmit={(event) => {
-          event.preventDefault();
-          setError(null);
-          startTransition(async () => {
-            const result = await authClient.signUp.email({
-              email,
-              password,
-              name,
-              callbackURL: '/blog',
+              navigate({ to: '/blog' });
             });
-
-            if (result.error) {
-              setError(result.error.message ?? '注册失败');
-              return;
-            }
-
-            navigate({ to: '/blog' });
-          });
-        }}
-      >
-        <label htmlFor='name' className='font-semibold'>
-          Name
-        </label>
-        <input
-          id='name'
-          name='name'
-          type='text'
-          required
-          autoComplete='name'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={name}
-          onChange={(event) => setName(event.target.value)}
-        />
-        <label htmlFor='email' className='font-semibold'>
-          Email
-        </label>
-        <input
-          id='email'
-          name='email'
-          type='email'
-          required
-          autoComplete='email'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-        />
-        <label htmlFor='password' className='font-semibold'>
-          Password
-        </label>
-        <input
-          id='password'
-          name='password'
-          type='password'
-          required
-          autoComplete='new-password'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={password}
-          onChange={(event) => setPassword(event.target.value)}
-        />
-        <button
-          type='submit'
-          className='rounded-md bg-black px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90 dark:bg-neutral-900'
-          disabled={isPending}
+          }}
         >
-          {isPending ? 'Creating account...' : 'Sign Up'}
-        </button>
-      </form>
-    </section>
+          <div className='z-field'>
+            <label htmlFor='name'>名 号</label>
+            <input
+              id='name'
+              name='name'
+              type='text'
+              required
+              autoComplete='name'
+              className='z-input'
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+            />
+          </div>
+          <div className='z-field'>
+            <label htmlFor='email'>邮 箱</label>
+            <input
+              id='email'
+              name='email'
+              type='email'
+              required
+              autoComplete='email'
+              className='z-input'
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+            />
+          </div>
+          <div className='z-field'>
+            <label htmlFor='password'>口 令</label>
+            <input
+              id='password'
+              name='password'
+              type='password'
+              required
+              autoComplete='new-password'
+              className='z-input'
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+            />
+          </div>
+          <div className='actions'>
+            <button
+              type='submit'
+              className='z-btn z-btn-fill'
+              disabled={isPending}
+            >
+              {isPending ? '建立中…' : '建立账号'}
+            </button>
+            <button
+              type='button'
+              className='z-btn'
+              onClick={async () => {
+                setError(null);
+                const result = await authClient.signIn.social({
+                  provider: 'github',
+                  callbackURL: '/blog',
+                });
+                if (result.error) {
+                  setError(result.error.message ?? 'GitHub 注册失败');
+                }
+              }}
+            >
+              GitHub
+            </button>
+          </div>
+          {error ? <p className='z-err'>{error}</p> : null}
+        </form>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/routes/unlock/$slug.tsx
+++ b/apps/web/src/routes/unlock/$slug.tsx
@@ -78,48 +78,43 @@ function UnlockPage() {
     search.error === 'missing'
       ? '请输入访问密码'
       : search.error === 'invalid'
-        ? '密码错误，请重试'
+        ? '口令有误，请再试'
         : undefined;
 
   return (
-    <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>输入文章访问密码</h1>
-      <p className='mb-6 opacity-70'>这篇文章使用了单文密码保护。</p>
-
-      {errorLabel ? (
-        <p role='alert' className='mb-4 text-sm text-red-700 dark:text-red-300'>
-          {errorLabel}
+    <div className='z-page'>
+      <div className='z-gate'>
+        <div className='z-lock' aria-hidden='true'>
+          鍵
+        </div>
+        <h1>解　鎖</h1>
+        <p className='sub'>
+          この記事は一言パスワードで封をされている ・ 24 時間有効
         </p>
-      ) : null}
-
-      <form method='post' className='grid max-w-[420px] gap-3'>
-        <label htmlFor='password' className='font-semibold'>
-          Password
-        </label>
-        <input
-          id='password'
-          name='password'
-          type='password'
-          required
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-        />
-        <button
-          type='submit'
-          className='rounded-md bg-black px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90 dark:bg-neutral-900'
-        >
-          Unlock
-        </button>
-      </form>
-
-      <p className='mt-4'>
-        <Link
-          to='/blog/$slug'
-          params={{ slug }}
-          className='opacity-70 hover:opacity-100'
-        >
-          返回文章页
-        </Link>
-      </p>
-    </section>
+        <form method='post'>
+          <div className='z-field'>
+            <label htmlFor='password'>篇 目 口 令</label>
+            <input
+              id='password'
+              name='password'
+              type='password'
+              required
+              className='z-input'
+            />
+          </div>
+          {errorLabel ? <p className='z-err'>{errorLabel}</p> : null}
+          <div className='actions'>
+            <button type='submit' className='z-btn z-btn-fill'>
+              启 封
+            </button>
+          </div>
+        </form>
+        <p className='aside'>
+          <Link to='/blog/$slug' params={{ slug }} className='z-link'>
+            ← 返回文章
+          </Link>
+        </p>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -144,3 +144,706 @@ html.dark ::-webkit-scrollbar-thumb {
 html.dark ::-webkit-scrollbar-thumb:hover {
   background: rgb(148 163 184 / 0.55);
 }
+
+/* =====================================================================
+ * THEME D — Zen whitespace 「字纸篓」 (UX redesign direction D)
+ * Bamboo-green accent on mist-white, serif display, borderless lists,
+ * 「間」 (ma) separators. Light-only, quiet by design.
+ * =================================================================== */
+:root {
+  /* shadcn token layer → zen palette */
+  --background: 100 12% 96%;
+  --foreground: 120 5% 17%;
+  --card: 90 10% 93%;
+  --card-foreground: 120 5% 17%;
+  --popover: 60 20% 98%;
+  --popover-foreground: 120 5% 17%;
+  --primary: 150 20% 41%;
+  --primary-foreground: 100 15% 97%;
+  --secondary: 100 10% 92%;
+  --secondary-foreground: 120 5% 17%;
+  --muted: 100 10% 92%;
+  --muted-foreground: 100 6% 46%;
+  --accent: 100 12% 90%;
+  --accent-foreground: 120 5% 17%;
+  --destructive: 20 45% 45%;
+  --destructive-foreground: 100 15% 97%;
+  --border: 90 12% 86%;
+  --input: 90 12% 86%;
+  --ring: 150 20% 41%;
+  --radius: 0.125rem;
+
+  --z-bg: #f7f8f5;
+  --z-wash: #eff1ec;
+  --z-ink: #2b302b;
+  --z-dim: #78816f;
+  --z-faint: #a9b2a3;
+  --z-bamboo: #557c67;
+  --z-bamboo-soft: #e3eae4;
+  --z-line: #e1e5da;
+  --z-serif:
+    "Songti SC", "Hiragino Mincho ProN", "Noto Serif SC", "SimSun", serif;
+  --z-sans:
+    "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", system-ui, sans-serif;
+  --z-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}
+
+html {
+  background-color: var(--z-bg);
+}
+
+html body {
+  font-family: var(--z-sans);
+  background-color: var(--z-bg);
+  color: var(--z-ink);
+  font-size: 15px;
+  line-height: 2.05;
+}
+
+::selection {
+  background: var(--z-bamboo-soft);
+}
+
+/* ---------- shell ---------- */
+.z-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+}
+.z-main {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.z-head {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 68px 24px 8px;
+  display: flex;
+  align-items: baseline;
+  gap: 18px;
+}
+.z-head .mark {
+  font-family: var(--z-serif);
+  font-size: 19px;
+  letter-spacing: 0.5em;
+  font-weight: 600;
+  color: var(--z-ink);
+}
+.z-head nav {
+  margin-left: auto;
+  display: flex;
+  gap: 22px;
+  font-size: 13px;
+  letter-spacing: 0.22em;
+}
+.z-head nav a,
+.z-head nav button {
+  color: var(--z-dim);
+  font-family: var(--z-sans);
+  font-size: 13px;
+  letter-spacing: 0.22em;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  padding: 0;
+}
+.z-head nav a:hover,
+.z-head nav button:hover {
+  color: var(--z-bamboo);
+  text-decoration: none;
+}
+.z-tools {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.z-tools :where(a),
+.z-tools :where(button) {
+  color: var(--z-faint);
+  background: none;
+  border: 0;
+  cursor: pointer;
+  padding: 0;
+}
+.z-tools :where(a):hover,
+.z-tools :where(button):hover {
+  color: var(--z-bamboo);
+}
+.z-user {
+  display: none;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 11.5px;
+  letter-spacing: 0.08em;
+  color: var(--z-faint);
+}
+@media (min-width: 768px) {
+  .z-user {
+    display: inline-flex;
+  }
+}
+
+/* margin note (signature) */
+.z-margin-note {
+  position: fixed;
+  right: 18px;
+  top: 50%;
+  transform: translateY(-50%);
+  writing-mode: vertical-rl;
+  letter-spacing: 0.6em;
+  font-size: 10.5px;
+  color: var(--z-faint);
+  user-select: none;
+  z-index: 5;
+}
+.z-margin-note::before {
+  content: "";
+  display: block;
+  width: 1px;
+  height: 46px;
+  background: var(--z-line);
+  margin: 0 auto 18px;
+}
+@media (max-width: 900px) {
+  .z-margin-note {
+    display: none;
+  }
+}
+
+/* 間 divider */
+.z-ma {
+  display: flex;
+  justify-content: center;
+  padding: 52px 0;
+}
+.z-ma :where(span) {
+  color: var(--z-faint);
+  font-size: 12px;
+  letter-spacing: 1.2em;
+  padding-left: 1.2em;
+}
+
+.z-foot {
+  text-align: center;
+  font-size: 11px;
+  letter-spacing: 0.34em;
+  color: var(--z-faint);
+  padding: 46px 0 60px;
+}
+.z-foot :where(a) {
+  color: var(--z-dim);
+}
+.z-foot :where(a):hover {
+  color: var(--z-bamboo);
+}
+
+/* ---------- shared ---------- */
+.z-page {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 0 24px 40px;
+}
+.z-label {
+  font-size: 11px;
+  letter-spacing: 0.42em;
+  color: var(--z-faint);
+  margin-bottom: 10px;
+}
+.z-btn {
+  font-family: var(--z-sans);
+  font-size: 13px;
+  letter-spacing: 0.34em;
+  cursor: pointer;
+  background: none;
+  border: 0;
+  color: var(--z-ink);
+  padding: 12px 10px;
+  border-bottom: 1px solid var(--z-line);
+}
+.z-btn:hover {
+  color: var(--z-bamboo);
+  border-color: var(--z-bamboo);
+}
+.z-btn-fill {
+  background: var(--z-bamboo);
+  color: #f4f7f3;
+  border-bottom-color: var(--z-bamboo);
+  padding: 12px 30px;
+}
+.z-btn-fill:hover {
+  background: #476856;
+  color: #f4f7f3;
+}
+.z-link {
+  color: var(--z-dim);
+  border-bottom: 1px solid var(--z-line);
+  padding-bottom: 2px;
+}
+.z-link:hover {
+  color: var(--z-bamboo);
+  border-color: var(--z-bamboo);
+  text-decoration: none;
+}
+
+/* ---------- home ---------- */
+.z-hero {
+  padding: 88px 0 8px;
+}
+.z-hero .since {
+  font-size: 12px;
+  letter-spacing: 0.5em;
+  color: var(--z-faint);
+}
+.z-hero h1 {
+  font-family: var(--z-serif);
+  font-weight: 600;
+  font-size: 34px;
+  line-height: 1.9;
+  letter-spacing: 0.12em;
+  margin-top: 18px;
+}
+.z-hero p {
+  color: var(--z-dim);
+  margin-top: 18px;
+  max-width: 38ch;
+}
+.z-links {
+  display: flex;
+  gap: 56px;
+  padding: 40px 0 0;
+}
+.z-links :where(a) {
+  font-size: 14px;
+  letter-spacing: 0.3em;
+  color: var(--z-ink);
+  border-bottom: 1px solid var(--z-line);
+  padding-bottom: 6px;
+}
+.z-links :where(a):hover {
+  color: var(--z-bamboo);
+  border-color: var(--z-bamboo);
+  text-decoration: none;
+}
+
+/* ---------- borderless list ---------- */
+.z-item {
+  display: flex;
+  align-items: baseline;
+  gap: 20px;
+  padding: 15px 2px;
+}
+.z-item .t {
+  flex: 1;
+  font-size: 15.5px;
+  color: var(--z-ink);
+}
+.z-item .d {
+  font-family: var(--z-mono);
+  font-size: 11.5px;
+  color: var(--z-faint);
+  white-space: nowrap;
+}
+a.z-item:hover .t {
+  color: var(--z-bamboo);
+  text-decoration: none;
+}
+.z-year {
+  font-family: var(--z-mono);
+  font-size: 12px;
+  color: var(--z-faint);
+  letter-spacing: 0.3em;
+  padding: 44px 2px 6px;
+}
+.z-vis {
+  font-size: 10px;
+  letter-spacing: 0.28em;
+  color: var(--z-faint);
+  margin-left: 12px;
+}
+.z-vis.mem {
+  color: var(--z-bamboo);
+}
+.z-vis.vip {
+  color: #8a7bb0;
+}
+.z-vis.pw {
+  color: #b0705f;
+}
+.z-vis.adm {
+  color: var(--z-dim);
+}
+.z-pager {
+  display: flex;
+  gap: 40px;
+  justify-content: center;
+  padding: 40px 0 0;
+  font-size: 13px;
+  letter-spacing: 0.2em;
+  color: var(--z-faint);
+}
+.z-pager :where(a) {
+  color: var(--z-dim);
+}
+.z-pager :where(a):hover {
+  color: var(--z-bamboo);
+}
+.z-devhint {
+  font-size: 12.5px;
+  color: var(--z-faint);
+  border-left: 2px solid var(--z-line);
+  padding: 4px 0 4px 14px;
+  margin: 20px 0;
+}
+
+/* ---------- article ---------- */
+.z-art h1 {
+  font-family: var(--z-serif);
+  font-size: 29px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  line-height: 1.8;
+}
+.z-art .meta {
+  font-family: var(--z-mono);
+  font-size: 11.5px;
+  color: var(--z-faint);
+  margin-top: 12px;
+  letter-spacing: 0.1em;
+}
+
+.md {
+  margin-top: 46px;
+  font-size: 16px;
+}
+.md p {
+  margin: 26px 0;
+  color: #3a403a;
+  text-align: justify;
+}
+.md > p:first-of-type::first-letter,
+.md > p:first-child::first-letter {
+  font-size: 2.9em;
+  font-weight: 600;
+  float: left;
+  line-height: 1;
+  margin: 10px 12px 0 0;
+  color: var(--z-bamboo);
+  font-family: var(--z-serif);
+}
+.md h2 {
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  margin: 64px 0 8px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  scroll-margin-top: 20px;
+}
+.md h2::before {
+  content: "";
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--z-bamboo);
+  flex: none;
+}
+.md h2 a {
+  color: inherit;
+}
+.md ul {
+  list-style: none;
+  margin: 20px 0;
+}
+.md ul li {
+  padding: 8px 0 8px 20px;
+  position: relative;
+  color: #3a403a;
+}
+.md ul li::before {
+  content: "・";
+  position: absolute;
+  left: 0;
+  color: var(--z-bamboo);
+}
+.md :where(a) {
+  color: var(--z-bamboo);
+}
+.md blockquote {
+  margin: 34px 0;
+  padding: 4px 0 4px 24px;
+  border-left: 1px solid var(--z-bamboo);
+  color: var(--z-dim);
+  font-size: 15px;
+}
+.md :where(code.z-inline) {
+  font-family: var(--z-mono);
+  font-size: 0.84em;
+  color: var(--z-bamboo);
+  background: var(--z-wash);
+  padding: 1px 7px;
+  border-radius: 10px;
+}
+
+.z-code {
+  position: relative;
+  margin: 30px 0;
+}
+.z-code-copy {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  z-index: 10;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid var(--z-line);
+  background: rgba(247, 248, 245, 0.9);
+  color: var(--z-dim);
+  border-radius: 10px;
+  padding: 2px 9px;
+  font-size: 11px;
+  font-family: var(--z-mono);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.z-code:hover .z-code-copy,
+.z-code-copy:focus-visible {
+  opacity: 1;
+}
+@media not (hover: hover) {
+  .z-code-copy {
+    opacity: 0.75;
+  }
+}
+.md pre.z-pre {
+  font-family: var(--z-mono);
+  font-size: 13px;
+  line-height: 1.9;
+  color: #39413b;
+  background: #ffffff;
+  border: 1px solid var(--z-line);
+  border-radius: 2px;
+  padding: 24px 26px;
+  overflow-x: auto;
+  margin: 0;
+}
+.md .z-pre code {
+  background: none;
+  padding: 0;
+}
+
+/* ---------- comments ---------- */
+.z-cmt {
+  padding: 22px 0;
+  border-top: 1px solid var(--z-line);
+}
+.z-cmt:first-child {
+  border-top: 0;
+}
+.z-cmt-h {
+  font-family: var(--z-mono);
+  font-size: 11px;
+  color: var(--z-faint);
+  margin-bottom: 6px;
+}
+.z-cmt-h .who {
+  color: var(--z-ink);
+  font-weight: 600;
+}
+.z-cmt.reply {
+  margin-left: 40px;
+}
+.z-cmt p {
+  margin: 0 0 6px;
+  font-size: 15px;
+}
+.z-cmt p:last-child {
+  margin-bottom: 0;
+}
+.z-cmt :where(code) {
+  font-family: var(--z-mono);
+  font-size: 0.85em;
+  color: var(--z-bamboo);
+  background: var(--z-wash);
+  border-radius: 8px;
+  padding: 0 6px;
+}
+.z-cmt blockquote {
+  border-left: 1px solid var(--z-line);
+  padding-left: 12px;
+  color: var(--z-dim);
+}
+.z-cmt-ops {
+  display: flex;
+  gap: 16px;
+  margin-top: 6px;
+}
+.z-cmt-ops :where(button) {
+  color: var(--z-faint);
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font-family: var(--z-sans);
+  font-size: 12px;
+  padding: 0;
+  letter-spacing: 0.1em;
+}
+.z-cmt-ops :where(button):hover {
+  color: var(--z-bamboo);
+}
+.z-cmt-form textarea {
+  width: 100%;
+  resize: vertical;
+  font-family: var(--z-sans);
+  font-size: 15px;
+  color: var(--z-ink);
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--z-line);
+  padding: 10px 2px;
+}
+.z-cmt-form textarea:focus {
+  outline: none;
+  border-bottom-color: var(--z-bamboo);
+}
+.z-cmt-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 10px;
+}
+.z-hint {
+  font-size: 12px;
+  color: var(--z-faint);
+}
+.z-hint .err {
+  color: #b0705f;
+  margin-left: 8px;
+}
+
+/* ---------- projects ---------- */
+.z-ware {
+  padding: 26px 2px;
+}
+.z-ware .name {
+  font-size: 16px;
+  letter-spacing: 0.06em;
+}
+.z-ware .name .feat {
+  font-size: 10px;
+  letter-spacing: 0.3em;
+  color: var(--z-bamboo);
+  margin-left: 14px;
+}
+.z-ware p {
+  color: var(--z-dim);
+  font-size: 14px;
+  margin-top: 6px;
+  max-width: 46ch;
+}
+.z-ware .wlinks {
+  margin-top: 10px;
+  font-family: var(--z-mono);
+  font-size: 12px;
+  display: flex;
+  gap: 20px;
+}
+.z-ware .wlinks a {
+  color: var(--z-faint);
+}
+.z-ware .wlinks a:hover {
+  color: var(--z-bamboo);
+}
+
+/* ---------- forms ---------- */
+.z-gate {
+  max-width: 400px;
+  margin: 30px auto 0;
+  padding: 30px 0;
+}
+.z-gate h1 {
+  font-family: var(--z-serif);
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: 0.3em;
+  text-align: center;
+}
+.z-gate .sub {
+  text-align: center;
+  color: var(--z-faint);
+  font-size: 12.5px;
+  letter-spacing: 0.14em;
+  margin-top: 8px;
+}
+.z-field {
+  margin: 34px 0;
+}
+.z-field label {
+  display: block;
+  font-size: 11px;
+  letter-spacing: 0.4em;
+  color: var(--z-faint);
+  margin-bottom: 4px;
+}
+.z-input {
+  width: 100%;
+  font-family: var(--z-sans);
+  font-size: 15px;
+  color: var(--z-ink);
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--z-line);
+  border-radius: 0;
+  padding: 8px 2px;
+}
+.z-input:focus {
+  outline: none;
+  border-bottom-color: var(--z-bamboo);
+}
+.z-gate .actions {
+  display: flex;
+  gap: 40px;
+  justify-content: center;
+  margin-top: 44px;
+}
+.z-gate .aside {
+  text-align: center;
+  margin-top: 34px;
+  font-size: 12.5px;
+  color: var(--z-faint);
+}
+.z-err {
+  text-align: center;
+  color: #b0705f;
+  font-size: 13px;
+  margin-top: 18px;
+  letter-spacing: 0.1em;
+}
+.z-lock {
+  text-align: center;
+  font-family: var(--z-serif);
+  font-size: 30px;
+  color: var(--z-bamboo);
+  padding: 6px 0 0;
+}
+
+/* ---------- 404 ---------- */
+.z-nf {
+  text-align: center;
+  padding: 80px 0 30px;
+}
+.z-nf .k {
+  font-family: var(--z-serif);
+  font-size: 64px;
+  color: var(--z-faint);
+}
+.z-nf p {
+  color: var(--z-dim);
+  font-size: 13.5px;
+  letter-spacing: 0.2em;
+  margin-top: 18px;
+}

--- a/tests/e2e/admin-flow.spec.ts
+++ b/tests/e2e/admin-flow.spec.ts
@@ -19,7 +19,7 @@ test('admin can create a post that appears on the blog', async ({ page }) => {
   await page.locator('#password').fill(ADMIN_PASSWORD);
   await page.locator('form button[type="submit"]').click();
 
-  const loggedIn = page.getByRole('link', { name: /logout/i });
+  const loggedIn = page.getByTestId('nav-logout');
   try {
     await expect(loggedIn).toBeVisible({ timeout: 8000 });
   } catch {

--- a/tests/e2e/auth-logout.spec.ts
+++ b/tests/e2e/auth-logout.spec.ts
@@ -8,18 +8,20 @@ function createUniqueEmail(): string {
 test('signup then logout returns to guest header state', async ({ page }) => {
   await page.goto('/signup', { waitUntil: 'domcontentloaded' });
 
-  await page.getByLabel('Name').fill('E2E Logout');
-  await page.getByLabel('Email').fill(createUniqueEmail());
-  await page.getByLabel('Password').fill('Playwright!12345');
-  await page.getByRole('button', { name: 'Sign Up' }).click();
+  // Form anchors are theme-stable: field ids on /signup + the submit button.
+  // Header anchors use data-testid because each UX theme words them
+  // differently (login / 入会 / SIGN IN …).
+  await page.locator('#name').fill('E2E Logout');
+  await page.locator('#email').fill(createUniqueEmail());
+  await page.locator('#password').fill('Playwright!12345');
+  await page.locator('form button[type="submit"]').click();
 
   await page.waitForURL('**/blog');
-  await expect(page.getByRole('link', { name: 'Logout' })).toBeVisible();
+  await expect(page.getByTestId('nav-logout')).toBeVisible();
 
-  await page.getByRole('link', { name: 'Logout' }).click();
+  await page.getByTestId('nav-logout').click();
 
   await page.waitForURL('**/blog');
-  await expect(page.getByRole('link', { name: 'Login' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Sign Up' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Logout' })).toHaveCount(0);
+  await expect(page.getByTestId('nav-login')).toBeVisible();
+  await expect(page.getByTestId('nav-logout')).toHaveCount(0);
 });


### PR DESCRIPTION
## What — UX 改版方向 D「日式余白 · 字纸篓」落地

把原型 `prototypes/d-zen.html` 落到真实应用：安静、大留白、竹青点睛。

- **壳**：细字重小刊头「字纸篓」+ 单字导航（读 / 物 / 理），右缘竖排边注
- **首页**：衬线大标题（自嘲句）+ 「間」分隔 + 下划线式链接 + 近稿三篇（真实 loader 数据）
- **博客列表 = 无边界清单**：不画线，靠留白对齐；年份小字；可见性标注为「会 员 / VIP / 密」
- **文章页**：衬线标题 + **竹青首字下沉** + 圆点二级标题 + 白底细边代码块；评论区 = 竖线分隔的来函
- **登录/注册/解锁**：下划线输入框（無边框表单）；**404 = 「空」**
- 青白底 #F7F8F5 + 竹青 #557C67 唯一强调色；亮色原生（隐藏主题切换）；shadcn tokens 重皮肤

## 不变的东西

路由 / loader / 鉴权 / 评论 / 搜索逻辑未动；首页新增只读 loader（复用公开列表 server fn）。Admin 沿用现有亮色样式。

## 验证

- [x] typecheck / lint（0 error）/ test 36 passed / build + 体积 **1024.3 KiB gzip**
- [x] 本地 dev 冒烟 7 页全 200/404
- [x] DOM/CSS 断言：青白背景 rgb(247,248,245)、首字下沉 46.4px 竹青 rgb(85,124,103)、白底代码块、間 ×2

> 7 个候选方向之一（A–G）。预览用 Workers Builds preview URL。