### PR TITLE
feat(web): apply neo-pop candy theme (UX direction F)

### DIFF
--- a/apps/web/src/components/comments.tsx
+++ b/apps/web/src/components/comments.tsx
@@ -20,14 +20,6 @@ type CommentsProps = {
 
 const PAGE_SIZE = 20;
 
-function getInitials(name: string): string {
-  const trimmed = name.trim();
-  if (!trimmed) {
-    return '?';
-  }
-  return trimmed.slice(0, 1).toUpperCase();
-}
-
 function formatRelative(iso: string): string {
   const then = new Date(iso).getTime();
   if (Number.isNaN(then)) {
@@ -54,24 +46,6 @@ function formatRelative(iso: string): string {
     day: 'numeric',
     year: 'numeric',
   });
-}
-
-function Avatar({ name, image }: { name: string; image: string | null }) {
-  if (image) {
-    return (
-      <img
-        src={image}
-        alt={name}
-        loading='lazy'
-        className='h-8 w-8 shrink-0 rounded-full bg-zinc-100 dark:bg-zinc-800'
-      />
-    );
-  }
-  return (
-    <div className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-zinc-200 text-xs font-semibold text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300'>
-      {getInitials(name)}
-    </div>
-  );
 }
 
 type ComposerProps = {
@@ -107,26 +81,25 @@ function Composer({
   }
 
   return (
-    <form onSubmit={handleSubmit} className='flex flex-col gap-2'>
+    <form onSubmit={handleSubmit} className='f-cmt-form'>
       <textarea
         value={body}
         onChange={(event) => setBody(event.target.value)}
         placeholder={placeholder}
         rows={compact ? 2 : 3}
         maxLength={2000}
-        className='w-full resize-y rounded-md border border-zinc-300 bg-transparent px-3 py-2 text-sm outline-none transition-colors focus:border-zinc-400 dark:border-zinc-600 dark:focus:border-zinc-400'
       />
-      <div className='flex items-center justify-between gap-2'>
-        <span className='text-xs opacity-50'>
+      <div className='f-cmt-foot'>
+        <span className='f-hint'>
           {remaining < 200 ? `${remaining} 字剩余` : '支持 Markdown'}
-          {error ? <span className='ml-2 text-red-500'>{error}</span> : null}
+          {error ? <span className='err'>{error}</span> : null}
         </span>
         <button
           type='submit'
           disabled={submitting || !body.trim()}
-          className='rounded-md bg-black px-3 py-1 text-xs font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-neutral-900'
+          className='f-btn f-btn-fill'
         >
-          {submitting ? '发送中…' : '发送'}
+          {submitting ? '发送中…' : '评论！'}
         </button>
       </div>
     </form>
@@ -191,7 +164,7 @@ function CommentItem({
       ) : null}
 
       {thread.replies.length > 0 ? (
-        <ul className='ml-10 flex flex-col gap-2 border-l border-zinc-200 pl-4 dark:border-zinc-700'>
+        <ul className='ml-10 flex flex-col gap-3'>
           {thread.replies.map((reply) => {
             const replyCanAct =
               sessionUser != null &&
@@ -233,49 +206,43 @@ function CommentView({
   onDelete,
 }: CommentViewProps) {
   return (
-    <div className='flex gap-3'>
-      <Avatar name={comment.author.name} image={comment.author.image} />
-      <div className='min-w-0 flex-1'>
-        <div className='flex flex-wrap items-center gap-x-2 gap-y-0.5'>
-          <span className='text-sm font-semibold'>{comment.author.name}</span>
-          {comment.author.role === 'admin' ? (
-            <span className='rounded bg-zinc-900 px-1.5 py-0.5 text-[10px] font-semibold text-white dark:bg-white dark:text-zinc-900'>
-              Author
-            </span>
-          ) : null}
-          {comment.status !== 'visible' ? (
-            <span className='rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'>
-              {comment.status}
-            </span>
-          ) : null}
-          <span className='text-xs opacity-50'>
-            {formatRelative(comment.createdAt)}
+    <div
+      className={
+        comment.parentId !== null
+          ? 'f-card f-cmt-card reply'
+          : 'f-card f-cmt-card'
+      }
+    >
+      <div className='f-cmt-h'>
+        <span
+          className={comment.author.role === 'admin' ? 'who author' : 'who'}
+        >
+          {comment.author.name}
+        </span>
+        {comment.status !== 'visible' ? (
+          <span className='f-sticker' style={{ background: '#FF90C2' }}>
+            {comment.status}
           </span>
-        </div>
-        <div className='mt-1'>
-          <CommentMarkdown content={comment.body} />
-        </div>
-        <div className='mt-1 flex gap-3 text-xs'>
+        ) : null}
+        <span className='when'>{formatRelative(comment.createdAt)}</span>
+      </div>
+      <div className='f-cmt-b'>
+        <CommentMarkdown content={comment.body} />
+      </div>
+      {(canReply && onReply) || canAct ? (
+        <div className='f-cmt-ops'>
           {canReply && onReply ? (
-            <button
-              type='button'
-              onClick={onReply}
-              className='opacity-50 transition-opacity hover:opacity-100'
-            >
+            <button type='button' onClick={onReply}>
               回复
             </button>
           ) : null}
           {canAct ? (
-            <button
-              type='button'
-              onClick={() => onDelete()}
-              className='text-red-500/70 transition-colors hover:text-red-500'
-            >
+            <button type='button' onClick={() => onDelete()}>
               删除
             </button>
           ) : null}
         </div>
-      </div>
+      ) : null}
     </div>
   );
 }
@@ -375,11 +342,7 @@ export function Comments({
   }
 
   return (
-    <section className='mt-12'>
-      <h2 className='mb-4 text-lg font-black'>
-        评论 {total > 0 ? <span className='opacity-50'>({total})</span> : null}
-      </h2>
-
+    <section className='mt-2'>
       {sessionUser ? (
         <div className='mb-6'>
           <Composer
@@ -389,37 +352,36 @@ export function Comments({
           />
         </div>
       ) : (
-        <p className='mb-6 text-sm opacity-60'>
-          <Link to='/login' className='underline hover:opacity-100'>
+        <p className='f-hint mb-6'>
+          <Link to='/login' style={{ color: 'var(--f-violet)' }}>
             登录
           </Link>{' '}
           后即可评论。
         </p>
       )}
 
-      {topError ? (
-        <p className='mb-4 text-sm text-red-500'>{topError}</p>
-      ) : null}
+      {topError ? <p className='f-err mb-4'>{topError}</p> : null}
 
       {threads.length === 0 ? (
-        <p className='py-8 text-center text-sm opacity-50'>
-          还没有评论，来抢沙发。
-        </p>
+        <p className='f-hint py-8 text-center'>还没有评论，来抢沙发！</p>
       ) : (
-        <ul className='flex flex-col gap-5'>
-          {threads.map((thread) => (
-            <CommentItem
-              key={thread.id}
-              thread={thread}
-              sessionUser={sessionUser}
-              onReply={handleReply}
-              onDelete={handleDelete}
-              replyingTo={replyingTo}
-              setReplyingTo={setReplyingTo}
-              replySubmitting={replySubmitting}
-            />
-          ))}
-        </ul>
+        <>
+          <p className='f-hint mb-3'>TOTAL — {total}</p>
+          <ul className='flex flex-col gap-3'>
+            {threads.map((thread) => (
+              <CommentItem
+                key={thread.id}
+                thread={thread}
+                sessionUser={sessionUser}
+                onReply={handleReply}
+                onDelete={handleDelete}
+                replyingTo={replyingTo}
+                setReplyingTo={setReplyingTo}
+                replySubmitting={replySubmitting}
+              />
+            ))}
+          </ul>
+        </>
       )}
 
       {hasMore ? (
@@ -428,9 +390,9 @@ export function Comments({
             type='button'
             onClick={handleLoadMore}
             disabled={loadingMore}
-            className='text-sm opacity-60 transition-opacity hover:opacity-100 disabled:opacity-40'
+            className='f-btn'
           >
-            {loadingMore ? '加载中…' : '加载更多'}
+            {loadingMore ? '加载中…' : '加载更多 ↓'}
           </button>
         </div>
       ) : null}

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -1,9 +1,12 @@
+import { Link } from '@tanstack/react-router';
+
 export function Footer() {
   return (
-    <footer className='p-6 text-center'>
-      © {new Date().getFullYear()}, Built with{' '}
-      <a className='text-blue-500' href='https://tanstack.com/start/latest'>
-        TanStack Start
+    <footer className='f-foot'>
+      © {new Date().getFullYear()} PERFECTPAN · <Link to='/blog'>BLOG!</Link> ·{' '}
+      <a href='/rss.xml'>RSS ↗</a> ·{' '}
+      <a href='https://github.com/PerfectPan' target='_blank' rel='noreferrer'>
+        GITHUB ↗
       </a>
     </footer>
   );

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -60,10 +60,18 @@ export function Header() {
             </Link>
           ) : (
             <>
-              <Link to='/login' className='opacity-70 hover:opacity-100'>
+              <Link
+                to='/login'
+                data-testid='nav-login'
+                className='opacity-70 hover:opacity-100'
+              >
                 Login
               </Link>
-              <Link to='/signup' className='opacity-70 hover:opacity-100'>
+              <Link
+                to='/signup'
+                data-testid='nav-signup'
+                className='opacity-70 hover:opacity-100'
+              >
                 Sign Up
               </Link>
             </>

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -53,6 +53,7 @@ export function Header() {
           {sessionUser ? (
             <Link
               to='/logout'
+              data-testid='nav-logout'
               className='inline-flex items-center gap-1 rounded-md border border-slate-300 px-2 py-1 text-sm opacity-85 transition-opacity hover:opacity-100 dark:border-slate-600'
             >
               <LogOut size={14} />

--- a/apps/web/src/components/layout.tsx
+++ b/apps/web/src/components/layout.tsx
@@ -7,21 +7,17 @@ type AppLayoutProps = {
 };
 
 /**
- * App shell. The header sits OUTSIDE the scroll container (`main`), so page
- * overscroll only rubber-bands the content — the pinned header never moves
- * (no macOS "fixed header drags on overscroll"). Window doesn't scroll; route
- * scroll reset/restore for `main` is handled by TanStack via
- * `scrollToTopSelectors: ['main']` in router.tsx.
+ * App shell (neo-pop theme). Header sits OUTSIDE the scroll container
+ * (`main`). Window doesn't scroll; route scroll reset/restore for `main` is
+ * handled by TanStack via `scrollToTopSelectors: ['main']` in router.tsx.
  */
 export function AppLayout({ children }: AppLayoutProps) {
   return (
-    <div className='flex h-dvh flex-col'>
+    <div className='f-shell'>
       <Header />
-      <main className='flex-1 overflow-y-auto'>
+      <main className='f-main'>
         <div className='flex min-h-full flex-col'>
-          <div className='flex flex-grow items-center justify-center px-6 *:min-h-64 *:min-w-64'>
-            {children}
-          </div>
+          <div className='flex-grow'>{children}</div>
           <Footer />
         </div>
       </main>

--- a/apps/web/src/components/markdown.tsx
+++ b/apps/web/src/components/markdown.tsx
@@ -78,20 +78,17 @@ function CodeBlock({ children }: { children?: ReactNode }) {
   }, []);
 
   return (
-    <div className='group relative mb-2'>
+    <div className='f-code group relative'>
       <button
         type='button'
         onClick={onCopy}
         aria-label='Copy code'
-        className='absolute right-2 top-2 z-10 inline-flex items-center gap-1 rounded border border-slate-300 bg-white/70 px-1.5 py-0.5 text-xs opacity-0 backdrop-blur transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100 hover-none:opacity-70 dark:border-slate-700 dark:bg-slate-900/70'
+        className='f-code-copy'
       >
         {copied ? <Check size={12} /> : <Copy size={12} />}
         {copied ? 'Copied' : 'Copy'}
       </button>
-      <pre
-        ref={preRef}
-        className='shiki w-full overflow-x-auto whitespace-pre-wrap rounded-md bg-zinc-50 p-4 dark:bg-shiki-dark'
-      >
+      <pre ref={preRef} className='shiki f-pre w-full overflow-x-auto'>
         {children}
       </pre>
     </div>
@@ -112,7 +109,7 @@ export function Markdown({ content }: MarkdownProps) {
   }, []);
 
   return (
-    <article>
+    <article className='md'>
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkMath]}
         rehypePlugins={[
@@ -133,10 +130,7 @@ export function Markdown({ content }: MarkdownProps) {
             const id = typeof children === 'string' ? children : '';
 
             return (
-              <h2
-                id={id}
-                className='mb-6 mt-14 scroll-mt-20 text-balance text-2xl leading-none font-black first:mt-0'
-              >
+              <h2 id={id} className='scroll-mt-20'>
                 <a
                   href={`#${id}`}
                   onClick={(event) => {
@@ -150,24 +144,21 @@ export function Markdown({ content }: MarkdownProps) {
               </h2>
             );
           },
-          p: ({ children }) => <p className='mb-6 leading-7'>{children}</p>,
+          p: ({ children }) => <p>{children}</p>,
           a: ({ href, children }) => (
-            <a
-              href={href}
-              className='text-blue-700/80 transition-colors duration-300 ease-in-out hover:text-blue-700'
-              target='_blank'
-              rel='noreferrer'
-            >
+            <a href={href} target='_blank' rel='noreferrer'>
               {children}
             </a>
           ),
-          strong: ({ children }) => (
-            <b className='font-extrabold'>{children}</b>
-          ),
-          ul: ({ children }) => (
-            <ul className='mb-4 ml-4 list-disc'>{children}</ul>
-          ),
+          strong: ({ children }) => <b className='font-bold'>{children}</b>,
+          ul: ({ children }) => <ul>{children}</ul>,
           pre: ({ children }) => <CodeBlock>{children}</CodeBlock>,
+          code: ({ className, children }) =>
+            /language-/.test(className ?? '') ? (
+              <code className={className}>{children}</code>
+            ) : (
+              <code className='f-inline'>{children}</code>
+            ),
         }}
       >
         {content}

--- a/apps/web/src/lib/tag-color.ts
+++ b/apps/web/src/lib/tag-color.ts
@@ -1,0 +1,17 @@
+/** Deterministic sticker color for an arbitrary tag (neo-pop palette). */
+const STICKER_COLORS = [
+  '#FFDE59',
+  '#FF6B35',
+  '#7C5CFF',
+  '#FF90C2',
+  '#21CBA8',
+  '#57B8FF',
+];
+
+export function tagColor(tag: string): string {
+  let hash = 0;
+  for (let i = 0; i < tag.length; i += 1) {
+    hash = (hash * 31 + tag.charCodeAt(i)) % 997;
+  }
+  return STICKER_COLORS[hash % STICKER_COLORS.length];
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -26,7 +26,7 @@ export const Route = createRootRoute({
       },
       {
         name: 'theme-color',
-        content: '#000000',
+        content: '#FFFDF4',
       },
     ],
     links: [
@@ -38,12 +38,22 @@ export const Route = createRootRoute({
   errorComponent: ({ error }) => (
     <RootDocument>
       <AppLayout>
-        <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-          <h2 className='mb-4 text-3xl'>Request Failed</h2>
-          <p className='mb-4 opacity-70'>{String(error)}</p>
-          <Link to='/blog' className='opacity-70 hover:opacity-100'>
-            Back to blog
-          </Link>
+        <div className='f-page'>
+          <div className='f-nf'>
+            <span
+              className='f-sticker'
+              style={{ background: '#FF6B35', color: '#fff' }}
+            >
+              REQUEST FAILED
+            </span>
+            <div className='code'>
+              5<b>0</b>0
+            </div>
+            <p>{String(error)}</p>
+            <Link to='/blog' className='f-btn f-btn-fill'>
+              ← 回到博客
+            </Link>
+          </div>
         </div>
       </AppLayout>
     </RootDocument>
@@ -51,12 +61,26 @@ export const Route = createRootRoute({
   notFoundComponent: () => (
     <RootDocument>
       <AppLayout>
-        <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-          <h2 className='mb-4 text-3xl'>404 Not Found</h2>
-          <p className='mb-4 opacity-70'>你闯入了无人之境...</p>
-          <Link to='/blog' className='opacity-70 hover:opacity-100'>
-            Back to blog
-          </Link>
+        <div className='f-page'>
+          <div className='f-nf'>
+            <span
+              className='f-sticker'
+              style={{
+                background: '#FF6B35',
+                color: '#fff',
+                transform: 'rotate(-2deg)',
+              }}
+            >
+              PAGE NOT FOUND
+            </span>
+            <div className='code'>
+              4<b>0</b>4
+            </div>
+            <p>你闯入了无人之境……</p>
+            <Link to='/blog' className='f-btn f-btn-fill'>
+              ← 回到博客
+            </Link>
+          </div>
         </div>
       </AppLayout>
     </RootDocument>

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -1,10 +1,5 @@
 import { type CommentThread, canAccessVisibility } from '@blog/shared';
-import {
-  createFileRoute,
-  Link,
-  notFound,
-  redirect,
-} from '@tanstack/react-router';
+import { createFileRoute, notFound, redirect } from '@tanstack/react-router';
 import { Comments } from '../../components/comments.js';
 import { Markdown } from '../../components/markdown.js';
 import { getBlogPostServerFn } from '../../lib/blog-service.js';
@@ -70,23 +65,33 @@ function BlogDetailPage() {
     return null;
   }
 
-  const date = new Date(post.publishedAt).toLocaleDateString('en-US', {
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
-  });
+  const date = new Date(post.publishedAt).toISOString().slice(0, 10);
 
   return (
-    <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <div className='m-auto mb-8 flex flex-col gap-2'>
-        <div className='text-3xl font-black'>{post.title}</div>
-        <div className='opacity-60'>{date}</div>
+    <div className='f-page'>
+      <div className='f-page-head' style={{ paddingBottom: 14 }}>
+        <span className='f-banner'>POST</span>
       </div>
-      <Markdown content={post.contentMdx} />
-      <Link to='/blog' className='mt-4 inline-block'>
-        <span className='opacity-70'>&gt;&nbsp;&nbsp;&nbsp;</span>
-        <span className='underline opacity-70 hover:opacity-100'>cd ..</span>
-      </Link>
+      <article className='f-card f-art'>
+        <h1>{post.title}</h1>
+        <div className='f-meta'>
+          <span className='f-sticker'>{date}</span>
+          <span
+            className='f-sticker'
+            style={{
+              background: post.visibility === 'public' ? '#21CBA8' : '#FF6B35',
+              color: post.visibility === 'public' ? '#141414' : '#fff',
+            }}
+          >
+            {post.visibility.toUpperCase()}
+          </span>
+        </div>
+        <Markdown content={post.contentMdx} />
+      </article>
+
+      <div className='f-page-head' style={{ paddingBottom: 10 }}>
+        <span className='f-banner'>COMMENTS · {data.comments.total}</span>
+      </div>
       <Comments
         key={post.slug}
         slug={post.slug}

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -1,9 +1,9 @@
 import type { PostSummary, SessionUser } from '@blog/shared';
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useEffect } from 'react';
 import { z } from 'zod';
 import { getBlogListServerFn } from '../../lib/blog-service.js';
+import { tagColor } from '../../lib/tag-color.js';
 
 type BlogGroup = {
   year: string;
@@ -49,6 +49,17 @@ function getDevScopeHint(sessionUser: SessionUser | null | undefined): string {
   return '当前身份：member；可见范围：public/member';
 }
 
+const VIS_STICKER: Record<
+  PostSummary['visibility'],
+  { text: string; bg: string }
+> = {
+  public: { text: '', bg: '' },
+  member: { text: 'MEMBER', bg: '#FF90C2' },
+  vip: { text: 'VIP', bg: '#7C5CFF' },
+  admin: { text: 'ADMIN', bg: '#141414' },
+  password: { text: '🔒 密码', bg: '#FF6B35' },
+};
+
 export const Route = createFileRoute('/blog/')({
   head: () => ({
     meta: [
@@ -77,88 +88,86 @@ function BlogListPage() {
   const devScopeHint = getDevScopeHint(data.sessionUser);
 
   // Conventional blog pagination: the page scrolls naturally; jump back to the
-  // top on each page change so the new page starts at its first post. (Without
-  // this, clicking "next" while scrolled to the bottom leaves the reader past a
-  // shorter page — the original "bounce".)
+  // top on each page change so the new page starts at its first post.
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-run on page change, value unused in body on purpose
   useEffect(() => {
     document.querySelector('main')?.scrollTo({ top: 0 });
   }, [data.page]);
 
   return (
-    <div className='mx-auto flex w-full max-w-[80ch] flex-col gap-8 self-start pt-8'>
-      <div className='w-full'>
-        {showDevHint ? (
-          <div className='mb-8 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900'>
-            {devScopeHint}
-          </div>
-        ) : null}
+    <div className='f-page'>
+      <div className='f-page-head'>
+        <span className='f-banner'>ALL POSTS</span>
+        <h1>博客</h1>
+      </div>
+
+      {showDevHint ? <div className='f-devhint'>{devScopeHint}</div> : null}
+
+      <div className='f-card f-list-card'>
         {blogGroups.map((group) => (
           <div key={group.year}>
-            <div className='mb-4 text-3xl'>{group.year}</div>
-            {group.blogs.map((blog: PostSummary) => (
-              <div
+            <div className='f-yr'>
+              <span className='pill'>{group.year}</span>
+            </div>
+            {group.blogs.map((blog: PostSummary, index: number) => (
+              <Link
                 key={blog.slug}
-                className='mt-2 mb-6 opacity-70 hover:opacity-100'
+                to='/blog/$slug'
+                params={{ slug: blog.slug }}
+                className='f-post-row'
               >
-                <Link
-                  to='/blog/$slug'
-                  params={{ slug: blog.slug }}
-                  className='flex items-center gap-2'
-                >
-                  <span className='text-lg leading-[1.2em]'>{blog.title}</span>
-                  <span className='text-sm opacity-50'>
-                    {new Date(blog.publishedAt).toLocaleDateString('en-US', {
-                      month: 'short',
-                      day: 'numeric',
-                    })}
-                  </span>
-                </Link>
-              </div>
+                <span className='no'>
+                  {String(data.total - ((data.page - 1) * 10 + index)).padStart(
+                    3,
+                    '0',
+                  )}
+                </span>
+                <span className='t'>{blog.title}</span>
+                <span className='tags'>
+                  {blog.visibility !== 'public' ? (
+                    <span
+                      className='f-sticker'
+                      style={{ background: VIS_STICKER[blog.visibility].bg }}
+                    >
+                      {VIS_STICKER[blog.visibility].text}
+                    </span>
+                  ) : null}
+                  {blog.tags.map((tag: string) => (
+                    <span
+                      key={tag}
+                      className='f-sticker'
+                      style={{ background: tagColor(tag) }}
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </span>
+                <span className='d'>
+                  {new Date(blog.publishedAt).toISOString().slice(5, 10)}
+                </span>
+              </Link>
             ))}
           </div>
         ))}
       </div>
+
       {data.totalPages > 1 ? (
-        <nav
-          className='flex w-full items-center justify-center gap-4 text-sm sm:gap-6'
-          aria-label='Pagination'
-        >
+        <nav className='f-pager' aria-label='Pagination'>
           {data.page > 1 ? (
-            <Link
-              to='/blog'
-              search={{ page: data.page - 1 }}
-              className='inline-flex items-center gap-1 opacity-60 hover:opacity-100'
-            >
-              <ChevronLeft size={14} /> prev
+            <Link className='f-btn' to='/blog' search={{ page: data.page - 1 }}>
+              ← PREV
             </Link>
-          ) : (
-            <span className='inline-flex items-center gap-1 opacity-30'>
-              <ChevronLeft size={14} /> prev
-            </span>
-          )}
-          <span className='opacity-60'>
-            page {data.page} / {data.totalPages}
+          ) : null}
+          <span className='f-btn cur'>
+            {data.page} / {data.totalPages}
           </span>
           {data.page < data.totalPages ? (
-            <Link
-              to='/blog'
-              search={{ page: data.page + 1 }}
-              className='inline-flex items-center gap-1 opacity-60 hover:opacity-100'
-            >
-              next <ChevronRight size={14} />
+            <Link className='f-btn' to='/blog' search={{ page: data.page + 1 }}>
+              NEXT →
             </Link>
-          ) : (
-            <span className='inline-flex items-center gap-1 opacity-30'>
-              next <ChevronRight size={14} />
-            </span>
-          )}
+          ) : null}
         </nav>
       ) : null}
-      <Link to='/' className='mt-4 inline-block'>
-        <span className='opacity-70'>&gt;&nbsp;&nbsp;&nbsp;</span>
-        <span className='underline opacity-70 hover:opacity-100'>cd ..</span>
-      </Link>
     </div>
   );
 }

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,25 +1,72 @@
+import type { PostSummary } from '@blog/shared';
 import { createFileRoute, Link } from '@tanstack/react-router';
+import { getBlogListServerFn } from '../lib/blog-service.js';
+import { PROJECTS } from '../lib/projects.js';
 
 export const Route = createFileRoute('/')({
   head: () => ({
     meta: [{ title: "Home | PerfectPan's Blog" }],
   }),
+  loader: async () => {
+    // Guest-scoped first page powers the LATEST panel.
+    return getBlogListServerFn({ data: { page: 1 } });
+  },
   component: HomePage,
 });
 
 function HomePage() {
+  const data = Route.useLoaderData();
+  const latest = data.posts.slice(0, 4);
+
   return (
-    <div className='flex flex-col items-center'>
-      <img className='m-0' src='/images/xm.jpg' alt='' />
-      <div className='mt-8 text-[2.5rem] font-black'>
-        是个什么都不会的废物.jpg
-      </div>
-      <div className='flex w-full justify-around'>
-        <div className='mx-1 mt-8 flex-1 rounded-md bg-slate-100 text-center font-semibold uppercase tracking-wider leading-[5rem] shadow-md transition-shadow hover:shadow-lg dark:bg-wash-dark dark:text-white dark:opacity-80'>
-          <Link to='/blog'>Blog</Link>
+    <div className='f-page'>
+      <div className='f-hero'>
+        <span className='f-sticker float'>EST. 2019 ★</span>
+        <h1>
+          <span className='stroke'>PERFECT</span>PAN
+          <span className='dot'>!</span>
+        </h1>
+        <p>
+          是个什么都不会的废物.jpg —— 但博客还在更新。算法题解、TypeScript
+          类型体操、Cloudflare $0/月 工程实践，全在这。
+        </p>
+        <div className='cta'>
+          <Link to='/blog' className='f-btn f-btn-fill'>
+            读博客 →
+          </Link>
+          <Link to='/projects' className='f-btn'>
+            看项目 →
+          </Link>
         </div>
-        <div className='mx-1 mt-8 flex-1 rounded-md bg-slate-100 text-center font-semibold uppercase tracking-wider leading-[5rem] shadow-md transition-shadow hover:shadow-lg dark:bg-wash-dark dark:text-white dark:opacity-80'>
-          <Link to='/projects'>Projects</Link>
+      </div>
+      <div className='f-home-grid'>
+        <div className='f-card f-lift f-panel'>
+          <h3>LATEST 最新</h3>
+          {latest.map((post: PostSummary, index: number) => (
+            <div className='f-row' key={post.slug}>
+              <span className='no'>
+                {String(data.total - index).padStart(3, '0')}
+              </span>
+              <Link className='t' to='/blog/$slug' params={{ slug: post.slug }}>
+                {post.title}
+              </Link>
+            </div>
+          ))}
+        </div>
+        <div className='f-card f-lift f-panel'>
+          <h3 className='o'>DATA 数据</h3>
+          <div className='f-stat'>
+            <b className='vio'>{data.total}</b>
+            <span>篇文章</span>
+          </div>
+          <div className='f-stat'>
+            <b className='org'>{PROJECTS.length}</b>
+            <span>个开源项目</span>
+          </div>
+          <div className='f-stat'>
+            <b>$0</b>
+            <span>每月托管费</span>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -34,96 +34,103 @@ function LoginPage() {
 
   if (sessionData?.user?.id || isSessionPending) {
     return (
-      <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-        <p className='opacity-70'>Checking session...</p>
-      </section>
+      <div className='f-page'>
+        <p className='f-hint pt-8 text-center'>Checking session…</p>
+      </div>
     );
   }
 
   return (
-    <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>登录</h1>
-      <p className='mb-6 opacity-70'>支持邮箱密码和 GitHub OAuth。</p>
+    <div className='f-page'>
+      <div className='f-gate'>
+        <div className='f-card f-lift f-gate-card'>
+          <span
+            className='f-sticker badge-top'
+            style={{ background: '#FF6B35', color: '#fff' }}
+          >
+            LOGIN
+          </span>
+          <h1>登录</h1>
+          <p className='sub'>会友可读「会员可读」文章 · 也支持 GitHub</p>
+          <form
+            method='post'
+            onSubmit={(event) => {
+              event.preventDefault();
+              setError(null);
+              startTransition(async () => {
+                const result = await authClient.signIn.email({
+                  email,
+                  password,
+                  callbackURL: '/blog',
+                });
 
-      {error ? (
-        <p role='alert' className='mb-4 text-sm text-red-700 dark:text-red-300'>
-          {error}
-        </p>
-      ) : null}
+                if (result.error) {
+                  setError(result.error.message ?? '登录失败');
+                  return;
+                }
 
-      <form
-        className='grid max-w-[420px] gap-3'
-        method='post'
-        onSubmit={(event) => {
-          event.preventDefault();
-          setError(null);
-          startTransition(async () => {
-            const result = await authClient.signIn.email({
-              email,
-              password,
-              callbackURL: '/blog',
-            });
-
-            if (result.error) {
-              setError(result.error.message ?? '登录失败');
-              return;
-            }
-
-            navigate({ to: '/blog' });
-          });
-        }}
-      >
-        <label htmlFor='email' className='font-semibold'>
-          Email
-        </label>
-        <input
-          id='email'
-          name='email'
-          type='email'
-          required
-          autoComplete='email'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-        />
-        <label htmlFor='password' className='font-semibold'>
-          Password
-        </label>
-        <input
-          id='password'
-          name='password'
-          type='password'
-          required
-          autoComplete='current-password'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={password}
-          onChange={(event) => setPassword(event.target.value)}
-        />
-        <button
-          type='submit'
-          className='rounded-md bg-black px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90 dark:bg-neutral-900'
-          disabled={isPending}
-        >
-          {isPending ? 'Signing in...' : 'Sign In'}
-        </button>
-      </form>
-
-      <button
-        type='button'
-        className='mt-3 rounded-md border border-slate-300 px-4 py-2 font-semibold transition-colors hover:bg-gray-100 dark:border-slate-700 dark:hover:bg-slate-800'
-        onClick={async () => {
-          setError(null);
-          const result = await authClient.signIn.social({
-            provider: 'github',
-            callbackURL: '/blog',
-          });
-          if (result.error) {
-            setError(result.error.message ?? 'GitHub 登录失败');
-          }
-        }}
-      >
-        Continue with GitHub
-      </button>
-    </section>
+                navigate({ to: '/blog' });
+              });
+            }}
+          >
+            <div className='f-field'>
+              <label htmlFor='email'>邮箱 EMAIL</label>
+              <input
+                id='email'
+                name='email'
+                type='email'
+                required
+                autoComplete='email'
+                className='f-input'
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+              />
+            </div>
+            <div className='f-field'>
+              <label htmlFor='password'>密码 PASSWORD</label>
+              <input
+                id='password'
+                name='password'
+                type='password'
+                required
+                autoComplete='current-password'
+                className='f-input'
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+            </div>
+            <div className='actions'>
+              <button
+                type='submit'
+                className='f-btn f-btn-fill'
+                disabled={isPending}
+              >
+                {isPending ? '登入中…' : '登入 →'}
+              </button>
+              <button
+                type='button'
+                className='f-btn'
+                onClick={async () => {
+                  setError(null);
+                  const result = await authClient.signIn.social({
+                    provider: 'github',
+                    callbackURL: '/blog',
+                  });
+                  if (result.error) {
+                    setError(result.error.message ?? 'GitHub 登录失败');
+                  }
+                }}
+              >
+                GitHub
+              </button>
+            </div>
+            {error ? <p className='f-err'>{error}！</p> : null}
+          </form>
+          <p className='aside'>
+            还没账号？ <a href='/signup'>注册一个 →</a>
+          </p>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/routes/projects.tsx
+++ b/apps/web/src/routes/projects.tsx
@@ -1,6 +1,6 @@
-import { createFileRoute, Link } from '@tanstack/react-router';
-import { ExternalLink, Github } from 'lucide-react';
+import { createFileRoute } from '@tanstack/react-router';
 import { PROJECTS, type Project } from '../lib/projects.js';
+import { tagColor } from '../lib/tag-color.js';
 
 export const Route = createFileRoute('/projects')({
   head: () => ({
@@ -25,67 +25,60 @@ function ProjectsPage() {
   const projects = sortProjects(PROJECTS);
 
   return (
-    <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>Projects</h1>
-      <p className='mb-8 opacity-70'>我做过的一些东西，按需更新。</p>
-
-      <div className='grid gap-4 sm:grid-cols-2'>
+    <div className='f-page'>
+      <div className='f-page-head'>
+        <span className='f-banner'>PROJECTS</span>
+        <h1>项目</h1>
+      </div>
+      <div className='f-proj-grid'>
         {projects.map((project) => (
-          <article
-            key={project.name}
-            className='flex flex-col rounded-lg border border-slate-200 bg-white/60 p-5 transition-shadow hover:shadow-md dark:border-slate-700 dark:bg-wash-dark'
-          >
-            <div className='mb-1 flex items-center gap-2'>
-              <h2 className='text-lg font-semibold'>{project.name}</h2>
+          <div className='f-card f-lift f-proj-card' key={project.name}>
+            <h2>
+              {project.name}
               {project.featured ? (
-                <span className='rounded-full bg-black px-2 py-[2px] text-[10px] font-semibold text-white dark:bg-neutral-100 dark:text-neutral-900'>
-                  FEATURED
+                <span
+                  className='f-sticker'
+                  style={{ background: '#FFDE59', transform: 'rotate(2deg)' }}
+                >
+                  ★ FEATURED
                 </span>
               ) : null}
-            </div>
-            <p className='mb-4 flex-grow text-sm opacity-70'>
-              {project.description}
-            </p>
-            <div className='mb-4 flex flex-wrap gap-1.5'>
+            </h2>
+            <p>{project.description}</p>
+            <div className='tags'>
               {project.tags.map((tag) => (
                 <span
                   key={tag}
-                  className='rounded-md border border-slate-200 px-2 py-[2px] text-[11px] opacity-70 dark:border-slate-700'
+                  className='f-sticker'
+                  style={{ background: tagColor(tag) }}
                 >
                   {tag}
                 </span>
               ))}
             </div>
-            <div className='flex items-center gap-4 text-sm'>
+            <div className='links'>
               <a
+                className='f-btn'
                 href={project.repo}
                 target='_blank'
                 rel='noreferrer'
-                className='inline-flex items-center gap-1 opacity-70 hover:opacity-100'
               >
-                <Github size={15} />
-                Code
+                CODE ↗
               </a>
               {project.demo ? (
                 <a
+                  className='f-btn f-btn-o'
                   href={project.demo}
                   target='_blank'
                   rel='noreferrer'
-                  className='inline-flex items-center gap-1 opacity-70 hover:opacity-100'
                 >
-                  <ExternalLink size={15} />
-                  Demo
+                  DEMO ↗
                 </a>
               ) : null}
             </div>
-          </article>
+          </div>
         ))}
       </div>
-
-      <Link to='/' className='mt-8 inline-block'>
-        <span className='opacity-70'>&gt;&nbsp;&nbsp;&nbsp;</span>
-        <span className='underline opacity-70 hover:opacity-100'>cd ..</span>
-      </Link>
     </div>
   );
 }

--- a/apps/web/src/routes/signup.tsx
+++ b/apps/web/src/routes/signup.tsx
@@ -35,93 +35,114 @@ function SignUpPage() {
 
   if (sessionData?.user?.id || isSessionPending) {
     return (
-      <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-        <p className='opacity-70'>Checking session...</p>
-      </section>
+      <div className='f-page'>
+        <p className='f-hint pt-8 text-center'>Checking session…</p>
+      </div>
     );
   }
 
   return (
-    <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>注册</h1>
-      <p className='mb-6 opacity-70'>注册后默认角色为 member，可在后台升权。</p>
+    <div className='f-page'>
+      <div className='f-gate'>
+        <div className='f-card f-lift f-gate-card'>
+          <span
+            className='f-sticker badge-top'
+            style={{ background: '#7C5CFF', color: '#fff' }}
+          >
+            SIGN UP
+          </span>
+          <h1>注册</h1>
+          <p className='sub'>注册即成为 member</p>
+          <form
+            method='post'
+            onSubmit={(event) => {
+              event.preventDefault();
+              setError(null);
+              startTransition(async () => {
+                const result = await authClient.signUp.email({
+                  email,
+                  password,
+                  name,
+                  callbackURL: '/blog',
+                });
 
-      {error ? (
-        <p role='alert' className='mb-4 text-sm text-red-700 dark:text-red-300'>
-          {error}
-        </p>
-      ) : null}
+                if (result.error) {
+                  setError(result.error.message ?? '注册失败');
+                  return;
+                }
 
-      <form
-        className='grid max-w-[420px] gap-3'
-        method='post'
-        onSubmit={(event) => {
-          event.preventDefault();
-          setError(null);
-          startTransition(async () => {
-            const result = await authClient.signUp.email({
-              email,
-              password,
-              name,
-              callbackURL: '/blog',
-            });
-
-            if (result.error) {
-              setError(result.error.message ?? '注册失败');
-              return;
-            }
-
-            navigate({ to: '/blog' });
-          });
-        }}
-      >
-        <label htmlFor='name' className='font-semibold'>
-          Name
-        </label>
-        <input
-          id='name'
-          name='name'
-          type='text'
-          required
-          autoComplete='name'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={name}
-          onChange={(event) => setName(event.target.value)}
-        />
-        <label htmlFor='email' className='font-semibold'>
-          Email
-        </label>
-        <input
-          id='email'
-          name='email'
-          type='email'
-          required
-          autoComplete='email'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-        />
-        <label htmlFor='password' className='font-semibold'>
-          Password
-        </label>
-        <input
-          id='password'
-          name='password'
-          type='password'
-          required
-          autoComplete='new-password'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={password}
-          onChange={(event) => setPassword(event.target.value)}
-        />
-        <button
-          type='submit'
-          className='rounded-md bg-black px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90 dark:bg-neutral-900'
-          disabled={isPending}
-        >
-          {isPending ? 'Creating account...' : 'Sign Up'}
-        </button>
-      </form>
-    </section>
+                navigate({ to: '/blog' });
+              });
+            }}
+          >
+            <div className='f-field'>
+              <label htmlFor='name'>名号 NAME</label>
+              <input
+                id='name'
+                name='name'
+                type='text'
+                required
+                autoComplete='name'
+                className='f-input'
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+              />
+            </div>
+            <div className='f-field'>
+              <label htmlFor='email'>邮箱 EMAIL</label>
+              <input
+                id='email'
+                name='email'
+                type='email'
+                required
+                autoComplete='email'
+                className='f-input'
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+              />
+            </div>
+            <div className='f-field'>
+              <label htmlFor='password'>密码 PASSWORD</label>
+              <input
+                id='password'
+                name='password'
+                type='password'
+                required
+                autoComplete='new-password'
+                className='f-input'
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+            </div>
+            <div className='actions'>
+              <button
+                type='submit'
+                className='f-btn f-btn-fill'
+                disabled={isPending}
+              >
+                {isPending ? '创建中…' : '创建账号！'}
+              </button>
+              <button
+                type='button'
+                className='f-btn'
+                onClick={async () => {
+                  setError(null);
+                  const result = await authClient.signIn.social({
+                    provider: 'github',
+                    callbackURL: '/blog',
+                  });
+                  if (result.error) {
+                    setError(result.error.message ?? 'GitHub 注册失败');
+                  }
+                }}
+              >
+                GitHub
+              </button>
+            </div>
+            {error ? <p className='f-err'>{error}！</p> : null}
+          </form>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/routes/unlock/$slug.tsx
+++ b/apps/web/src/routes/unlock/$slug.tsx
@@ -78,48 +78,44 @@ function UnlockPage() {
     search.error === 'missing'
       ? '请输入访问密码'
       : search.error === 'invalid'
-        ? '密码错误，请重试'
+        ? '密码不对，再试试！（连错会限流）'
         : undefined;
 
   return (
-    <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>输入文章访问密码</h1>
-      <p className='mb-6 opacity-70'>这篇文章使用了单文密码保护。</p>
-
-      {errorLabel ? (
-        <p role='alert' className='mb-4 text-sm text-red-700 dark:text-red-300'>
-          {errorLabel}
-        </p>
-      ) : null}
-
-      <form method='post' className='grid max-w-[420px] gap-3'>
-        <label htmlFor='password' className='font-semibold'>
-          Password
-        </label>
-        <input
-          id='password'
-          name='password'
-          type='password'
-          required
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-        />
-        <button
-          type='submit'
-          className='rounded-md bg-black px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90 dark:bg-neutral-900'
-        >
-          Unlock
-        </button>
-      </form>
-
-      <p className='mt-4'>
-        <Link
-          to='/blog/$slug'
-          params={{ slug }}
-          className='opacity-70 hover:opacity-100'
-        >
-          返回文章页
-        </Link>
-      </p>
-    </section>
+    <div className='f-page'>
+      <div className='f-gate'>
+        <div className='f-card f-lift f-gate-card'>
+          <span
+            className='f-sticker badge-top'
+            style={{ background: '#FF6B35', color: '#fff' }}
+          >
+            🔒 LOCKED
+          </span>
+          <h1>解锁文章</h1>
+          <p className='sub'>这篇用单文密码上着锁 ・ 输对后 24 小时免密</p>
+          <form method='post'>
+            <div className='f-field'>
+              <label htmlFor='password'>文章密码</label>
+              <input
+                id='password'
+                name='password'
+                type='password'
+                required
+                className='f-input'
+              />
+            </div>
+            {errorLabel ? <p className='f-err'>{errorLabel}</p> : null}
+            <div className='actions'>
+              <button type='submit' className='f-btn f-btn-o'>
+                解锁！
+              </button>
+              <Link to='/blog/$slug' params={{ slug }} className='f-btn'>
+                ← 返回文章
+              </Link>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -144,3 +144,869 @@ html.dark ::-webkit-scrollbar-thumb {
 html.dark ::-webkit-scrollbar-thumb:hover {
   background: rgb(148 163 184 / 0.55);
 }
+
+/* =====================================================================
+ * THEME F — Neo-Pop candy (UX redesign direction F)
+ * Black 2px borders, hard offset shadows, rotated sticker badges, loud
+ * candy palette on cream dots. Light-native.
+ * =================================================================== */
+:root {
+  --background: 48 100% 97%;
+  --foreground: 0 0% 8%;
+  --card: 0 0% 100%;
+  --card-foreground: 0 0% 8%;
+  --popover: 48 100% 98%;
+  --popover-foreground: 0 0% 8%;
+  --primary: 16 100% 60%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 48 80% 89%;
+  --secondary-foreground: 0 0% 8%;
+  --muted: 48 80% 89%;
+  --muted-foreground: 0 0% 34%;
+  --accent: 48 80% 86%;
+  --accent-foreground: 0 0% 8%;
+  --destructive: 16 100% 60%;
+  --destructive-foreground: 0 0% 100%;
+  --border: 0 0% 8%;
+  --input: 0 0% 8%;
+  --ring: 255 100% 68%;
+  --radius: 0.125rem;
+
+  --f-bg: #fffdf4;
+  --f-ink: #141414;
+  --f-block: #ffde59;
+  --f-orange: #ff6b35;
+  --f-violet: #7c5cff;
+  --f-pink: #ff90c2;
+  --f-mint: #21cba8;
+  --f-sky: #57b8ff;
+  --f-shadow: 5px 5px 0 #141414;
+  --f-shadow-sm: 3px 3px 0 #141414;
+  --f-sans:
+    "Helvetica Neue", Inter, "PingFang SC", "Hiragino Sans GB",
+    "Microsoft YaHei", system-ui, sans-serif;
+  --f-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}
+
+html {
+  background-color: var(--f-bg);
+}
+
+html body {
+  font-family: var(--f-sans);
+  background-color: var(--f-bg);
+  background-image: radial-gradient(
+    rgba(20, 20, 20, 0.06) 1.2px,
+    transparent 1.2px
+  );
+  background-size: 22px 22px;
+  color: var(--f-ink);
+  font-size: 15px;
+  line-height: 1.75;
+}
+
+::selection {
+  background: var(--f-block);
+}
+
+/* ---------- shell ---------- */
+.f-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+}
+.f-main {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.f-head {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 28px 22px 0;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+.f-logo {
+  background: var(--f-ink);
+  color: #fffdf4;
+  font-weight: 900;
+  font-size: 17px;
+  padding: 8px 16px;
+  border-radius: 2px;
+  transform: rotate(-1.5deg);
+  box-shadow: var(--f-shadow-sm);
+}
+.f-head nav {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.f-nav {
+  font-size: 13px;
+  font-weight: 800;
+  padding: 5px 14px;
+  border: 2px solid var(--f-ink);
+  border-radius: 999px;
+  background: #fff;
+  box-shadow: var(--f-shadow-sm);
+}
+.f-nav:hover {
+  background: var(--f-block);
+  text-decoration: none;
+}
+.f-nav.on {
+  background: var(--f-orange);
+  color: #fff;
+}
+.f-head .tools {
+  margin-left: auto;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.f-tool {
+  font-family: var(--f-sans);
+  font-size: 12px;
+  font-weight: 800;
+  background: #fff;
+  border: 2px solid var(--f-ink);
+  border-radius: 2px;
+  box-shadow: var(--f-shadow-sm);
+  padding: 5px 12px;
+  cursor: pointer;
+}
+.f-tool:hover {
+  background: var(--f-sky);
+  text-decoration: none;
+}
+.f-user {
+  display: none;
+  align-items: center;
+  gap: 8px;
+  font-size: 11.5px;
+  font-weight: 700;
+  border: 2px solid var(--f-ink);
+  border-radius: 999px;
+  background: #fff;
+  box-shadow: var(--f-shadow-sm);
+  padding: 3px 12px;
+}
+@media (min-width: 768px) {
+  .f-user {
+    display: inline-flex;
+  }
+}
+.f-role {
+  background: var(--f-ink);
+  color: var(--f-block);
+  font-size: 10px;
+  padding: 1px 8px;
+  border-radius: 999px;
+}
+
+.f-foot {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 30px 22px 46px;
+  text-align: center;
+  font-family: var(--f-mono);
+  font-size: 11px;
+  font-weight: 700;
+  color: rgba(20, 20, 20, 0.55);
+  letter-spacing: 0.1em;
+}
+.f-foot a {
+  color: var(--f-ink);
+}
+.f-foot a:hover {
+  color: var(--f-violet);
+}
+
+/* ---------- shared ---------- */
+.f-page {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 0 22px 80px;
+}
+.f-card {
+  background: #fff;
+  border: 2px solid var(--f-ink);
+  box-shadow: var(--f-shadow);
+  border-radius: 2px;
+  transition:
+    transform 0.1s,
+    box-shadow 0.1s;
+}
+.f-lift:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: 7px 7px 0 #141414;
+}
+
+.f-sticker {
+  display: inline-block;
+  border: 2px solid var(--f-ink);
+  box-shadow: var(--f-shadow-sm);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  padding: 1px 9px;
+  background: #fff;
+  border-radius: 2px;
+  white-space: nowrap;
+}
+.f-btn {
+  font-family: var(--f-sans);
+  font-size: 14px;
+  font-weight: 800;
+  cursor: pointer;
+  background: #fff;
+  color: var(--f-ink);
+  border: 2px solid var(--f-ink);
+  box-shadow: var(--f-shadow-sm);
+  border-radius: 2px;
+  padding: 10px 22px;
+  transition:
+    transform 0.1s,
+    box-shadow 0.1s;
+  display: inline-block;
+}
+.f-btn:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: 5px 5px 0 #141414;
+  text-decoration: none;
+}
+.f-btn:active {
+  transform: translate(2px, 2px);
+  box-shadow: 1px 1px 0 #141414;
+}
+.f-btn-fill {
+  background: var(--f-block);
+}
+.f-btn-o {
+  background: var(--f-orange);
+  color: #fff;
+}
+.f-banner {
+  display: inline-block;
+  background: var(--f-ink);
+  color: var(--f-block);
+  font-weight: 900;
+  font-size: 13px;
+  letter-spacing: 0.24em;
+  padding: 4px 16px;
+  transform: rotate(-1.2deg);
+}
+
+/* ---------- home ---------- */
+.f-hero {
+  background: var(--f-block);
+  border: 2px solid var(--f-ink);
+  box-shadow: var(--f-shadow);
+  border-radius: 2px;
+  padding: 50px 44px;
+  position: relative;
+  overflow: hidden;
+  margin-top: 22px;
+}
+.f-hero .float {
+  position: absolute;
+  top: 18px;
+  right: 26px;
+  transform: rotate(2deg);
+}
+.f-hero h1 {
+  font-size: clamp(40px, 7vw, 70px);
+  font-weight: 900;
+  line-height: 1.08;
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
+}
+.f-hero .stroke {
+  color: var(--f-bg);
+  -webkit-text-stroke: 2.5px var(--f-ink);
+}
+.f-hero .dot {
+  color: var(--f-orange);
+}
+.f-hero p {
+  margin-top: 16px;
+  font-size: 16.5px;
+  max-width: 52ch;
+  font-weight: 500;
+}
+.f-hero .cta {
+  margin-top: 28px;
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+.f-home-grid {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  gap: 22px;
+  margin-top: 22px;
+}
+.f-panel {
+  padding: 22px 26px;
+}
+.f-panel h3 {
+  display: inline-block;
+  font-size: 13px;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  background: var(--f-violet);
+  color: #fff;
+  padding: 2px 12px;
+  transform: rotate(-1deg);
+  margin-bottom: 16px;
+}
+.f-panel h3.o {
+  background: var(--f-orange);
+}
+.f-row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  padding: 9px 0;
+  border-bottom: 2px dashed rgba(20, 20, 20, 0.16);
+}
+.f-row:last-child {
+  border-bottom: 0;
+}
+.f-row .no {
+  font-family: var(--f-mono);
+  font-size: 11px;
+  color: rgba(20, 20, 20, 0.5);
+  font-weight: 700;
+}
+.f-row .t {
+  flex: 1;
+  font-weight: 700;
+  font-size: 14.5px;
+}
+.f-row .t:hover {
+  color: var(--f-violet);
+  text-decoration: none;
+}
+.f-stat {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 0;
+  border-bottom: 2px dashed rgba(20, 20, 20, 0.16);
+}
+.f-stat:last-child {
+  border-bottom: 0;
+}
+.f-stat b {
+  font-size: 26px;
+  font-weight: 900;
+}
+.f-stat b.vio {
+  color: var(--f-violet);
+}
+.f-stat b.org {
+  color: var(--f-orange);
+}
+.f-stat :where(span) {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: rgba(20, 20, 20, 0.6);
+}
+@media (max-width: 860px) {
+  .f-home-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ---------- blog list ---------- */
+.f-page-head {
+  padding: 34px 0 22px;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+.f-page-head h1 {
+  font-size: 38px;
+  font-weight: 900;
+  letter-spacing: -0.02em;
+}
+.f-list-card {
+  padding: 8px 26px 18px;
+}
+.f-yr {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 20px 0 8px;
+}
+.f-yr .pill {
+  background: var(--f-ink);
+  color: #fffdf4;
+  font-weight: 900;
+  font-size: 13px;
+  padding: 2px 14px;
+  border-radius: 999px;
+  letter-spacing: 0.1em;
+}
+.f-yr::after {
+  content: "";
+  flex: 1;
+  border-top: 2px dashed rgba(20, 20, 20, 0.2);
+}
+.f-post-row {
+  display: grid;
+  grid-template-columns: 52px 1fr auto auto;
+  gap: 18px;
+  align-items: center;
+  padding: 12px 10px;
+  border-radius: 2px;
+}
+.f-post-row:hover {
+  background: var(--f-block);
+  outline: 2px solid var(--f-ink);
+}
+.f-post-row .no {
+  font-family: var(--f-mono);
+  font-size: 12px;
+  font-weight: 700;
+  color: rgba(20, 20, 20, 0.55);
+}
+.f-post-row .t {
+  font-weight: 700;
+  font-size: 16px;
+}
+.f-post-row .tags {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.f-post-row .d {
+  font-family: var(--f-mono);
+  font-size: 11.5px;
+  font-weight: 700;
+  color: rgba(20, 20, 20, 0.55);
+}
+.f-pager {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  margin-top: 24px;
+}
+.f-pager .cur {
+  background: var(--f-orange);
+  color: #fff;
+}
+.f-devhint {
+  border: 2px dashed rgba(20, 20, 20, 0.3);
+  font-size: 12.5px;
+  font-weight: 600;
+  color: rgba(20, 20, 20, 0.6);
+  padding: 8px 14px;
+  margin: 14px 0;
+}
+@media (max-width: 720px) {
+  .f-post-row {
+    grid-template-columns: 44px 1fr;
+  }
+  .f-post-row .tags,
+  .f-post-row .d {
+    display: none;
+  }
+}
+
+/* ---------- article ---------- */
+.f-art {
+  padding: 36px 44px 40px;
+  margin-top: 8px;
+}
+.f-art h1 {
+  font-size: clamp(26px, 4vw, 38px);
+  font-weight: 900;
+  line-height: 1.3;
+}
+.f-meta {
+  display: flex;
+  gap: 10px;
+  margin: 16px 0 8px;
+  flex-wrap: wrap;
+}
+
+.md {
+  margin-top: 26px;
+  font-size: 16px;
+}
+.md p {
+  margin: 18px 0;
+}
+.md h2 {
+  font-size: 20px;
+  font-weight: 900;
+  margin: 36px 0 12px;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  scroll-margin-top: 20px;
+}
+.md h2 .chip {
+  background: var(--f-mint);
+  border: 2px solid var(--f-ink);
+  box-shadow: var(--f-shadow-sm);
+  font-size: 12px;
+  font-family: var(--f-mono);
+  padding: 0 10px;
+  border-radius: 999px;
+}
+.md h2 a {
+  color: inherit;
+}
+.md ul {
+  margin: 14px 0;
+  list-style: none;
+}
+.md ul li {
+  padding: 7px 0 7px 30px;
+  position: relative;
+  font-weight: 500;
+}
+.md ul li::before {
+  content: "★";
+  position: absolute;
+  left: 2px;
+  color: var(--f-orange);
+  font-size: 13px;
+}
+.md a {
+  color: var(--f-violet);
+  font-weight: 600;
+}
+.md blockquote {
+  background: var(--f-pink);
+  border: 2px solid var(--f-ink);
+  box-shadow: var(--f-shadow-sm);
+  padding: 12px 20px;
+  margin: 22px 0;
+  font-weight: 600;
+  border-radius: 2px;
+  transform: rotate(-0.6deg);
+}
+.md :where(code.f-inline) {
+  font-family: var(--f-mono);
+  font-size: 0.85em;
+  background: var(--f-block);
+  border: 1.5px solid var(--f-ink);
+  border-radius: 2px;
+  padding: 1px 6px;
+  font-weight: 700;
+}
+
+.f-code {
+  position: relative;
+  margin: 24px 0;
+}
+.f-code-copy {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  z-index: 10;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: 2px solid var(--f-ink);
+  background: var(--f-sky);
+  box-shadow: var(--f-shadow-sm);
+  font-size: 11px;
+  font-weight: 800;
+  font-family: var(--f-mono);
+  border-radius: 999px;
+  padding: 1px 10px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s;
+  transform: rotate(-1.5deg);
+}
+.f-code:hover .f-code-copy,
+.f-code-copy:focus-visible {
+  opacity: 1;
+}
+@media not (hover: hover) {
+  .f-code-copy {
+    opacity: 0.75;
+  }
+}
+.md pre.f-pre {
+  font-family: var(--f-mono);
+  font-size: 13px;
+  line-height: 1.8;
+  color: #f4f1e8;
+  background: #141414;
+  border: 2px solid var(--f-ink);
+  box-shadow: var(--f-shadow);
+  border-radius: 2px;
+  padding: 20px 22px;
+  overflow-x: auto;
+  margin: 0;
+}
+.md pre.f-pre code {
+  background: none;
+  padding: 0;
+}
+.md pre.f-pre {
+  /* biome-ignore lint/complexity/noImportantStyles: shiki writes an inline light bg; the panel is ink black. */
+  background: #141414 !important;
+}
+.md pre.f-pre span {
+  /* biome-ignore lint/complexity/noImportantStyles: force shiki dark tokens (SSR-safe). */
+  color: var(--shiki-dark) !important;
+}
+
+/* ---------- comments ---------- */
+.f-cmt-card {
+  padding: 16px 20px;
+  margin: 14px 0;
+}
+.f-cmt-card.reply {
+  margin-left: 48px;
+  background: var(--f-bg);
+}
+.f-cmt-h {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  font-size: 12.5px;
+  font-weight: 700;
+  margin-bottom: 6px;
+  flex-wrap: wrap;
+}
+.f-cmt-h .who {
+  background: var(--f-violet);
+  color: #fff;
+  padding: 0 10px;
+  border-radius: 999px;
+  border: 2px solid var(--f-ink);
+  font-size: 11.5px;
+}
+.f-cmt-h .who.author {
+  background: var(--f-orange);
+}
+.f-cmt-h .when {
+  font-family: var(--f-mono);
+  font-size: 11px;
+  color: rgba(20, 20, 20, 0.5);
+}
+.f-cmt-b p {
+  margin: 0 0 6px;
+  font-size: 14.5px;
+}
+.f-cmt-b p:last-child {
+  margin-bottom: 0;
+}
+.f-cmt-b :where(code) {
+  font-family: var(--f-mono);
+  font-size: 0.85em;
+  background: var(--f-block);
+  border: 1.5px solid var(--f-ink);
+  padding: 0 5px;
+  border-radius: 2px;
+}
+.f-cmt-b blockquote {
+  border-left: 3px solid var(--f-ink);
+  padding-left: 12px;
+  color: rgba(20, 20, 20, 0.6);
+}
+.f-cmt-ops {
+  display: flex;
+  gap: 14px;
+  margin-top: 8px;
+  font-size: 12px;
+}
+.f-cmt-ops :where(button) {
+  color: rgba(20, 20, 20, 0.55);
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font-family: var(--f-sans);
+  font-size: 12px;
+  font-weight: 800;
+  padding: 0;
+}
+.f-cmt-ops :where(button):hover {
+  color: var(--f-violet);
+}
+.f-cmt-form textarea {
+  width: 100%;
+  resize: vertical;
+  font-family: var(--f-sans);
+  font-size: 14.5px;
+  font-weight: 500;
+  color: var(--f-ink);
+  background: #fff;
+  border: 2px solid var(--f-ink);
+  border-radius: 2px;
+  padding: 10px 14px;
+  box-shadow: inset 2px 2px 0 rgba(20, 20, 20, 0.08);
+}
+.f-cmt-form textarea:focus {
+  outline: none;
+  box-shadow: 3px 3px 0 var(--f-violet);
+}
+.f-cmt-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 10px;
+}
+.f-hint {
+  font-size: 12px;
+  font-weight: 600;
+  color: rgba(20, 20, 20, 0.55);
+}
+.f-hint .err {
+  color: var(--f-orange);
+  margin-left: 8px;
+}
+
+/* ---------- projects ---------- */
+.f-proj-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 22px;
+}
+.f-proj-card {
+  padding: 24px 26px;
+}
+.f-proj-card h2 {
+  font-size: 19px;
+  font-weight: 900;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.f-proj-card p {
+  margin-top: 8px;
+  font-size: 14px;
+  color: rgba(20, 20, 20, 0.75);
+}
+.f-proj-card .tags {
+  margin: 14px 0;
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.f-proj-card .links {
+  display: flex;
+  gap: 10px;
+}
+@media (max-width: 860px) {
+  .f-proj-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ---------- forms ---------- */
+.f-gate {
+  max-width: 460px;
+  margin: 30px auto 0;
+}
+.f-gate-card {
+  padding: 34px 36px 36px;
+  position: relative;
+}
+.f-gate-card .badge-top {
+  position: absolute;
+  top: -16px;
+  left: 26px;
+  transform: rotate(-2deg);
+}
+.f-gate h1 {
+  font-size: 30px;
+  font-weight: 900;
+}
+.f-gate .sub {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: rgba(20, 20, 20, 0.6);
+  margin: 6px 0 22px;
+}
+.f-field {
+  margin: 15px 0;
+}
+.f-field label {
+  display: block;
+  font-size: 12px;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  margin-bottom: 5px;
+}
+.f-input {
+  width: 100%;
+  font-family: var(--f-sans);
+  font-size: 14.5px;
+  font-weight: 500;
+  color: var(--f-ink);
+  background: var(--f-bg);
+  border: 2px solid var(--f-ink);
+  border-radius: 2px;
+  padding: 10px 14px;
+  box-shadow: inset 2px 2px 0 rgba(20, 20, 20, 0.08);
+}
+.f-input:focus {
+  outline: none;
+  background: #fff;
+  border-color: var(--f-violet);
+  box-shadow: 3px 3px 0 var(--f-violet);
+}
+.f-gate .actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 24px;
+  flex-wrap: wrap;
+}
+.f-err {
+  display: inline-block;
+  background: var(--f-pink);
+  border: 2px solid var(--f-ink);
+  box-shadow: var(--f-shadow-sm);
+  font-size: 13px;
+  font-weight: 700;
+  padding: 6px 14px;
+  margin-top: 16px;
+  transform: rotate(-1deg);
+}
+.f-gate .aside {
+  margin-top: 20px;
+  font-size: 13.5px;
+  font-weight: 600;
+}
+.f-gate .aside a {
+  color: var(--f-violet);
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+}
+
+/* ---------- 404 ---------- */
+.f-nf {
+  text-align: center;
+  padding: 70px 0 40px;
+}
+.f-nf .code {
+  font-size: 100px;
+  font-weight: 900;
+  letter-spacing: -0.03em;
+  line-height: 1;
+}
+.f-nf .code b {
+  color: var(--f-orange);
+}
+.f-nf p {
+  font-weight: 700;
+  margin: 16px 0 28px;
+}

--- a/tests/e2e/admin-flow.spec.ts
+++ b/tests/e2e/admin-flow.spec.ts
@@ -19,7 +19,7 @@ test('admin can create a post that appears on the blog', async ({ page }) => {
   await page.locator('#password').fill(ADMIN_PASSWORD);
   await page.locator('form button[type="submit"]').click();
 
-  const loggedIn = page.getByRole('link', { name: /logout/i });
+  const loggedIn = page.getByTestId('nav-logout');
   try {
     await expect(loggedIn).toBeVisible({ timeout: 8000 });
   } catch {

--- a/tests/e2e/auth-logout.spec.ts
+++ b/tests/e2e/auth-logout.spec.ts
@@ -8,18 +8,20 @@ function createUniqueEmail(): string {
 test('signup then logout returns to guest header state', async ({ page }) => {
   await page.goto('/signup', { waitUntil: 'domcontentloaded' });
 
-  await page.getByLabel('Name').fill('E2E Logout');
-  await page.getByLabel('Email').fill(createUniqueEmail());
-  await page.getByLabel('Password').fill('Playwright!12345');
-  await page.getByRole('button', { name: 'Sign Up' }).click();
+  // Form anchors are theme-stable: field ids on /signup + the submit button.
+  // Header anchors use data-testid because each UX theme words them
+  // differently (login / 入会 / SIGN IN …).
+  await page.locator('#name').fill('E2E Logout');
+  await page.locator('#email').fill(createUniqueEmail());
+  await page.locator('#password').fill('Playwright!12345');
+  await page.locator('form button[type="submit"]').click();
 
   await page.waitForURL('**/blog');
-  await expect(page.getByRole('link', { name: 'Logout' })).toBeVisible();
+  await expect(page.getByTestId('nav-logout')).toBeVisible();
 
-  await page.getByRole('link', { name: 'Logout' }).click();
+  await page.getByTestId('nav-logout').click();
 
   await page.waitForURL('**/blog');
-  await expect(page.getByRole('link', { name: 'Login' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Sign Up' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Logout' })).toHaveCount(0);
+  await expect(page.getByTestId('nav-login')).toBeVisible();
+  await expect(page.getByTestId('nav-logout')).toHaveCount(0);
 });


### PR DESCRIPTION
## What — UX 改版方向 F「糖果粗野」落地

把原型 `prototypes/f-neopop.html` 落到真实应用：黑粗边 + 硬阴影 + 高饱和撞色的贴纸世界。

- **壳**：旋转黑色 logo 块 + 胶囊导航（当前页橙色）+ 圆点纹理奶白底
- **首页**：大黄色块 hero（PERFECT 空心描边 + 橙色叹号）+ 旋转贴纸 EST. 2019 + 硬阴影数据面板
- **博客列表**：硬阴影大卡片 + 黑色年份胶囊 + 行 hover 变黄块；标签 = **彩色贴纸**（按标签名确定性配色）；MEMBER/VIP/密码 = 对应色贴纸
- **文章页**：硬阴影卡片 + 星号列表 + 粉色倾斜引用块 + 黑底代码块（局部强制 shiki 暗色 token）
- **评论**：贴纸卡片（作者徽章 violet、管理员 orange）；**表单**：顶部旋转贴纸徽章卡片，聚焦时紫色硬阴影
- **404** = 巨型 4⭐4；亮色原生（隐藏主题切换）

## 不变的东西

路由 / loader / 鉴权 / 评论 / 搜索逻辑未动；首页新增只读 loader。Admin 沿用现有亮色样式。

## 验证

- [x] typecheck / lint / test 36 passed / build + 体积 **1024.9 KiB gzip**
- [x] 生产构建 wrangler dev 探针：受控复测与 master 基线一致（均为 clean）
- [x] ⚠️ 发现一个 **master 既有**的间歇性 React #418（args[]=HTML，<html> 层 hydration 竞态，master 上 /login 4/4、/projects 2/4 可复现）——与本主题无关，建议另开 issue 单独排查

> 7 个候选方向之一（A–G）。预览用 Workers Builds preview URL。