### PR TITLE
feat(web): apply engineering blueprint theme (UX direction E)

### DIFF
--- a/apps/web/src/components/comments.tsx
+++ b/apps/web/src/components/comments.tsx
@@ -20,14 +20,6 @@ type CommentsProps = {
 
 const PAGE_SIZE = 20;
 
-function getInitials(name: string): string {
-  const trimmed = name.trim();
-  if (!trimmed) {
-    return '?';
-  }
-  return trimmed.slice(0, 1).toUpperCase();
-}
-
 function formatRelative(iso: string): string {
   const then = new Date(iso).getTime();
   if (Number.isNaN(then)) {
@@ -54,24 +46,6 @@ function formatRelative(iso: string): string {
     day: 'numeric',
     year: 'numeric',
   });
-}
-
-function Avatar({ name, image }: { name: string; image: string | null }) {
-  if (image) {
-    return (
-      <img
-        src={image}
-        alt={name}
-        loading='lazy'
-        className='h-8 w-8 shrink-0 rounded-full bg-zinc-100 dark:bg-zinc-800'
-      />
-    );
-  }
-  return (
-    <div className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-zinc-200 text-xs font-semibold text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300'>
-      {getInitials(name)}
-    </div>
-  );
 }
 
 type ComposerProps = {
@@ -107,26 +81,25 @@ function Composer({
   }
 
   return (
-    <form onSubmit={handleSubmit} className='flex flex-col gap-2'>
+    <form onSubmit={handleSubmit} className='e-cmt-form'>
       <textarea
         value={body}
         onChange={(event) => setBody(event.target.value)}
         placeholder={placeholder}
         rows={compact ? 2 : 3}
         maxLength={2000}
-        className='w-full resize-y rounded-md border border-zinc-300 bg-transparent px-3 py-2 text-sm outline-none transition-colors focus:border-zinc-400 dark:border-zinc-600 dark:focus:border-zinc-400'
       />
-      <div className='flex items-center justify-between gap-2'>
-        <span className='text-xs opacity-50'>
-          {remaining < 200 ? `${remaining} 字剩余` : '支持 Markdown'}
-          {error ? <span className='ml-2 text-red-500'>{error}</span> : null}
+      <div className='e-cmt-foot'>
+        <span className='e-hint'>
+          {remaining < 200 ? `${remaining} 字剩余` : 'MARKDOWN OK'}
+          {error ? <span className='err'>{error}</span> : null}
         </span>
         <button
           type='submit'
           disabled={submitting || !body.trim()}
-          className='rounded-md bg-black px-3 py-1 text-xs font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-neutral-900'
+          className='e-btn e-btn-fill'
         >
-          {submitting ? '发送中…' : '发送'}
+          {submitting ? 'SUBMITTING…' : 'SUBMIT'}
         </button>
       </div>
     </form>
@@ -191,7 +164,7 @@ function CommentItem({
       ) : null}
 
       {thread.replies.length > 0 ? (
-        <ul className='ml-10 flex flex-col gap-2 border-l border-zinc-200 pl-4 dark:border-zinc-700'>
+        <ul className='ml-10 flex flex-col'>
           {thread.replies.map((reply) => {
             const replyCanAct =
               sessionUser != null &&
@@ -233,49 +206,32 @@ function CommentView({
   onDelete,
 }: CommentViewProps) {
   return (
-    <div className='flex gap-3'>
-      <Avatar name={comment.author.name} image={comment.author.image} />
-      <div className='min-w-0 flex-1'>
-        <div className='flex flex-wrap items-center gap-x-2 gap-y-0.5'>
-          <span className='text-sm font-semibold'>{comment.author.name}</span>
-          {comment.author.role === 'admin' ? (
-            <span className='rounded bg-zinc-900 px-1.5 py-0.5 text-[10px] font-semibold text-white dark:bg-white dark:text-zinc-900'>
-              Author
-            </span>
-          ) : null}
-          {comment.status !== 'visible' ? (
-            <span className='rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'>
-              {comment.status}
-            </span>
-          ) : null}
-          <span className='text-xs opacity-50'>
-            {formatRelative(comment.createdAt)}
-          </span>
-        </div>
-        <div className='mt-1'>
-          <CommentMarkdown content={comment.body} />
-        </div>
-        <div className='mt-1 flex gap-3 text-xs'>
+    <div className={comment.parentId !== null ? 'e-cmt reply' : 'e-cmt'}>
+      <div className='e-cmt-h'>
+        <span className='who'>{comment.author.name}</span>
+        {comment.author.role === 'admin' ? <span>AUTHOR</span> : null}
+        {comment.status !== 'visible' ? (
+          <span style={{ color: 'var(--e-red)' }}>{comment.status}</span>
+        ) : null}
+        <span>{formatRelative(comment.createdAt)}</span>
+      </div>
+      <div className='e-cmt-b'>
+        <CommentMarkdown content={comment.body} />
+      </div>
+      {(canReply && onReply) || canAct ? (
+        <div className='e-cmt-ops'>
           {canReply && onReply ? (
-            <button
-              type='button'
-              onClick={onReply}
-              className='opacity-50 transition-opacity hover:opacity-100'
-            >
-              回复
+            <button type='button' onClick={onReply}>
+              REPLY
             </button>
           ) : null}
           {canAct ? (
-            <button
-              type='button'
-              onClick={() => onDelete()}
-              className='text-red-500/70 transition-colors hover:text-red-500'
-            >
-              删除
+            <button type='button' className='del' onClick={() => onDelete()}>
+              DEL
             </button>
           ) : null}
         </div>
-      </div>
+      ) : null}
     </div>
   );
 }
@@ -375,10 +331,8 @@ export function Comments({
   }
 
   return (
-    <section className='mt-12'>
-      <h2 className='mb-4 text-lg font-black'>
-        评论 {total > 0 ? <span className='opacity-50'>({total})</span> : null}
-      </h2>
+    <section className='mt-2'>
+      <h3 className='e-hint mb-3'>INSPECTION RECORD ({total})</h3>
 
       {sessionUser ? (
         <div className='mb-6'>
@@ -389,24 +343,20 @@ export function Comments({
           />
         </div>
       ) : (
-        <p className='mb-6 text-sm opacity-60'>
-          <Link to='/login' className='underline hover:opacity-100'>
-            登录
+        <p className='e-hint mb-6'>
+          <Link to='/login' style={{ color: 'var(--e-cyan)' }}>
+            SIGN IN
           </Link>{' '}
-          后即可评论。
+          后即可留档。
         </p>
       )}
 
-      {topError ? (
-        <p className='mb-4 text-sm text-red-500'>{topError}</p>
-      ) : null}
+      {topError ? <p className='e-err mb-4'>{topError}</p> : null}
 
       {threads.length === 0 ? (
-        <p className='py-8 text-center text-sm opacity-50'>
-          还没有评论，来抢沙发。
-        </p>
+        <p className='e-hint py-8 text-center'>NO RECORDS YET.</p>
       ) : (
-        <ul className='flex flex-col gap-5'>
+        <ul className='flex flex-col'>
           {threads.map((thread) => (
             <CommentItem
               key={thread.id}
@@ -428,9 +378,9 @@ export function Comments({
             type='button'
             onClick={handleLoadMore}
             disabled={loadingMore}
-            className='text-sm opacity-60 transition-opacity hover:opacity-100 disabled:opacity-40'
+            className='e-btn'
           >
-            {loadingMore ? '加载中…' : '加载更多'}
+            {loadingMore ? 'LOADING…' : 'MORE RECORDS ↓'}
           </button>
         </div>
       ) : null}

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -1,10 +1,20 @@
+import { Link } from '@tanstack/react-router';
+
 export function Footer() {
   return (
-    <footer className='p-6 text-center'>
-      © {new Date().getFullYear()}, Built with{' '}
-      <a className='text-blue-500' href='https://tanstack.com/start/latest'>
-        TanStack Start
-      </a>
+    <footer
+      className='py-5 text-center'
+      style={{
+        fontFamily: 'var(--e-mono)',
+        fontSize: 10.5,
+        letterSpacing: '0.3em',
+        color: 'var(--e-faint)',
+      }}
+    >
+      PERFECTPAN.ORG · DWG SET © {new Date().getFullYear()} ·{' '}
+      <Link to='/blog' style={{ color: 'var(--e-dim)' }}>
+        INDEX
+      </Link>
     </footer>
   );
 }

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -1,8 +1,6 @@
 import { Link } from '@tanstack/react-router';
-import { Github, LogOut, Rss, Search, UserRound } from 'lucide-react';
+import { Github, LogOut, Rss, UserRound } from 'lucide-react';
 import { authClient } from '../lib/auth-client.js';
-import { DarkMode } from './dark-mode.js';
-import { MenuLink } from './menu.js';
 import { searchPalette } from './search-palette-store.js';
 
 function getRoleLabel(role?: string | null): string {
@@ -17,78 +15,84 @@ function getRoleLabel(role?: string | null): string {
   return 'MEMBER';
 }
 
+/** Blueprint drawing-index bar: DWG no + nav + tools. Dark-native theme. */
 export function Header() {
   const { data: sessionData } = authClient.useSession();
   const sessionUser = sessionData?.user ?? null;
 
   return (
-    <header className='border-b border-slate-200 bg-white shadow-md dark:border-slate-300/10 dark:bg-slate-900'>
-      <div className='mx-4 flex h-16 items-center sm:mx-6'>
+    <header className='e-head'>
+      <span className='dwg'>
+        DWG NO. <b>PP-NAV-000</b> · REV <b>C</b>
+      </span>
+      <nav aria-label='图纸目录'>
         <Link
           to='/'
-          className='rounded-md border-10 border-black bg-black px-1 font-bold text-white dark:border-neutral-900 dark:bg-neutral-900'
+          activeOptions={{ exact: true }}
+          activeProps={{ className: 'on' }}
         >
-          PerfectPan
+          COVER
         </Link>
-        <div className='m-0 flex list-none items-center pl-1'>
-          <MenuLink href='/' name='Home' />
-          <MenuLink href='/blog' name='Blog' />
-          <MenuLink href='/projects' name='Projects' />
-          {sessionUser?.role === 'admin' ? (
-            <MenuLink href='/admin' name='Admin' />
-          ) : null}
-        </div>
-        <div className='ml-auto flex items-center gap-2 sm:gap-3'>
-          {sessionUser ? (
-            <div className='hidden items-center gap-2 rounded-full border border-slate-300 px-3 py-1 text-xs text-gray-700 md:flex dark:border-slate-600 dark:text-slate-200'>
-              <UserRound size={14} className='opacity-70' />
-              <span className='max-w-[220px] truncate'>
-                {sessionUser.email}
-              </span>
-              <span className='rounded-full bg-black px-2 py-[2px] text-[10px] font-semibold text-white dark:bg-neutral-100 dark:text-neutral-900'>
-                {getRoleLabel(sessionUser.role)}
-              </span>
-            </div>
-          ) : null}
-          {sessionUser ? (
-            <Link
-              to='/logout'
-              className='inline-flex items-center gap-1 rounded-md border border-slate-300 px-2 py-1 text-sm opacity-85 transition-opacity hover:opacity-100 dark:border-slate-600'
-            >
-              <LogOut size={14} />
-              <span className='hidden sm:inline'>Logout</span>
+        <Link to='/blog' activeProps={{ className: 'on' }}>
+          BLOG
+        </Link>
+        <Link to='/projects' activeProps={{ className: 'on' }}>
+          PROJECTS
+        </Link>
+        {sessionUser?.role === 'admin' ? (
+          <Link to='/admin' activeProps={{ className: 'on' }}>
+            ADMIN
+          </Link>
+        ) : null}
+      </nav>
+      <div className='tools'>
+        {sessionUser ? (
+          <span className='e-user'>
+            <UserRound size={12} aria-hidden='true' />
+            <span className='max-w-[180px] truncate'>{sessionUser.email}</span>
+            <span className='e-role'>{getRoleLabel(sessionUser.role)}</span>
+          </span>
+        ) : null}
+        {sessionUser ? (
+          <Link to='/logout' className='e-tool' aria-label='Logout'>
+            <LogOut size={12} aria-hidden='true' />
+          </Link>
+        ) : (
+          <>
+            <Link to='/login' className='e-tool'>
+              SIGN IN
             </Link>
-          ) : (
-            <>
-              <Link to='/login' className='opacity-70 hover:opacity-100'>
-                Login
-              </Link>
-              <Link to='/signup' className='opacity-70 hover:opacity-100'>
-                Sign Up
-              </Link>
-            </>
-          )}
-          <button
-            type='button'
-            aria-label='Search posts (Cmd+K)'
-            onClick={() => searchPalette.open()}
-            className='inline-flex items-center opacity-70 transition-opacity hover:opacity-100'
-          >
-            <Search size={22} />
-          </button>
-          <DarkMode />
-          <a
-            href='https://github.com/PerfectPan'
-            target='_blank'
-            rel='noreferrer'
-            className='flex items-center'
-          >
-            <Github size={22} className='opacity-70 hover:opacity-100' />
-          </a>
-          <a href='/rss.xml' target='_blank' rel='noreferrer'>
-            <Rss size={24} className='opacity-70 hover:opacity-100' />
-          </a>
-        </div>
+            <Link to='/signup' className='e-tool'>
+              SIGN UP
+            </Link>
+          </>
+        )}
+        <button
+          type='button'
+          className='e-tool'
+          aria-label='检索 (Cmd+K)'
+          onClick={() => searchPalette.open()}
+        >
+          ⌘K
+        </button>
+        <a
+          href='https://github.com/PerfectPan'
+          target='_blank'
+          rel='noreferrer'
+          className='e-tool'
+          aria-label='GitHub'
+        >
+          <Github size={12} aria-hidden='true' />
+        </a>
+        <a
+          href='/rss.xml'
+          target='_blank'
+          rel='noreferrer'
+          className='e-tool'
+          aria-label='RSS'
+        >
+          <Rss size={12} aria-hidden='true' />
+        </a>
       </div>
     </header>
   );

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -54,15 +54,20 @@ export function Header() {
           </span>
         ) : null}
         {sessionUser ? (
-          <Link to='/logout' className='e-tool' aria-label='Logout'>
+          <Link
+            to='/logout'
+            data-testid='nav-logout'
+            className='e-tool'
+            aria-label='Logout'
+          >
             <LogOut size={12} aria-hidden='true' />
           </Link>
         ) : (
           <>
-            <Link to='/login' className='e-tool'>
+            <Link to='/login' data-testid='nav-login' className='e-tool'>
               SIGN IN
             </Link>
-            <Link to='/signup' className='e-tool'>
+            <Link to='/signup' data-testid='nav-signup' className='e-tool'>
               SIGN UP
             </Link>
           </>

--- a/apps/web/src/components/layout.tsx
+++ b/apps/web/src/components/layout.tsx
@@ -7,21 +7,18 @@ type AppLayoutProps = {
 };
 
 /**
- * App shell. The header sits OUTSIDE the scroll container (`main`), so page
- * overscroll only rubber-bands the content — the pinned header never moves
- * (no macOS "fixed header drags on overscroll"). Window doesn't scroll; route
- * scroll reset/restore for `main` is handled by TanStack via
- * `scrollToTopSelectors: ['main']` in router.tsx.
+ * App shell (blueprint theme). The drawing-index bar sits OUTSIDE the scroll
+ * container (`main`). Window doesn't scroll; route scroll reset/restore for
+ * `main` is handled by TanStack via `scrollToTopSelectors: ['main']` in
+ * router.tsx.
  */
 export function AppLayout({ children }: AppLayoutProps) {
   return (
-    <div className='flex h-dvh flex-col'>
+    <div className='e-shell'>
       <Header />
-      <main className='flex-1 overflow-y-auto'>
+      <main className='e-main'>
         <div className='flex min-h-full flex-col'>
-          <div className='flex flex-grow items-center justify-center px-6 *:min-h-64 *:min-w-64'>
-            {children}
-          </div>
+          <div className='flex-grow'>{children}</div>
           <Footer />
         </div>
       </main>

--- a/apps/web/src/components/markdown.tsx
+++ b/apps/web/src/components/markdown.tsx
@@ -78,20 +78,17 @@ function CodeBlock({ children }: { children?: ReactNode }) {
   }, []);
 
   return (
-    <div className='group relative mb-2'>
+    <div className='e-code group relative'>
       <button
         type='button'
         onClick={onCopy}
         aria-label='Copy code'
-        className='absolute right-2 top-2 z-10 inline-flex items-center gap-1 rounded border border-slate-300 bg-white/70 px-1.5 py-0.5 text-xs opacity-0 backdrop-blur transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100 hover-none:opacity-70 dark:border-slate-700 dark:bg-slate-900/70'
+        className='e-code-copy'
       >
         {copied ? <Check size={12} /> : <Copy size={12} />}
         {copied ? 'Copied' : 'Copy'}
       </button>
-      <pre
-        ref={preRef}
-        className='shiki w-full overflow-x-auto whitespace-pre-wrap rounded-md bg-zinc-50 p-4 dark:bg-shiki-dark'
-      >
+      <pre ref={preRef} className='shiki e-pre w-full overflow-x-auto'>
         {children}
       </pre>
     </div>
@@ -112,7 +109,7 @@ export function Markdown({ content }: MarkdownProps) {
   }, []);
 
   return (
-    <article>
+    <article className='md'>
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkMath]}
         rehypePlugins={[
@@ -133,10 +130,7 @@ export function Markdown({ content }: MarkdownProps) {
             const id = typeof children === 'string' ? children : '';
 
             return (
-              <h2
-                id={id}
-                className='mb-6 mt-14 scroll-mt-20 text-balance text-2xl leading-none font-black first:mt-0'
-              >
+              <h2 id={id} className='scroll-mt-20'>
                 <a
                   href={`#${id}`}
                   onClick={(event) => {
@@ -150,24 +144,21 @@ export function Markdown({ content }: MarkdownProps) {
               </h2>
             );
           },
-          p: ({ children }) => <p className='mb-6 leading-7'>{children}</p>,
+          p: ({ children }) => <p>{children}</p>,
           a: ({ href, children }) => (
-            <a
-              href={href}
-              className='text-blue-700/80 transition-colors duration-300 ease-in-out hover:text-blue-700'
-              target='_blank'
-              rel='noreferrer'
-            >
+            <a href={href} target='_blank' rel='noreferrer'>
               {children}
             </a>
           ),
-          strong: ({ children }) => (
-            <b className='font-extrabold'>{children}</b>
-          ),
-          ul: ({ children }) => (
-            <ul className='mb-4 ml-4 list-disc'>{children}</ul>
-          ),
+          strong: ({ children }) => <b className='font-bold'>{children}</b>,
+          ul: ({ children }) => <ul>{children}</ul>,
           pre: ({ children }) => <CodeBlock>{children}</CodeBlock>,
+          code: ({ className, children }) =>
+            /language-/.test(className ?? '') ? (
+              <code className={className}>{children}</code>
+            ) : (
+              <code className='e-inline'>{children}</code>
+            ),
         }}
       >
         {content}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -26,7 +26,7 @@ export const Route = createRootRoute({
       },
       {
         name: 'theme-color',
-        content: '#000000',
+        content: '#173E62',
       },
     ],
     links: [
@@ -38,12 +38,23 @@ export const Route = createRootRoute({
   errorComponent: ({ error }) => (
     <RootDocument>
       <AppLayout>
-        <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-          <h2 className='mb-4 text-3xl'>Request Failed</h2>
-          <p className='mb-4 opacity-70'>{String(error)}</p>
-          <Link to='/blog' className='opacity-70 hover:opacity-100'>
-            Back to blog
-          </Link>
+        <div className='e-board'>
+          <section className='e-sheet'>
+            <span className='e-tick tl' aria-hidden='true' />
+            <span className='e-tick tr' aria-hidden='true' />
+            <span className='e-tick bl' aria-hidden='true' />
+            <span className='e-tick br' aria-hidden='true' />
+            <div className='e-nf'>
+              <div className='lbl'>ERROR — REQUEST FAILED</div>
+              <div className='code'>
+                5<b>0</b>0
+              </div>
+              <p>{String(error)}</p>
+              <Link to='/blog' className='e-btn'>
+                ← BACK TO BLOG
+              </Link>
+            </div>
+          </section>
         </div>
       </AppLayout>
     </RootDocument>
@@ -51,12 +62,31 @@ export const Route = createRootRoute({
   notFoundComponent: () => (
     <RootDocument>
       <AppLayout>
-        <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-          <h2 className='mb-4 text-3xl'>404 Not Found</h2>
-          <p className='mb-4 opacity-70'>你闯入了无人之境...</p>
-          <Link to='/blog' className='opacity-70 hover:opacity-100'>
-            Back to blog
-          </Link>
+        <div className='e-board'>
+          <section className='e-sheet'>
+            <span className='e-tick tl' aria-hidden='true' />
+            <span className='e-tick tr' aria-hidden='true' />
+            <span className='e-tick bl' aria-hidden='true' />
+            <span className='e-tick br' aria-hidden='true' />
+            <div className='e-nf'>
+              <div className='lbl'>ERROR — NO SUCH DRAWING</div>
+              <div className='code'>
+                4<b>0</b>4
+              </div>
+              <p>本图集并无此图号 · 或已作废归档</p>
+              <Link to='/blog' className='e-btn'>
+                ← BACK TO BLOG
+              </Link>
+            </div>
+            <div className='e-titleblock'>
+              <span className='cell'>
+                <b>PP-404</b>
+              </span>
+              <span className='cell'>
+                TITLE<b>阙图</b>
+              </span>
+            </div>
+          </section>
         </div>
       </AppLayout>
     </RootDocument>

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -1,10 +1,5 @@
 import { type CommentThread, canAccessVisibility } from '@blog/shared';
-import {
-  createFileRoute,
-  Link,
-  notFound,
-  redirect,
-} from '@tanstack/react-router';
+import { createFileRoute, notFound, redirect } from '@tanstack/react-router';
 import { Comments } from '../../components/comments.js';
 import { Markdown } from '../../components/markdown.js';
 import { getBlogPostServerFn } from '../../lib/blog-service.js';
@@ -70,31 +65,72 @@ function BlogDetailPage() {
     return null;
   }
 
-  const date = new Date(post.publishedAt).toLocaleDateString('en-US', {
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
-  });
+  const year = new Date(post.publishedAt).getFullYear();
+  const date = new Date(post.publishedAt).toISOString().slice(0, 10);
 
   return (
-    <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <div className='m-auto mb-8 flex flex-col gap-2'>
-        <div className='text-3xl font-black'>{post.title}</div>
-        <div className='opacity-60'>{date}</div>
-      </div>
-      <Markdown content={post.contentMdx} />
-      <Link to='/blog' className='mt-4 inline-block'>
-        <span className='opacity-70'>&gt;&nbsp;&nbsp;&nbsp;</span>
-        <span className='underline opacity-70 hover:opacity-100'>cd ..</span>
-      </Link>
-      <Comments
-        key={post.slug}
-        slug={post.slug}
-        initialComments={data.comments.comments}
-        initialHasMore={data.comments.hasMore}
-        initialTotal={data.comments.total}
-        sessionUser={data.sessionUser}
-      />
+    <div className='e-board'>
+      <article className='e-sheet'>
+        <span className='e-tick tl' aria-hidden='true' />
+        <span className='e-tick tr' aria-hidden='true' />
+        <span className='e-tick bl' aria-hidden='true' />
+        <span className='e-tick br' aria-hidden='true' />
+        <div className='e-sheet-head'>
+          <span className='dwg'>
+            DWG NO. PP-POST-{post.slug.slice(0, 14).toUpperCase()}
+          </span>
+          <span className='dwg'>
+            REV <span className='rev'>B</span>
+          </span>
+        </div>
+
+        <div className='e-art-head'>
+          <h1>{post.title}</h1>
+          <div className='meta'>
+            <span>DATE: {date}</span>
+            <span>ACCESS: {post.visibility.toUpperCase()}</span>
+            {post.tags.length > 0 ? (
+              <span>MATERIAL: {post.tags.join(' / ')}</span>
+            ) : null}
+          </div>
+        </div>
+
+        <Markdown content={post.contentMdx} />
+
+        <div
+          className='dwg'
+          style={{
+            color: 'var(--e-faint)',
+            letterSpacing: '0.3em',
+            margin: '44px 0 6px',
+          }}
+        >
+          INSPECTION RECORD — 检验记录
+        </div>
+        <Comments
+          key={post.slug}
+          slug={post.slug}
+          initialComments={data.comments.comments}
+          initialHasMore={data.comments.hasMore}
+          initialTotal={data.comments.total}
+          sessionUser={data.sessionUser}
+        />
+
+        <div className='e-titleblock'>
+          <span className='cell'>
+            <b>{year}</b>
+          </span>
+          <span className='cell'>
+            TITLE<b>{post.slug.slice(0, 12)}</b>
+          </span>
+          <span className='cell opt'>
+            SCALE<b>1:1</b>
+          </span>
+          <span className='cell opt'>
+            SHEET<b>DETAIL</b>
+          </span>
+        </div>
+      </article>
     </div>
   );
 }

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -1,6 +1,5 @@
 import type { PostSummary, SessionUser } from '@blog/shared';
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useEffect } from 'react';
 import { z } from 'zod';
 import { getBlogListServerFn } from '../../lib/blog-service.js';
@@ -49,6 +48,14 @@ function getDevScopeHint(sessionUser: SessionUser | null | undefined): string {
   return '当前身份：member；可见范围：public/member';
 }
 
+const PERM_CLASS: Record<PostSummary['visibility'], string> = {
+  public: 'e-perm pub',
+  member: 'e-perm mem',
+  vip: 'e-perm vip',
+  admin: 'e-perm adm',
+  password: 'e-perm pw',
+};
+
 export const Route = createFileRoute('/blog/')({
   head: () => ({
     meta: [
@@ -77,88 +84,122 @@ function BlogListPage() {
   const devScopeHint = getDevScopeHint(data.sessionUser);
 
   // Conventional blog pagination: the page scrolls naturally; jump back to the
-  // top on each page change so the new page starts at its first post. (Without
-  // this, clicking "next" while scrolled to the bottom leaves the reader past a
-  // shorter page — the original "bounce".)
+  // top on each page change so the new page starts at its first post.
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-run on page change, value unused in body on purpose
   useEffect(() => {
     document.querySelector('main')?.scrollTo({ top: 0 });
   }, [data.page]);
 
   return (
-    <div className='mx-auto flex w-full max-w-[80ch] flex-col gap-8 self-start pt-8'>
-      <div className='w-full'>
-        {showDevHint ? (
-          <div className='mb-8 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900'>
-            {devScopeHint}
-          </div>
-        ) : null}
-        {blogGroups.map((group) => (
-          <div key={group.year}>
-            <div className='mb-4 text-3xl'>{group.year}</div>
-            {group.blogs.map((blog: PostSummary) => (
-              <div
-                key={blog.slug}
-                className='mt-2 mb-6 opacity-70 hover:opacity-100'
-              >
-                <Link
-                  to='/blog/$slug'
-                  params={{ slug: blog.slug }}
-                  className='flex items-center gap-2'
-                >
-                  <span className='text-lg leading-[1.2em]'>{blog.title}</span>
-                  <span className='text-sm opacity-50'>
-                    {new Date(blog.publishedAt).toLocaleDateString('en-US', {
-                      month: 'short',
-                      day: 'numeric',
-                    })}
-                  </span>
-                </Link>
-              </div>
-            ))}
-          </div>
-        ))}
-      </div>
-      {data.totalPages > 1 ? (
-        <nav
-          className='flex w-full items-center justify-center gap-4 text-sm sm:gap-6'
-          aria-label='Pagination'
-        >
-          {data.page > 1 ? (
-            <Link
-              to='/blog'
-              search={{ page: data.page - 1 }}
-              className='inline-flex items-center gap-1 opacity-60 hover:opacity-100'
-            >
-              <ChevronLeft size={14} /> prev
-            </Link>
-          ) : (
-            <span className='inline-flex items-center gap-1 opacity-30'>
-              <ChevronLeft size={14} /> prev
-            </span>
-          )}
-          <span className='opacity-60'>
-            page {data.page} / {data.totalPages}
+    <div className='e-board'>
+      <section className='e-sheet'>
+        <span className='e-tick tl' aria-hidden='true' />
+        <span className='e-tick tr' aria-hidden='true' />
+        <span className='e-tick bl' aria-hidden='true' />
+        <span className='e-tick br' aria-hidden='true' />
+        <div className='e-sheet-head'>
+          <span className='dwg'>
+            DWG NO. PP-BLOG-{String(data.page).padStart(3, '0')}
           </span>
-          {data.page < data.totalPages ? (
-            <Link
-              to='/blog'
-              search={{ page: data.page + 1 }}
-              className='inline-flex items-center gap-1 opacity-60 hover:opacity-100'
-            >
-              next <ChevronRight size={14} />
-            </Link>
-          ) : (
-            <span className='inline-flex items-center gap-1 opacity-30'>
-              next <ChevronRight size={14} />
+          <span className='dwg'>
+            REV <span className='rev'>C</span>
+          </span>
+        </div>
+
+        {showDevHint ? <div className='e-devhint'>{devScopeHint}</div> : null}
+
+        <table className='e-bom'>
+          <thead>
+            <tr>
+              <th>ITEM</th>
+              <th>TITLE / DESCRIPTION</th>
+              <th>ACCESS</th>
+              <th>DATE</th>
+              <th>MARK</th>
+            </tr>
+          </thead>
+          <tbody>
+            {blogGroups.map((group) => (
+              <Fragment key={group.year} group={group} data={data} />
+            ))}
+          </tbody>
+        </table>
+
+        {data.totalPages > 1 ? (
+          <nav className='e-pager' aria-label='Pagination'>
+            {data.page > 1 ? (
+              <Link to='/blog' search={{ page: data.page - 1 }}>
+                ← PREV
+              </Link>
+            ) : (
+              <span style={{ opacity: 0.5 }}>← PREV</span>
+            )}
+            <span>
+              SHEET {data.page} / {data.totalPages}
             </span>
-          )}
-        </nav>
-      ) : null}
-      <Link to='/' className='mt-4 inline-block'>
-        <span className='opacity-70'>&gt;&nbsp;&nbsp;&nbsp;</span>
-        <span className='underline opacity-70 hover:opacity-100'>cd ..</span>
-      </Link>
+            {data.page < data.totalPages ? (
+              <Link to='/blog' search={{ page: data.page + 1 }}>
+                NEXT →
+              </Link>
+            ) : (
+              <span style={{ opacity: 0.5 }}>NEXT →</span>
+            )}
+          </nav>
+        ) : null}
+
+        <div className='e-titleblock'>
+          <span className='cell'>
+            <b>PP-BLOG</b>
+          </span>
+          <span className='cell'>
+            TITLE<b>材料清单</b>
+          </span>
+          <span className='cell opt'>
+            SHEET
+            <b>
+              {data.page}/{data.totalPages}
+            </b>
+          </span>
+        </div>
+      </section>
     </div>
+  );
+}
+
+function Fragment({
+  group,
+  data,
+}: {
+  group: BlogGroup;
+  data: { total: number; page: number; totalPages: number };
+}) {
+  const startIndex = data.total - (data.page - 1) * 10;
+  return (
+    <>
+      <tr className='yr'>
+        <td colSpan={5}>— {group.year} —</td>
+      </tr>
+      {group.blogs.map((blog: PostSummary, index: number) => (
+        <tr key={blog.slug}>
+          <td className='e-item-no'>
+            {String(Math.max(1, startIndex - index)).padStart(3, '0')}
+          </td>
+          <td>
+            <Link to='/blog/$slug' params={{ slug: blog.slug }}>
+              {blog.title}
+            </Link>
+          </td>
+          <td className={PERM_CLASS[blog.visibility]}>
+            {blog.visibility.toUpperCase()}
+          </td>
+          <td className='e-item-no'>
+            {new Date(blog.publishedAt).toISOString().slice(5, 10)}
+          </td>
+          <td className='e-item-no'>
+            {blog.tags.slice(0, 2).join('·') || '—'}
+          </td>
+        </tr>
+      ))}
+    </>
   );
 }

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,27 +1,121 @@
+import type { PostSummary } from '@blog/shared';
 import { createFileRoute, Link } from '@tanstack/react-router';
+import { getBlogListServerFn } from '../lib/blog-service.js';
+import { PROJECTS } from '../lib/projects.js';
 
 export const Route = createFileRoute('/')({
   head: () => ({
     meta: [{ title: "Home | PerfectPan's Blog" }],
   }),
+  loader: async () => {
+    // Guest-scoped first page powers the LATEST INDEX column.
+    return getBlogListServerFn({ data: { page: 1 } });
+  },
   component: HomePage,
 });
 
-function HomePage() {
+function Ticks() {
   return (
-    <div className='flex flex-col items-center'>
-      <img className='m-0' src='/images/xm.jpg' alt='' />
-      <div className='mt-8 text-[2.5rem] font-black'>
-        是个什么都不会的废物.jpg
-      </div>
-      <div className='flex w-full justify-around'>
-        <div className='mx-1 mt-8 flex-1 rounded-md bg-slate-100 text-center font-semibold uppercase tracking-wider leading-[5rem] shadow-md transition-shadow hover:shadow-lg dark:bg-wash-dark dark:text-white dark:opacity-80'>
-          <Link to='/blog'>Blog</Link>
+    <>
+      <span className='e-tick tl' aria-hidden='true' />
+      <span className='e-tick tr' aria-hidden='true' />
+      <span className='e-tick bl' aria-hidden='true' />
+      <span className='e-tick br' aria-hidden='true' />
+    </>
+  );
+}
+
+function HomePage() {
+  const data = Route.useLoaderData();
+  const latest = data.posts.slice(0, 5);
+
+  return (
+    <div className='e-board'>
+      <section className='e-sheet'>
+        <Ticks />
+        <div className='e-sheet-head'>
+          <span className='dwg'>DWG NO. PP-HOME-001</span>
+          <span className='dwg'>
+            REV <span className='rev'>C</span>
+          </span>
         </div>
-        <div className='mx-1 mt-8 flex-1 rounded-md bg-slate-100 text-center font-semibold uppercase tracking-wider leading-[5rem] shadow-md transition-shadow hover:shadow-lg dark:bg-wash-dark dark:text-white dark:opacity-80'>
-          <Link to='/projects'>Projects</Link>
+
+        <div className='e-cover'>
+          <div>
+            <div
+              className='dwg'
+              style={{ color: 'var(--e-faint)', letterSpacing: '0.3em' }}
+            >
+              GENERAL ARRANGEMENT — SINCE 2019
+            </div>
+            <div className='big' style={{ marginTop: 14 }}>
+              PERFECTPAN<span>.</span>
+            </div>
+            <p className='sub'>
+              个人博客施工图集：算法竞赛旧题解、TypeScript 类型体操、Cloudflare
+              $0/月 工程实践，以及随想。
+            </p>
+            <div className='mt-6'>
+              <div className='e-spec-line'>
+                <span className='k'>DOCUMENTS</span>
+                <span className='v'>{data.total} 篇（2019 — 2023）</span>
+              </div>
+              <div className='e-spec-line'>
+                <span className='k'>ASSEMBLIES</span>
+                <span className='v'>{PROJECTS.length} 个开源项目</span>
+              </div>
+              <div className='e-spec-line'>
+                <span className='k'>SUBSTRATE</span>
+                <span className='v'>Cloudflare Workers + D1</span>
+              </div>
+              <div className='e-spec-line'>
+                <span className='k'>TOLERANCE</span>
+                <span className='v'>$0.00 / 月</span>
+              </div>
+            </div>
+            <div className='e-cta'>
+              <Link to='/blog' className='e-btn e-btn-fill'>
+                OPEN BLOG/
+              </Link>
+              <Link to='/projects' className='e-btn'>
+                OPEN PROJECTS/
+              </Link>
+            </div>
+          </div>
+          <div className='e-cover-right'>
+            <h3>LATEST INDEX</h3>
+            {latest.map((post: PostSummary, index: number) => (
+              <div className='e-idx-row' key={post.slug}>
+                <span className='no'>
+                  {String(data.total - index).padStart(3, '0')}
+                </span>
+                <Link
+                  className='t'
+                  to='/blog/$slug'
+                  params={{ slug: post.slug }}
+                >
+                  {post.title}
+                </Link>
+              </div>
+            ))}
+          </div>
         </div>
-      </div>
+
+        <div className='e-titleblock'>
+          <span className='cell'>
+            <b>PERFECTPAN.ORG</b>
+          </span>
+          <span className='cell'>
+            TITLE<b>总布置图</b>
+          </span>
+          <span className='cell opt'>
+            SCALE<b>1:1</b>
+          </span>
+          <span className='cell opt'>
+            SHEET<b>1/1</b>
+          </span>
+        </div>
+      </section>
     </div>
   );
 }

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -34,96 +34,115 @@ function LoginPage() {
 
   if (sessionData?.user?.id || isSessionPending) {
     return (
-      <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-        <p className='opacity-70'>Checking session...</p>
-      </section>
+      <div className='e-board'>
+        <p className='e-aside'>CHECKING SESSION…</p>
+      </div>
     );
   }
 
   return (
-    <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>登录</h1>
-      <p className='mb-6 opacity-70'>支持邮箱密码和 GitHub OAuth。</p>
+    <div className='e-board'>
+      <section className='e-sheet' style={{ maxWidth: 540, margin: '0 auto' }}>
+        <span className='e-tick tl' aria-hidden='true' />
+        <span className='e-tick tr' aria-hidden='true' />
+        <span className='e-tick bl' aria-hidden='true' />
+        <span className='e-tick br' aria-hidden='true' />
+        <div className='e-sheet-head'>
+          <span className='dwg'>DWG NO. PP-AUTH-01</span>
+          <span className='dwg'>
+            REV <span className='rev'>A</span>
+          </span>
+        </div>
+        <div className='e-gate'>
+          <h1>SIGN IN / 登录</h1>
+          <p className='sub'>会友可读 MEMBER 图纸 · 亦支持 GITHUB OAUTH</p>
+          <form
+            method='post'
+            onSubmit={(event) => {
+              event.preventDefault();
+              setError(null);
+              startTransition(async () => {
+                const result = await authClient.signIn.email({
+                  email,
+                  password,
+                  callbackURL: '/blog',
+                });
 
-      {error ? (
-        <p role='alert' className='mb-4 text-sm text-red-700 dark:text-red-300'>
-          {error}
-        </p>
-      ) : null}
+                if (result.error) {
+                  setError(result.error.message ?? '登录失败');
+                  return;
+                }
 
-      <form
-        className='grid max-w-[420px] gap-3'
-        method='post'
-        onSubmit={(event) => {
-          event.preventDefault();
-          setError(null);
-          startTransition(async () => {
-            const result = await authClient.signIn.email({
-              email,
-              password,
-              callbackURL: '/blog',
-            });
-
-            if (result.error) {
-              setError(result.error.message ?? '登录失败');
-              return;
-            }
-
-            navigate({ to: '/blog' });
-          });
-        }}
-      >
-        <label htmlFor='email' className='font-semibold'>
-          Email
-        </label>
-        <input
-          id='email'
-          name='email'
-          type='email'
-          required
-          autoComplete='email'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-        />
-        <label htmlFor='password' className='font-semibold'>
-          Password
-        </label>
-        <input
-          id='password'
-          name='password'
-          type='password'
-          required
-          autoComplete='current-password'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={password}
-          onChange={(event) => setPassword(event.target.value)}
-        />
-        <button
-          type='submit'
-          className='rounded-md bg-black px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90 dark:bg-neutral-900'
-          disabled={isPending}
-        >
-          {isPending ? 'Signing in...' : 'Sign In'}
-        </button>
-      </form>
-
-      <button
-        type='button'
-        className='mt-3 rounded-md border border-slate-300 px-4 py-2 font-semibold transition-colors hover:bg-gray-100 dark:border-slate-700 dark:hover:bg-slate-800'
-        onClick={async () => {
-          setError(null);
-          const result = await authClient.signIn.social({
-            provider: 'github',
-            callbackURL: '/blog',
-          });
-          if (result.error) {
-            setError(result.error.message ?? 'GitHub 登录失败');
-          }
-        }}
-      >
-        Continue with GitHub
-      </button>
-    </section>
+                navigate({ to: '/blog' });
+              });
+            }}
+          >
+            <div className='e-field'>
+              <label htmlFor='email'>EMAIL</label>
+              <input
+                id='email'
+                name='email'
+                type='email'
+                required
+                autoComplete='email'
+                className='e-input'
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+              />
+            </div>
+            <div className='e-field'>
+              <label htmlFor='password'>PASSWORD</label>
+              <input
+                id='password'
+                name='password'
+                type='password'
+                required
+                autoComplete='current-password'
+                className='e-input'
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+            </div>
+            <div className='e-actions'>
+              <button
+                type='submit'
+                className='e-btn e-btn-fill'
+                disabled={isPending}
+              >
+                {isPending ? 'SIGNING IN…' : 'SIGN IN'}
+              </button>
+              <button
+                type='button'
+                className='e-btn'
+                onClick={async () => {
+                  setError(null);
+                  const result = await authClient.signIn.social({
+                    provider: 'github',
+                    callbackURL: '/blog',
+                  });
+                  if (result.error) {
+                    setError(result.error.message ?? 'GitHub 登录失败');
+                  }
+                }}
+              >
+                GITHUB
+              </button>
+            </div>
+            {error ? <p className='e-err'>{error}</p> : null}
+          </form>
+          <p className='e-aside'>
+            尚未注册？ <a href='/signup'>SIGN UP ↗</a>
+          </p>
+        </div>
+        <div className='e-titleblock'>
+          <span className='cell'>
+            <b>PP-AUTH-01</b>
+          </span>
+          <span className='cell'>
+            TITLE<b>登录</b>
+          </span>
+        </div>
+      </section>
+    </div>
   );
 }

--- a/apps/web/src/routes/projects.tsx
+++ b/apps/web/src/routes/projects.tsx
@@ -1,5 +1,4 @@
-import { createFileRoute, Link } from '@tanstack/react-router';
-import { ExternalLink, Github } from 'lucide-react';
+import { createFileRoute } from '@tanstack/react-router';
 import { PROJECTS, type Project } from '../lib/projects.js';
 
 export const Route = createFileRoute('/projects')({
@@ -25,67 +24,54 @@ function ProjectsPage() {
   const projects = sortProjects(PROJECTS);
 
   return (
-    <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>Projects</h1>
-      <p className='mb-8 opacity-70'>我做过的一些东西，按需更新。</p>
+    <div className='e-board'>
+      <section className='e-sheet'>
+        <span className='e-tick tl' aria-hidden='true' />
+        <span className='e-tick tr' aria-hidden='true' />
+        <span className='e-tick bl' aria-hidden='true' />
+        <span className='e-tick br' aria-hidden='true' />
+        <div className='e-sheet-head'>
+          <span className='dwg'>DWG NO. PP-PRJ-001</span>
+          <span className='dwg'>
+            REV <span className='rev'>A</span>
+          </span>
+        </div>
 
-      <div className='grid gap-4 sm:grid-cols-2'>
-        {projects.map((project) => (
-          <article
-            key={project.name}
-            className='flex flex-col rounded-lg border border-slate-200 bg-white/60 p-5 transition-shadow hover:shadow-md dark:border-slate-700 dark:bg-wash-dark'
-          >
-            <div className='mb-1 flex items-center gap-2'>
-              <h2 className='text-lg font-semibold'>{project.name}</h2>
-              {project.featured ? (
-                <span className='rounded-full bg-black px-2 py-[2px] text-[10px] font-semibold text-white dark:bg-neutral-100 dark:text-neutral-900'>
-                  FEATURED
-                </span>
-              ) : null}
+        {projects.map((project, index) => (
+          <div className='e-dwg-row' key={project.name}>
+            <div className='no'>
+              {String(projects.length - index).padStart(2, '0')}
+              {project.featured ? <span className='feat'>FEATURED</span> : null}
             </div>
-            <p className='mb-4 flex-grow text-sm opacity-70'>
-              {project.description}
-            </p>
-            <div className='mb-4 flex flex-wrap gap-1.5'>
-              {project.tags.map((tag) => (
-                <span
-                  key={tag}
-                  className='rounded-md border border-slate-200 px-2 py-[2px] text-[11px] opacity-70 dark:border-slate-700'
-                >
-                  {tag}
-                </span>
-              ))}
+            <div>
+              <h2>{project.name}</h2>
+              <p>{project.description}</p>
             </div>
-            <div className='flex items-center gap-4 text-sm'>
-              <a
-                href={project.repo}
-                target='_blank'
-                rel='noreferrer'
-                className='inline-flex items-center gap-1 opacity-70 hover:opacity-100'
-              >
-                <Github size={15} />
-                Code
+            <div className='links'>
+              <a href={project.repo} target='_blank' rel='noreferrer'>
+                CODE ↗
               </a>
               {project.demo ? (
-                <a
-                  href={project.demo}
-                  target='_blank'
-                  rel='noreferrer'
-                  className='inline-flex items-center gap-1 opacity-70 hover:opacity-100'
-                >
-                  <ExternalLink size={15} />
-                  Demo
+                <a href={project.demo} target='_blank' rel='noreferrer'>
+                  DEMO ↗
                 </a>
               ) : null}
             </div>
-          </article>
+          </div>
         ))}
-      </div>
 
-      <Link to='/' className='mt-8 inline-block'>
-        <span className='opacity-70'>&gt;&nbsp;&nbsp;&nbsp;</span>
-        <span className='underline opacity-70 hover:opacity-100'>cd ..</span>
-      </Link>
+        <div className='e-titleblock'>
+          <span className='cell'>
+            <b>PP-PRJ</b>
+          </span>
+          <span className='cell'>
+            TITLE<b>装配图集</b>
+          </span>
+          <span className='cell opt'>
+            QTY<b>{projects.length}</b>
+          </span>
+        </div>
+      </section>
     </div>
   );
 }

--- a/apps/web/src/routes/signup.tsx
+++ b/apps/web/src/routes/signup.tsx
@@ -35,93 +35,126 @@ function SignUpPage() {
 
   if (sessionData?.user?.id || isSessionPending) {
     return (
-      <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-        <p className='opacity-70'>Checking session...</p>
-      </section>
+      <div className='e-board'>
+        <p className='e-aside'>CHECKING SESSION…</p>
+      </div>
     );
   }
 
   return (
-    <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>注册</h1>
-      <p className='mb-6 opacity-70'>注册后默认角色为 member，可在后台升权。</p>
+    <div className='e-board'>
+      <section className='e-sheet' style={{ maxWidth: 540, margin: '0 auto' }}>
+        <span className='e-tick tl' aria-hidden='true' />
+        <span className='e-tick tr' aria-hidden='true' />
+        <span className='e-tick bl' aria-hidden='true' />
+        <span className='e-tick br' aria-hidden='true' />
+        <div className='e-sheet-head'>
+          <span className='dwg'>DWG NO. PP-AUTH-02</span>
+          <span className='dwg'>
+            REV <span className='rev'>A</span>
+          </span>
+        </div>
+        <div className='e-gate'>
+          <h1>SIGN UP / 注册</h1>
+          <p className='sub'>注册即成为 MEMBER</p>
+          <form
+            method='post'
+            onSubmit={(event) => {
+              event.preventDefault();
+              setError(null);
+              startTransition(async () => {
+                const result = await authClient.signUp.email({
+                  email,
+                  password,
+                  name,
+                  callbackURL: '/blog',
+                });
 
-      {error ? (
-        <p role='alert' className='mb-4 text-sm text-red-700 dark:text-red-300'>
-          {error}
-        </p>
-      ) : null}
+                if (result.error) {
+                  setError(result.error.message ?? '注册失败');
+                  return;
+                }
 
-      <form
-        className='grid max-w-[420px] gap-3'
-        method='post'
-        onSubmit={(event) => {
-          event.preventDefault();
-          setError(null);
-          startTransition(async () => {
-            const result = await authClient.signUp.email({
-              email,
-              password,
-              name,
-              callbackURL: '/blog',
-            });
-
-            if (result.error) {
-              setError(result.error.message ?? '注册失败');
-              return;
-            }
-
-            navigate({ to: '/blog' });
-          });
-        }}
-      >
-        <label htmlFor='name' className='font-semibold'>
-          Name
-        </label>
-        <input
-          id='name'
-          name='name'
-          type='text'
-          required
-          autoComplete='name'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={name}
-          onChange={(event) => setName(event.target.value)}
-        />
-        <label htmlFor='email' className='font-semibold'>
-          Email
-        </label>
-        <input
-          id='email'
-          name='email'
-          type='email'
-          required
-          autoComplete='email'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-        />
-        <label htmlFor='password' className='font-semibold'>
-          Password
-        </label>
-        <input
-          id='password'
-          name='password'
-          type='password'
-          required
-          autoComplete='new-password'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={password}
-          onChange={(event) => setPassword(event.target.value)}
-        />
-        <button
-          type='submit'
-          className='rounded-md bg-black px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90 dark:bg-neutral-900'
-          disabled={isPending}
-        >
-          {isPending ? 'Creating account...' : 'Sign Up'}
-        </button>
-      </form>
-    </section>
+                navigate({ to: '/blog' });
+              });
+            }}
+          >
+            <div className='e-field'>
+              <label htmlFor='name'>NAME</label>
+              <input
+                id='name'
+                name='name'
+                type='text'
+                required
+                autoComplete='name'
+                className='e-input'
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+              />
+            </div>
+            <div className='e-field'>
+              <label htmlFor='email'>EMAIL</label>
+              <input
+                id='email'
+                name='email'
+                type='email'
+                required
+                autoComplete='email'
+                className='e-input'
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+              />
+            </div>
+            <div className='e-field'>
+              <label htmlFor='password'>PASSWORD</label>
+              <input
+                id='password'
+                name='password'
+                type='password'
+                required
+                autoComplete='new-password'
+                className='e-input'
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+            </div>
+            <div className='e-actions'>
+              <button
+                type='submit'
+                className='e-btn e-btn-fill'
+                disabled={isPending}
+              >
+                {isPending ? 'CREATING…' : 'CREATE'}
+              </button>
+              <button
+                type='button'
+                className='e-btn'
+                onClick={async () => {
+                  setError(null);
+                  const result = await authClient.signIn.social({
+                    provider: 'github',
+                    callbackURL: '/blog',
+                  });
+                  if (result.error) {
+                    setError(result.error.message ?? 'GitHub 注册失败');
+                  }
+                }}
+              >
+                GITHUB
+              </button>
+            </div>
+            {error ? <p className='e-err'>{error}</p> : null}
+          </form>
+        </div>
+        <div className='e-titleblock'>
+          <span className='cell'>
+            <b>PP-AUTH-02</b>
+          </span>
+          <span className='cell'>
+            TITLE<b>注册</b>
+          </span>
+        </div>
+      </section>
+    </div>
   );
 }

--- a/apps/web/src/routes/unlock/$slug.tsx
+++ b/apps/web/src/routes/unlock/$slug.tsx
@@ -78,48 +78,56 @@ function UnlockPage() {
     search.error === 'missing'
       ? '请输入访问密码'
       : search.error === 'invalid'
-        ? '密码错误，请重试'
+        ? '密码错误，请重试（连续失败会触发限流）'
         : undefined;
 
   return (
-    <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>输入文章访问密码</h1>
-      <p className='mb-6 opacity-70'>这篇文章使用了单文密码保护。</p>
-
-      {errorLabel ? (
-        <p role='alert' className='mb-4 text-sm text-red-700 dark:text-red-300'>
-          {errorLabel}
-        </p>
-      ) : null}
-
-      <form method='post' className='grid max-w-[420px] gap-3'>
-        <label htmlFor='password' className='font-semibold'>
-          Password
-        </label>
-        <input
-          id='password'
-          name='password'
-          type='password'
-          required
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-        />
-        <button
-          type='submit'
-          className='rounded-md bg-black px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90 dark:bg-neutral-900'
-        >
-          Unlock
-        </button>
-      </form>
-
-      <p className='mt-4'>
-        <Link
-          to='/blog/$slug'
-          params={{ slug }}
-          className='opacity-70 hover:opacity-100'
-        >
-          返回文章页
-        </Link>
-      </p>
-    </section>
+    <div className='e-board'>
+      <section className='e-sheet' style={{ maxWidth: 540, margin: '0 auto' }}>
+        <span className='e-tick tl' aria-hidden='true' />
+        <span className='e-tick tr' aria-hidden='true' />
+        <span className='e-tick bl' aria-hidden='true' />
+        <span className='e-tick br' aria-hidden='true' />
+        <div className='e-sheet-head'>
+          <span className='dwg'>DWG NO. PP-AUTH-03</span>
+          <span className='dwg' style={{ color: 'var(--e-red)' }}>
+            STATUS: LOCKED
+          </span>
+        </div>
+        <div className='e-gate'>
+          <h1>UNLOCK / 解锁图纸</h1>
+          <p className='sub'>此篇以单文密码封缄 ・ 验后 24 小时免复输入</p>
+          <form method='post'>
+            <div className='e-field'>
+              <label htmlFor='password'>POST PASSWORD</label>
+              <input
+                id='password'
+                name='password'
+                type='password'
+                required
+                className='e-input'
+              />
+            </div>
+            {errorLabel ? <p className='e-err'>{errorLabel}</p> : null}
+            <div className='e-actions'>
+              <button type='submit' className='e-btn e-btn-fill'>
+                UNLOCK
+              </button>
+              <Link to='/blog/$slug' params={{ slug }} className='e-btn'>
+                ← BACK
+              </Link>
+            </div>
+          </form>
+        </div>
+        <div className='e-titleblock'>
+          <span className='cell'>
+            <b>PP-AUTH-03</b>
+          </span>
+          <span className='cell'>
+            TITLE<b>密笺</b>
+          </span>
+        </div>
+      </section>
+    </div>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -144,3 +144,842 @@ html.dark ::-webkit-scrollbar-thumb {
 html.dark ::-webkit-scrollbar-thumb:hover {
   background: rgb(148 163 184 / 0.55);
 }
+
+/* =====================================================================
+ * THEME E — Engineering Blueprint (UX redesign direction E)
+ * Every page is a numbered drawing sheet on grid paper: frame, corner
+ * ticks, title block (DWG NO / REV / SHEET), BOM-style post list.
+ * Dark-native blue: html renders with .dark by default.
+ * =================================================================== */
+:root,
+.dark {
+  --background: 211 45% 21%;
+  --foreground: 210 60% 94%;
+  --card: 211 45% 14%;
+  --card-foreground: 210 60% 94%;
+  --popover: 211 45% 17%;
+  --popover-foreground: 210 60% 94%;
+  --primary: 42 100% 68%;
+  --primary-foreground: 211 45% 14%;
+  --secondary: 211 40% 18%;
+  --secondary-foreground: 210 60% 94%;
+  --muted: 211 40% 18%;
+  --muted-foreground: 210 30% 65%;
+  --accent: 211 40% 22%;
+  --accent-foreground: 210 60% 94%;
+  --destructive: 8 70% 72%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 210 40% 32%;
+  --input: 210 40% 32%;
+  --ring: 42 100% 68%;
+  --radius: 0.1875rem;
+}
+
+:root {
+  --e-bp: #173e62;
+  --e-deep: #113149;
+  --e-sheet: rgba(233, 242, 252, 0.045);
+  --e-ink: #e8f1fa;
+  --e-dim: #9fb9d6;
+  --e-faint: #6d89ab;
+  --e-line: rgba(232, 241, 250, 0.28);
+  --e-line-soft: rgba(232, 241, 250, 0.14);
+  --e-yellow: #ffc957;
+  --e-cyan: #8fdcff;
+  --e-red: #ff8e7a;
+  --e-green: #9be3b4;
+  --e-mono:
+    ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, "PingFang SC",
+    monospace;
+}
+
+html,
+html.dark {
+  background-color: var(--e-bp);
+  scrollbar-color: #2c4a6b var(--e-bp);
+}
+
+html body {
+  font-family: var(--e-mono);
+  background-color: var(--e-bp);
+  background-image:
+    linear-gradient(rgba(232, 241, 250, 0.055) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(232, 241, 250, 0.055) 1px, transparent 1px);
+  background-size: 26px 26px;
+  color: var(--e-ink);
+  font-size: 14px;
+  line-height: 1.8;
+}
+
+::selection {
+  background: rgba(255, 201, 87, 0.28);
+}
+
+/* ---------- shell ---------- */
+.e-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+}
+.e-main {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.e-head {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 10px 22px;
+  border-bottom: 1.5px solid var(--e-line);
+  background: rgba(17, 49, 73, 0.85);
+}
+.e-head .dwg {
+  font-size: 10.5px;
+  letter-spacing: 0.3em;
+  color: var(--e-faint);
+}
+.e-head .dwg b {
+  color: var(--e-yellow);
+  font-weight: 600;
+}
+.e-head nav {
+  display: flex;
+  gap: 2px;
+}
+.e-head nav a {
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  color: var(--e-dim);
+  padding: 4px 12px;
+  border: 1px solid transparent;
+}
+.e-head nav a:hover {
+  color: var(--e-ink);
+  text-decoration: none;
+}
+.e-head nav a.on {
+  color: var(--e-yellow);
+  border-color: var(--e-yellow);
+}
+.e-head .tools {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.e-tool {
+  font-family: var(--e-mono);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  color: var(--e-dim);
+  background: none;
+  border: 1px solid var(--e-line-soft);
+  padding: 4px 10px;
+  cursor: pointer;
+}
+.e-tool:hover {
+  color: var(--e-yellow);
+  border-color: var(--e-yellow);
+  text-decoration: none;
+}
+.e-user {
+  display: none;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  color: var(--e-dim);
+}
+@media (min-width: 768px) {
+  .e-user {
+    display: inline-flex;
+  }
+}
+.e-role {
+  background: var(--e-yellow);
+  color: #113049;
+  font-size: 9.5px;
+  font-weight: 700;
+  padding: 1px 7px;
+  letter-spacing: 0.1em;
+}
+
+/* ---------- sheet ---------- */
+.e-board {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 30px 22px 70px;
+}
+.e-sheet {
+  position: relative;
+  border: 1.6px solid var(--e-line);
+  background: var(--e-sheet);
+  padding: 30px 36px 96px;
+}
+.e-sheet::before {
+  content: "";
+  position: absolute;
+  inset: 5px;
+  border: 1px solid var(--e-line-soft);
+  pointer-events: none;
+}
+.e-tick {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  pointer-events: none;
+}
+.e-tick::before,
+.e-tick::after {
+  content: "";
+  position: absolute;
+  background: var(--e-yellow);
+}
+.e-tick::before {
+  width: 14px;
+  height: 2px;
+}
+.e-tick::after {
+  width: 2px;
+  height: 14px;
+}
+.e-tick.tl {
+  top: -1.6px;
+  left: -1.6px;
+}
+.e-tick.tr {
+  top: -1.6px;
+  right: -1.6px;
+  transform: scaleX(-1);
+}
+.e-tick.bl {
+  bottom: -1.6px;
+  left: -1.6px;
+  transform: scaleY(-1);
+}
+.e-tick.br {
+  bottom: -1.6px;
+  right: -1.6px;
+  transform: scale(-1);
+}
+
+.e-sheet-head {
+  display: flex;
+  align-items: baseline;
+  gap: 18px;
+  flex-wrap: wrap;
+  padding-bottom: 16px;
+  border-bottom: 1px dashed var(--e-line);
+  margin-bottom: 24px;
+}
+.e-sheet-head .dwg {
+  font-size: 10.5px;
+  letter-spacing: 0.3em;
+  color: var(--e-faint);
+}
+.e-sheet-head .dwg .rev {
+  color: var(--e-yellow);
+}
+.e-sheet-head h1 {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.e-titleblock {
+  position: absolute;
+  right: -1.6px;
+  bottom: -1.6px;
+  display: flex;
+  background: rgba(12, 34, 55, 0.92);
+  border: 1.6px solid var(--e-line);
+  border-right: 0;
+  border-bottom: 0;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  color: var(--e-dim);
+}
+.e-titleblock .cell {
+  padding: 6px 13px;
+  border-left: 1px solid var(--e-line-soft);
+}
+.e-titleblock .cell:first-child {
+  border-left: 0;
+}
+.e-titleblock .cell b {
+  display: block;
+  color: var(--e-yellow);
+  font-weight: 600;
+  font-size: 12.5px;
+  letter-spacing: 0.06em;
+}
+@media (max-width: 760px) {
+  .e-sheet {
+    padding: 20px 16px 130px;
+  }
+  .e-titleblock .cell.opt {
+    display: none;
+  }
+}
+
+/* ---------- shared ---------- */
+.e-btn {
+  font-family: var(--e-mono);
+  font-size: 12px;
+  letter-spacing: 0.22em;
+  cursor: pointer;
+  background: none;
+  color: var(--e-ink);
+  border: 1.4px solid var(--e-line);
+  padding: 9px 20px;
+  transition: all 0.12s;
+}
+.e-btn:hover {
+  border-color: var(--e-yellow);
+  color: var(--e-yellow);
+  text-decoration: none;
+}
+.e-btn-fill {
+  background: var(--e-yellow);
+  border-color: var(--e-yellow);
+  color: #123049;
+  font-weight: 700;
+}
+.e-btn-fill:hover {
+  background: #ffd57a;
+  color: #123049;
+}
+
+/* ---------- home cover ---------- */
+.e-cover {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr;
+  gap: 44px;
+}
+.e-cover .big {
+  font-size: clamp(38px, 6vw, 60px);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  line-height: 1.15;
+}
+.e-cover .big :where(span) {
+  color: var(--e-yellow);
+}
+.e-cover .sub {
+  margin-top: 18px;
+  color: var(--e-dim);
+  max-width: 48ch;
+}
+.e-spec-line {
+  display: flex;
+  gap: 16px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--e-line-soft);
+  font-size: 12.5px;
+}
+.e-spec-line .k {
+  color: var(--e-faint);
+  letter-spacing: 0.2em;
+  min-width: 12ch;
+}
+.e-spec-line .v {
+  color: var(--e-ink);
+}
+.e-cover-right {
+  border-left: 1px dashed var(--e-line);
+  padding-left: 36px;
+}
+.e-cover-right h3 {
+  font-size: 10.5px;
+  letter-spacing: 0.3em;
+  color: var(--e-yellow);
+  margin-bottom: 12px;
+  font-weight: 600;
+}
+.e-idx-row {
+  display: flex;
+  gap: 12px;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--e-line-soft);
+  align-items: baseline;
+}
+.e-idx-row .no {
+  color: var(--e-faint);
+  font-size: 11px;
+  min-width: 4ch;
+}
+.e-idx-row .t {
+  flex: 1;
+  color: var(--e-ink);
+}
+.e-idx-row .t:hover {
+  color: var(--e-cyan);
+  text-decoration: none;
+}
+.e-cta {
+  margin-top: 26px;
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+@media (max-width: 820px) {
+  .e-cover {
+    grid-template-columns: 1fr;
+  }
+  .e-cover-right {
+    border-left: 0;
+    border-top: 1px dashed var(--e-line);
+    padding: 24px 0 0;
+  }
+}
+
+/* ---------- BOM list ---------- */
+.e-bom {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.e-bom th {
+  text-align: left;
+  font-weight: 400;
+  font-size: 10px;
+  letter-spacing: 0.26em;
+  color: var(--e-yellow);
+  padding: 9px 12px;
+  border-bottom: 1.4px solid var(--e-line);
+}
+.e-bom td {
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--e-line-soft);
+}
+.e-bom tbody tr:hover td {
+  background: rgba(143, 220, 255, 0.06);
+}
+.e-bom td a {
+  color: var(--e-ink);
+}
+.e-bom td a:hover {
+  color: var(--e-cyan);
+  text-decoration: none;
+}
+.e-bom .yr td {
+  padding: 22px 12px 6px;
+  color: var(--e-dim);
+  letter-spacing: 0.3em;
+  font-size: 11px;
+}
+.e-perm {
+  font-size: 11px;
+  letter-spacing: 0.06em;
+}
+.e-perm.pub {
+  color: var(--e-green);
+}
+.e-perm.mem {
+  color: var(--e-cyan);
+}
+.e-perm.vip {
+  color: #c7a6f2;
+}
+.e-perm.pw {
+  color: var(--e-red);
+}
+.e-perm.adm {
+  color: var(--e-dim);
+}
+.e-item-no {
+  color: var(--e-faint);
+  font-size: 11px;
+}
+@media (max-width: 720px) {
+  .e-bom th:nth-child(3),
+  .e-bom td:nth-child(3),
+  .e-bom th:nth-child(5),
+  .e-bom td:nth-child(5) {
+    display: none;
+  }
+}
+.e-pager {
+  display: flex;
+  justify-content: center;
+  gap: 22px;
+  padding-top: 28px;
+  font-size: 12px;
+  color: var(--e-dim);
+}
+.e-pager :where(a) {
+  color: var(--e-yellow);
+}
+.e-devhint {
+  border: 1px dashed var(--e-line);
+  color: var(--e-dim);
+  font-size: 12px;
+  padding: 8px 14px;
+  margin-bottom: 16px;
+}
+
+/* ---------- article ---------- */
+.e-art-head {
+  border-bottom: 1.4px solid var(--e-line);
+  padding-bottom: 18px;
+  margin-bottom: 26px;
+}
+.e-art-head h1 {
+  font-size: 25px;
+  font-weight: 700;
+}
+.e-art-head .meta {
+  margin-top: 10px;
+  display: flex;
+  gap: 22px;
+  flex-wrap: wrap;
+  font-size: 10.5px;
+  letter-spacing: 0.2em;
+  color: var(--e-dim);
+}
+
+.md {
+  max-width: 72ch;
+  counter-reset: note;
+}
+.md p {
+  margin: 16px 0;
+  color: #d9e6f4;
+}
+.md h2 {
+  font-size: 16px;
+  margin: 34px 0 10px;
+  letter-spacing: 0.08em;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  scroll-margin-top: 20px;
+}
+.md h2::before {
+  content: "NOTE " counter(note);
+  counter-increment: note;
+  color: var(--e-yellow);
+  font-size: 11px;
+  letter-spacing: 0.24em;
+  flex: none;
+}
+.md h2::after {
+  content: "";
+  flex: 1;
+  border-top: 1px dashed var(--e-line-soft);
+}
+.md h2 a {
+  color: inherit;
+}
+.md ul {
+  margin: 14px 0;
+  list-style: none;
+}
+.md ul li {
+  padding: 6px 0 6px 26px;
+  position: relative;
+  color: #d9e6f4;
+}
+.md ul li::before {
+  content: "—";
+  position: absolute;
+  left: 0;
+  color: var(--e-yellow);
+}
+.md :where(a) {
+  color: var(--e-cyan);
+}
+.md blockquote {
+  border-left: 2px solid var(--e-yellow);
+  background: rgba(255, 201, 87, 0.06);
+  padding: 12px 20px;
+  margin: 20px 0;
+  color: var(--e-dim);
+}
+.md :where(code.e-inline) {
+  font-size: 0.85em;
+  color: var(--e-yellow);
+  border: 1px solid var(--e-line-soft);
+  padding: 1px 6px;
+  background: rgba(232, 241, 250, 0.05);
+}
+
+.e-code {
+  position: relative;
+  margin: 22px 0;
+}
+.e-code-copy {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  z-index: 10;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid var(--e-line-soft);
+  background: rgba(17, 49, 73, 0.9);
+  color: var(--e-dim);
+  padding: 2px 8px;
+  font-size: 10.5px;
+  font-family: var(--e-mono);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.e-code:hover .e-code-copy,
+.e-code-copy:focus-visible {
+  opacity: 1;
+}
+@media not (hover: hover) {
+  .e-code-copy {
+    opacity: 0.75;
+  }
+}
+.md pre.e-pre {
+  font-size: 13px;
+  line-height: 1.8;
+  color: #d9e6f4;
+  background: var(--e-deep);
+  border: 1px solid var(--e-line);
+  padding: 18px 20px;
+  overflow-x: auto;
+  margin: 0;
+}
+.md pre.e-pre code {
+  background: none;
+  padding: 0;
+}
+
+/* ---------- comments (inspection record) ---------- */
+.e-cmt {
+  border: 1px solid var(--e-line-soft);
+  background: var(--e-sheet);
+  margin: 12px 0;
+}
+.e-cmt-h {
+  display: flex;
+  gap: 14px;
+  padding: 7px 14px;
+  border-bottom: 1px dashed var(--e-line-soft);
+  font-size: 11px;
+  color: var(--e-dim);
+}
+.e-cmt-h .who {
+  color: var(--e-ink);
+}
+.e-cmt-b {
+  padding: 10px 14px;
+}
+.e-cmt-b p {
+  margin: 0 0 6px;
+  font-size: 13.5px;
+}
+.e-cmt-b p:last-child {
+  margin-bottom: 0;
+}
+.e-cmt-b :where(code) {
+  font-size: 0.85em;
+  color: var(--e-yellow);
+  border: 1px solid var(--e-line-soft);
+  padding: 0 5px;
+}
+.e-cmt-b blockquote {
+  border-left: 2px solid var(--e-line-soft);
+  padding-left: 12px;
+  color: var(--e-dim);
+}
+.e-cmt.reply {
+  margin-left: 44px;
+  border-left: 2px solid var(--e-yellow);
+}
+.e-cmt-ops {
+  display: flex;
+  gap: 14px;
+  padding: 0 14px 10px;
+  font-size: 11px;
+}
+.e-cmt-ops :where(button) {
+  color: var(--e-dim);
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font-family: var(--e-mono);
+  font-size: 11px;
+  padding: 0;
+  letter-spacing: 0.1em;
+}
+.e-cmt-ops :where(button):hover {
+  color: var(--e-yellow);
+}
+.e-cmt-ops .del:hover {
+  color: var(--e-red);
+}
+.e-cmt-form textarea {
+  width: 100%;
+  resize: vertical;
+  font-family: var(--e-mono);
+  font-size: 13px;
+  color: var(--e-ink);
+  background: var(--e-deep);
+  border: 1px solid var(--e-line-soft);
+  padding: 10px 13px;
+}
+.e-cmt-form textarea:focus {
+  outline: none;
+  border-color: var(--e-yellow);
+}
+.e-cmt-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 8px;
+}
+.e-hint {
+  font-size: 11px;
+  color: var(--e-faint);
+}
+.e-hint .err {
+  color: var(--e-red);
+  margin-left: 8px;
+}
+.e-err {
+  color: var(--e-red);
+  font-size: 12.5px;
+}
+
+/* ---------- projects ---------- */
+.e-dwg-row {
+  display: grid;
+  grid-template-columns: 100px 1fr auto;
+  gap: 26px;
+  padding: 20px 8px;
+  border-bottom: 1px solid var(--e-line-soft);
+  align-items: start;
+}
+.e-dwg-row .no {
+  font-size: 22px;
+  color: var(--e-faint);
+}
+.e-dwg-row .no .feat {
+  display: block;
+  font-size: 9px;
+  letter-spacing: 0.3em;
+  color: var(--e-yellow);
+  margin-top: 3px;
+}
+.e-dwg-row h2 {
+  font-size: 16px;
+}
+.e-dwg-row p {
+  color: var(--e-dim);
+  font-size: 13px;
+  margin-top: 6px;
+  max-width: 58ch;
+}
+.e-dwg-row .links {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 11.5px;
+  text-align: right;
+}
+@media (max-width: 760px) {
+  .e-dwg-row {
+    grid-template-columns: 56px 1fr;
+  }
+  .e-dwg-row .links {
+    flex-direction: row;
+    grid-column: 2;
+    text-align: left;
+    gap: 16px;
+  }
+}
+
+/* ---------- forms ---------- */
+.e-gate {
+  max-width: 460px;
+  margin: 0 auto;
+}
+.e-gate h1 {
+  font-size: 19px;
+  letter-spacing: 0.14em;
+}
+.e-gate .sub {
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  color: var(--e-dim);
+  margin: 8px 0 22px;
+}
+.e-field {
+  margin: 15px 0;
+}
+.e-field label {
+  display: block;
+  font-size: 10px;
+  letter-spacing: 0.3em;
+  color: var(--e-faint);
+  margin-bottom: 6px;
+}
+.e-input {
+  width: 100%;
+  font-family: var(--e-mono);
+  font-size: 13.5px;
+  color: var(--e-ink);
+  background: var(--e-deep);
+  border: 1px solid var(--e-line-soft);
+  padding: 10px 13px;
+}
+.e-input:focus {
+  outline: none;
+  border-color: var(--e-yellow);
+}
+.e-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 22px;
+}
+.e-err {
+  border: 1px dashed var(--e-red);
+  color: var(--e-red);
+  padding: 7px 13px;
+  font-size: 12px;
+  margin-top: 16px;
+}
+.e-aside {
+  margin-top: 18px;
+  font-size: 12px;
+  color: var(--e-dim);
+}
+.e-aside :where(a) {
+  color: var(--e-cyan);
+}
+
+/* ---------- 404 ---------- */
+.e-nf {
+  text-align: center;
+  padding: 60px 0 30px;
+}
+.e-nf .lbl {
+  font-size: 10.5px;
+  letter-spacing: 0.3em;
+  color: var(--e-faint);
+  margin-bottom: 8px;
+}
+.e-nf .code {
+  font-size: 76px;
+  font-weight: 700;
+  color: var(--e-faint);
+  letter-spacing: 0.1em;
+}
+.e-nf .code b {
+  color: var(--e-red);
+  font-weight: 700;
+}
+.e-nf p {
+  color: var(--e-dim);
+  margin: 12px 0 24px;
+  font-size: 12px;
+  letter-spacing: 0.24em;
+}

--- a/tests/e2e/admin-flow.spec.ts
+++ b/tests/e2e/admin-flow.spec.ts
@@ -19,7 +19,7 @@ test('admin can create a post that appears on the blog', async ({ page }) => {
   await page.locator('#password').fill(ADMIN_PASSWORD);
   await page.locator('form button[type="submit"]').click();
 
-  const loggedIn = page.getByRole('link', { name: /logout/i });
+  const loggedIn = page.getByTestId('nav-logout');
   try {
     await expect(loggedIn).toBeVisible({ timeout: 8000 });
   } catch {

--- a/tests/e2e/auth-logout.spec.ts
+++ b/tests/e2e/auth-logout.spec.ts
@@ -8,18 +8,20 @@ function createUniqueEmail(): string {
 test('signup then logout returns to guest header state', async ({ page }) => {
   await page.goto('/signup', { waitUntil: 'domcontentloaded' });
 
-  await page.getByLabel('Name').fill('E2E Logout');
-  await page.getByLabel('Email').fill(createUniqueEmail());
-  await page.getByLabel('Password').fill('Playwright!12345');
-  await page.getByRole('button', { name: 'Sign Up' }).click();
+  // Form anchors are theme-stable: field ids on /signup + the submit button.
+  // Header anchors use data-testid because each UX theme words them
+  // differently (login / 入会 / SIGN IN …).
+  await page.locator('#name').fill('E2E Logout');
+  await page.locator('#email').fill(createUniqueEmail());
+  await page.locator('#password').fill('Playwright!12345');
+  await page.locator('form button[type="submit"]').click();
 
   await page.waitForURL('**/blog');
-  await expect(page.getByRole('link', { name: 'Logout' })).toBeVisible();
+  await expect(page.getByTestId('nav-logout')).toBeVisible();
 
-  await page.getByRole('link', { name: 'Logout' }).click();
+  await page.getByTestId('nav-logout').click();
 
   await page.waitForURL('**/blog');
-  await expect(page.getByRole('link', { name: 'Login' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Sign Up' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Logout' })).toHaveCount(0);
+  await expect(page.getByTestId('nav-login')).toBeVisible();
+  await expect(page.getByTestId('nav-logout')).toHaveCount(0);
 });


### PR DESCRIPTION
## What — UX 改版方向 E「工程蓝图」落地

把原型 `prototypes/e-blueprint.html` 落到真实应用：整站是一叠工程图纸。

- **壳**：顶部图纸目录条（DWG NO. PP-NAV-000 / REV C / COVER·BLOG·PROJECTS），蓝底白线**坐标纸网格**背景
- **每个页面 = 一张图纸**：双线图框 + 四角黄色角标 + 右下角**图签标题栏**（DWG NO. / TITLE / SCALE / SHEET）
- **博客列表 = 材料清单 BOM**：ITEM / TITLE / ACCESS / DATE / MARK 五列，ACCESS 用彩色文字（PUBLIC/MEMBER/VIP/PASSWORD），分页显示 SHEET n/m
- **文章页 = 详图**：DWG NO. 按_slug_生成；二级标题自动编号 **NOTE 1 / NOTE 2**（CSS counter）；评论区 = 检验记录 INSPECTION RECORD
- **登录/注册/解锁 = 授权图纸**（STATUS: LOCKED 红字）；**404 = 无此图纸 №404**
- 蓝图蓝 #173E62 + 标注黄 #FFC957 + 信号青/红；等宽标注字体；暗色原生（隐藏主题切换）

## 技术说明

- 代码块用局部 CSS 强制 shiki 暗色 token（不依赖 html.dark，SSR 安全——实测 SSR 挂 .dark 会引发全站 hydration #418，已规避）
- Admin 后台沿用现有亮色样式（与蓝底有反差，但功能完整；如选此方向可后续统一）

## 验证

- [x] typecheck / lint（0 error）/ test 36 passed / build + 体积 **1025.6 KiB gzip**
- [x] 本地 dev 冒烟 7 页 + **生产构建 wrangler dev 实测**：无新增 hydration 错误（/login 与文章页存在 master 同款偶发 #418，与本主题无关）；NOTE 计数器、图签、坐标纸背景断言通过

> 7 个候选方向之一（A–G）。预览用 Workers Builds preview URL。