### PR TITLE
feat(web): apply synthwave night theme (UX direction G)

### DIFF
--- a/apps/web/src/components/comments.tsx
+++ b/apps/web/src/components/comments.tsx
@@ -20,14 +20,6 @@ type CommentsProps = {
 
 const PAGE_SIZE = 20;
 
-function getInitials(name: string): string {
-  const trimmed = name.trim();
-  if (!trimmed) {
-    return '?';
-  }
-  return trimmed.slice(0, 1).toUpperCase();
-}
-
 function formatRelative(iso: string): string {
   const then = new Date(iso).getTime();
   if (Number.isNaN(then)) {
@@ -54,24 +46,6 @@ function formatRelative(iso: string): string {
     day: 'numeric',
     year: 'numeric',
   });
-}
-
-function Avatar({ name, image }: { name: string; image: string | null }) {
-  if (image) {
-    return (
-      <img
-        src={image}
-        alt={name}
-        loading='lazy'
-        className='h-8 w-8 shrink-0 rounded-full bg-zinc-100 dark:bg-zinc-800'
-      />
-    );
-  }
-  return (
-    <div className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-zinc-200 text-xs font-semibold text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300'>
-      {getInitials(name)}
-    </div>
-  );
 }
 
 type ComposerProps = {
@@ -107,26 +81,25 @@ function Composer({
   }
 
   return (
-    <form onSubmit={handleSubmit} className='flex flex-col gap-2'>
+    <form onSubmit={handleSubmit} className='g-cmt-form'>
       <textarea
         value={body}
         onChange={(event) => setBody(event.target.value)}
         placeholder={placeholder}
         rows={compact ? 2 : 3}
         maxLength={2000}
-        className='w-full resize-y rounded-md border border-zinc-300 bg-transparent px-3 py-2 text-sm outline-none transition-colors focus:border-zinc-400 dark:border-zinc-600 dark:focus:border-zinc-400'
       />
-      <div className='flex items-center justify-between gap-2'>
-        <span className='text-xs opacity-50'>
+      <div className='g-cmt-foot'>
+        <span className='g-hint'>
           {remaining < 200 ? `${remaining} 字剩余` : '支持 Markdown'}
-          {error ? <span className='ml-2 text-red-500'>{error}</span> : null}
+          {error ? <span className='err'>{error}</span> : null}
         </span>
         <button
           type='submit'
           disabled={submitting || !body.trim()}
-          className='rounded-md bg-black px-3 py-1 text-xs font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-neutral-900'
+          className='g-btn g-btn-grad'
         >
-          {submitting ? '发送中…' : '发送'}
+          {submitting ? '发送中…' : '评论 →'}
         </button>
       </div>
     </form>
@@ -191,7 +164,7 @@ function CommentItem({
       ) : null}
 
       {thread.replies.length > 0 ? (
-        <ul className='ml-10 flex flex-col gap-2 border-l border-zinc-200 pl-4 dark:border-zinc-700'>
+        <ul className='ml-10 flex flex-col gap-2'>
           {thread.replies.map((reply) => {
             const replyCanAct =
               sessionUser != null &&
@@ -233,49 +206,36 @@ function CommentView({
   onDelete,
 }: CommentViewProps) {
   return (
-    <div className='flex gap-3'>
-      <Avatar name={comment.author.name} image={comment.author.image} />
-      <div className='min-w-0 flex-1'>
-        <div className='flex flex-wrap items-center gap-x-2 gap-y-0.5'>
-          <span className='text-sm font-semibold'>{comment.author.name}</span>
-          {comment.author.role === 'admin' ? (
-            <span className='rounded bg-zinc-900 px-1.5 py-0.5 text-[10px] font-semibold text-white dark:bg-white dark:text-zinc-900'>
-              Author
-            </span>
-          ) : null}
-          {comment.status !== 'visible' ? (
-            <span className='rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'>
-              {comment.status}
-            </span>
-          ) : null}
-          <span className='text-xs opacity-50'>
-            {formatRelative(comment.createdAt)}
-          </span>
-        </div>
-        <div className='mt-1'>
-          <CommentMarkdown content={comment.body} />
-        </div>
-        <div className='mt-1 flex gap-3 text-xs'>
+    <div
+      className={
+        comment.parentId !== null ? 'g-panel g-cmt reply' : 'g-panel g-cmt'
+      }
+    >
+      <div className='g-cmt-h'>
+        <span className='who'>{comment.author.name}</span>
+        {comment.author.role === 'admin' ? <span>AUTHOR</span> : null}
+        {comment.status !== 'visible' ? (
+          <span style={{ color: 'var(--g-pink)' }}>{comment.status}</span>
+        ) : null}
+        <span>{formatRelative(comment.createdAt)}</span>
+      </div>
+      <div className='g-cmt-b'>
+        <CommentMarkdown content={comment.body} />
+      </div>
+      {(canReply && onReply) || canAct ? (
+        <div className='g-cmt-ops'>
           {canReply && onReply ? (
-            <button
-              type='button'
-              onClick={onReply}
-              className='opacity-50 transition-opacity hover:opacity-100'
-            >
+            <button type='button' onClick={onReply}>
               回复
             </button>
           ) : null}
           {canAct ? (
-            <button
-              type='button'
-              onClick={() => onDelete()}
-              className='text-red-500/70 transition-colors hover:text-red-500'
-            >
+            <button type='button' onClick={() => onDelete()}>
               删除
             </button>
           ) : null}
         </div>
-      </div>
+      ) : null}
     </div>
   );
 }
@@ -375,11 +335,7 @@ export function Comments({
   }
 
   return (
-    <section className='mt-12'>
-      <h2 className='mb-4 text-lg font-black'>
-        评论 {total > 0 ? <span className='opacity-50'>({total})</span> : null}
-      </h2>
-
+    <section className='mt-2'>
       {sessionUser ? (
         <div className='mb-6'>
           <Composer
@@ -389,37 +345,36 @@ export function Comments({
           />
         </div>
       ) : (
-        <p className='mb-6 text-sm opacity-60'>
-          <Link to='/login' className='underline hover:opacity-100'>
+        <p className='g-hint mb-6'>
+          <Link to='/login' style={{ color: 'var(--g-cyan)' }}>
             登录
           </Link>{' '}
           后即可评论。
         </p>
       )}
 
-      {topError ? (
-        <p className='mb-4 text-sm text-red-500'>{topError}</p>
-      ) : null}
+      {topError ? <p className='g-err mb-4'>{topError}</p> : null}
 
       {threads.length === 0 ? (
-        <p className='py-8 text-center text-sm opacity-50'>
-          还没有评论，来抢沙发。
-        </p>
+        <p className='g-hint py-8 text-center'>还没有评论，来抢沙发。</p>
       ) : (
-        <ul className='flex flex-col gap-5'>
-          {threads.map((thread) => (
-            <CommentItem
-              key={thread.id}
-              thread={thread}
-              sessionUser={sessionUser}
-              onReply={handleReply}
-              onDelete={handleDelete}
-              replyingTo={replyingTo}
-              setReplyingTo={setReplyingTo}
-              replySubmitting={replySubmitting}
-            />
-          ))}
-        </ul>
+        <>
+          <p className='g-hint mb-2'>TOTAL — {total}</p>
+          <ul className='flex flex-col gap-2'>
+            {threads.map((thread) => (
+              <CommentItem
+                key={thread.id}
+                thread={thread}
+                sessionUser={sessionUser}
+                onReply={handleReply}
+                onDelete={handleDelete}
+                replyingTo={replyingTo}
+                setReplyingTo={setReplyingTo}
+                replySubmitting={replySubmitting}
+              />
+            ))}
+          </ul>
+        </>
       )}
 
       {hasMore ? (
@@ -428,9 +383,9 @@ export function Comments({
             type='button'
             onClick={handleLoadMore}
             disabled={loadingMore}
-            className='text-sm opacity-60 transition-opacity hover:opacity-100 disabled:opacity-40'
+            className='g-btn'
           >
-            {loadingMore ? '加载中…' : '加载更多'}
+            {loadingMore ? '加载中…' : '加载更多 ↓'}
           </button>
         </div>
       ) : null}

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -1,10 +1,12 @@
+import { Link } from '@tanstack/react-router';
+
 export function Footer() {
   return (
-    <footer className='p-6 text-center'>
-      © {new Date().getFullYear()}, Built with{' '}
-      <a className='text-blue-500' href='https://tanstack.com/start/latest'>
-        TanStack Start
-      </a>
+    <footer className='g-foot'>
+      <span>PERFECTPAN.ORG — {new Date().getFullYear()}</span>
+      <Link to='/blog'>/BLOG</Link>
+      <Link to='/projects'>/PROJECTS</Link>
+      <a href='/rss.xml'>RSS ↗</a>
     </footer>
   );
 }

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -57,15 +57,20 @@ export function Header() {
             </span>
           ) : null}
           {sessionUser ? (
-            <Link to='/logout' className='g-tool' aria-label='Logout'>
+            <Link
+              to='/logout'
+              data-testid='nav-logout'
+              className='g-tool'
+              aria-label='Logout'
+            >
               <LogOut size={13} aria-hidden='true' />
             </Link>
           ) : (
             <>
-              <Link to='/login' className='g-tool'>
+              <Link to='/login' data-testid='nav-login' className='g-tool'>
                 Login
               </Link>
-              <Link to='/signup' className='g-tool'>
+              <Link to='/signup' data-testid='nav-signup' className='g-tool'>
                 Sign Up
               </Link>
             </>

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -1,8 +1,6 @@
 import { Link } from '@tanstack/react-router';
 import { Github, LogOut, Rss, Search, UserRound } from 'lucide-react';
 import { authClient } from '../lib/auth-client.js';
-import { DarkMode } from './dark-mode.js';
-import { MenuLink } from './menu.js';
 import { searchPalette } from './search-palette-store.js';
 
 function getRoleLabel(role?: string | null): string {
@@ -17,76 +15,86 @@ function getRoleLabel(role?: string | null): string {
   return 'MEMBER';
 }
 
+/** Synthwave header: gradient logo + nav with gradient underline. */
 export function Header() {
   const { data: sessionData } = authClient.useSession();
   const sessionUser = sessionData?.user ?? null;
 
   return (
-    <header className='border-b border-slate-200 bg-white shadow-md dark:border-slate-300/10 dark:bg-slate-900'>
-      <div className='mx-4 flex h-16 items-center sm:mx-6'>
-        <Link
-          to='/'
-          className='rounded-md border-10 border-black bg-black px-1 font-bold text-white dark:border-neutral-900 dark:bg-neutral-900'
-        >
-          PerfectPan
+    <header className='g-head'>
+      <div className='g-head-in'>
+        <Link to='/' className='g-logo'>
+          Perfect<b>PAN</b>
         </Link>
-        <div className='m-0 flex list-none items-center pl-1'>
-          <MenuLink href='/' name='Home' />
-          <MenuLink href='/blog' name='Blog' />
-          <MenuLink href='/projects' name='Projects' />
+        <nav aria-label='主导航'>
+          <Link
+            to='/'
+            activeOptions={{ exact: true }}
+            activeProps={{ className: 'on' }}
+          >
+            Home
+          </Link>
+          <Link to='/blog' activeProps={{ className: 'on' }}>
+            Blog
+          </Link>
+          <Link to='/projects' activeProps={{ className: 'on' }}>
+            Projects
+          </Link>
           {sessionUser?.role === 'admin' ? (
-            <MenuLink href='/admin' name='Admin' />
+            <Link to='/admin' activeProps={{ className: 'on' }}>
+              Admin
+            </Link>
           ) : null}
-        </div>
-        <div className='ml-auto flex items-center gap-2 sm:gap-3'>
+        </nav>
+        <div className='tools'>
           {sessionUser ? (
-            <div className='hidden items-center gap-2 rounded-full border border-slate-300 px-3 py-1 text-xs text-gray-700 md:flex dark:border-slate-600 dark:text-slate-200'>
-              <UserRound size={14} className='opacity-70' />
-              <span className='max-w-[220px] truncate'>
+            <span className='g-user'>
+              <UserRound size={12} aria-hidden='true' />
+              <span className='max-w-[180px] truncate'>
                 {sessionUser.email}
               </span>
-              <span className='rounded-full bg-black px-2 py-[2px] text-[10px] font-semibold text-white dark:bg-neutral-100 dark:text-neutral-900'>
-                {getRoleLabel(sessionUser.role)}
-              </span>
-            </div>
+              <span className='g-role'>{getRoleLabel(sessionUser.role)}</span>
+            </span>
           ) : null}
           {sessionUser ? (
-            <Link
-              to='/logout'
-              className='inline-flex items-center gap-1 rounded-md border border-slate-300 px-2 py-1 text-sm opacity-85 transition-opacity hover:opacity-100 dark:border-slate-600'
-            >
-              <LogOut size={14} />
-              <span className='hidden sm:inline'>Logout</span>
+            <Link to='/logout' className='g-tool' aria-label='Logout'>
+              <LogOut size={13} aria-hidden='true' />
             </Link>
           ) : (
             <>
-              <Link to='/login' className='opacity-70 hover:opacity-100'>
+              <Link to='/login' className='g-tool'>
                 Login
               </Link>
-              <Link to='/signup' className='opacity-70 hover:opacity-100'>
+              <Link to='/signup' className='g-tool'>
                 Sign Up
               </Link>
             </>
           )}
           <button
             type='button'
-            aria-label='Search posts (Cmd+K)'
+            className='g-tool'
+            aria-label='Search (Cmd+K)'
             onClick={() => searchPalette.open()}
-            className='inline-flex items-center opacity-70 transition-opacity hover:opacity-100'
           >
-            <Search size={22} />
+            <Search size={13} aria-hidden='true' /> ⌘K
           </button>
-          <DarkMode />
           <a
             href='https://github.com/PerfectPan'
             target='_blank'
             rel='noreferrer'
-            className='flex items-center'
+            className='g-tool'
+            aria-label='GitHub'
           >
-            <Github size={22} className='opacity-70 hover:opacity-100' />
+            <Github size={13} aria-hidden='true' />
           </a>
-          <a href='/rss.xml' target='_blank' rel='noreferrer'>
-            <Rss size={24} className='opacity-70 hover:opacity-100' />
+          <a
+            href='/rss.xml'
+            target='_blank'
+            rel='noreferrer'
+            className='g-tool'
+            aria-label='RSS'
+          >
+            <Rss size={13} aria-hidden='true' />
           </a>
         </div>
       </div>

--- a/apps/web/src/components/layout.tsx
+++ b/apps/web/src/components/layout.tsx
@@ -7,21 +7,17 @@ type AppLayoutProps = {
 };
 
 /**
- * App shell. The header sits OUTSIDE the scroll container (`main`), so page
- * overscroll only rubber-bands the content — the pinned header never moves
- * (no macOS "fixed header drags on overscroll"). Window doesn't scroll; route
- * scroll reset/restore for `main` is handled by TanStack via
- * `scrollToTopSelectors: ['main']` in router.tsx.
+ * App shell (synthwave theme). Header sits OUTSIDE the scroll container
+ * (`main`). Window doesn't scroll; route scroll reset/restore for `main` is
+ * handled by TanStack via `scrollToTopSelectors: ['main']` in router.tsx.
  */
 export function AppLayout({ children }: AppLayoutProps) {
   return (
-    <div className='flex h-dvh flex-col'>
+    <div className='g-shell'>
       <Header />
-      <main className='flex-1 overflow-y-auto'>
+      <main className='g-main'>
         <div className='flex min-h-full flex-col'>
-          <div className='flex flex-grow items-center justify-center px-6 *:min-h-64 *:min-w-64'>
-            {children}
-          </div>
+          <div className='flex-grow'>{children}</div>
           <Footer />
         </div>
       </main>

--- a/apps/web/src/components/markdown.tsx
+++ b/apps/web/src/components/markdown.tsx
@@ -78,20 +78,17 @@ function CodeBlock({ children }: { children?: ReactNode }) {
   }, []);
 
   return (
-    <div className='group relative mb-2'>
+    <div className='g-code group relative'>
       <button
         type='button'
         onClick={onCopy}
         aria-label='Copy code'
-        className='absolute right-2 top-2 z-10 inline-flex items-center gap-1 rounded border border-slate-300 bg-white/70 px-1.5 py-0.5 text-xs opacity-0 backdrop-blur transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100 hover-none:opacity-70 dark:border-slate-700 dark:bg-slate-900/70'
+        className='g-code-copy'
       >
         {copied ? <Check size={12} /> : <Copy size={12} />}
         {copied ? 'Copied' : 'Copy'}
       </button>
-      <pre
-        ref={preRef}
-        className='shiki w-full overflow-x-auto whitespace-pre-wrap rounded-md bg-zinc-50 p-4 dark:bg-shiki-dark'
-      >
+      <pre ref={preRef} className='shiki g-pre w-full overflow-x-auto'>
         {children}
       </pre>
     </div>
@@ -112,7 +109,7 @@ export function Markdown({ content }: MarkdownProps) {
   }, []);
 
   return (
-    <article>
+    <article className='md'>
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkMath]}
         rehypePlugins={[
@@ -133,10 +130,7 @@ export function Markdown({ content }: MarkdownProps) {
             const id = typeof children === 'string' ? children : '';
 
             return (
-              <h2
-                id={id}
-                className='mb-6 mt-14 scroll-mt-20 text-balance text-2xl leading-none font-black first:mt-0'
-              >
+              <h2 id={id} className='scroll-mt-20'>
                 <a
                   href={`#${id}`}
                   onClick={(event) => {
@@ -150,24 +144,21 @@ export function Markdown({ content }: MarkdownProps) {
               </h2>
             );
           },
-          p: ({ children }) => <p className='mb-6 leading-7'>{children}</p>,
+          p: ({ children }) => <p>{children}</p>,
           a: ({ href, children }) => (
-            <a
-              href={href}
-              className='text-blue-700/80 transition-colors duration-300 ease-in-out hover:text-blue-700'
-              target='_blank'
-              rel='noreferrer'
-            >
+            <a href={href} target='_blank' rel='noreferrer'>
               {children}
             </a>
           ),
-          strong: ({ children }) => (
-            <b className='font-extrabold'>{children}</b>
-          ),
-          ul: ({ children }) => (
-            <ul className='mb-4 ml-4 list-disc'>{children}</ul>
-          ),
+          strong: ({ children }) => <b className='font-bold'>{children}</b>,
+          ul: ({ children }) => <ul>{children}</ul>,
           pre: ({ children }) => <CodeBlock>{children}</CodeBlock>,
+          code: ({ className, children }) =>
+            /language-/.test(className ?? '') ? (
+              <code className={className}>{children}</code>
+            ) : (
+              <code className='g-inline'>{children}</code>
+            ),
         }}
       >
         {content}

--- a/apps/web/src/lib/tag-color.ts
+++ b/apps/web/src/lib/tag-color.ts
@@ -1,0 +1,10 @@
+/** Deterministic neon chip color for an arbitrary tag (synthwave palette). */
+const NEON_COLORS = ['#ff4fd8', '#8b6cff', '#3ee6d2', '#ffd24f'];
+
+export function tagColor(tag: string): string {
+  let hash = 0;
+  for (let i = 0; i < tag.length; i += 1) {
+    hash = (hash * 31 + tag.charCodeAt(i)) % 997;
+  }
+  return NEON_COLORS[hash % NEON_COLORS.length];
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -26,7 +26,7 @@ export const Route = createRootRoute({
       },
       {
         name: 'theme-color',
-        content: '#000000',
+        content: '#120E24',
       },
     ],
     links: [
@@ -38,12 +38,14 @@ export const Route = createRootRoute({
   errorComponent: ({ error }) => (
     <RootDocument>
       <AppLayout>
-        <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-          <h2 className='mb-4 text-3xl'>Request Failed</h2>
-          <p className='mb-4 opacity-70'>{String(error)}</p>
-          <Link to='/blog' className='opacity-70 hover:opacity-100'>
-            Back to blog
-          </Link>
+        <div className='g-page'>
+          <div className='g-nf'>
+            <div className='code'>500</div>
+            <p>{String(error)}</p>
+            <Link to='/blog' className='g-btn g-btn-grad'>
+              ← 回到博客
+            </Link>
+          </div>
         </div>
       </AppLayout>
     </RootDocument>
@@ -51,12 +53,14 @@ export const Route = createRootRoute({
   notFoundComponent: () => (
     <RootDocument>
       <AppLayout>
-        <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-          <h2 className='mb-4 text-3xl'>404 Not Found</h2>
-          <p className='mb-4 opacity-70'>你闯入了无人之境...</p>
-          <Link to='/blog' className='opacity-70 hover:opacity-100'>
-            Back to blog
-          </Link>
+        <div className='g-page'>
+          <div className='g-nf'>
+            <div className='code'>404</div>
+            <p>你驶入了没有霓虹的街区。</p>
+            <Link to='/blog' className='g-btn g-btn-grad'>
+              ← 回到博客
+            </Link>
+          </div>
         </div>
       </AppLayout>
     </RootDocument>

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -1,10 +1,5 @@
 import { type CommentThread, canAccessVisibility } from '@blog/shared';
-import {
-  createFileRoute,
-  Link,
-  notFound,
-  redirect,
-} from '@tanstack/react-router';
+import { createFileRoute, notFound, redirect } from '@tanstack/react-router';
 import { Comments } from '../../components/comments.js';
 import { Markdown } from '../../components/markdown.js';
 import { getBlogPostServerFn } from '../../lib/blog-service.js';
@@ -70,23 +65,34 @@ function BlogDetailPage() {
     return null;
   }
 
-  const date = new Date(post.publishedAt).toLocaleDateString('en-US', {
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
-  });
+  const date = new Date(post.publishedAt).toISOString().slice(0, 10);
 
   return (
-    <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <div className='m-auto mb-8 flex flex-col gap-2'>
-        <div className='text-3xl font-black'>{post.title}</div>
-        <div className='opacity-60'>{date}</div>
+    <div className='g-page'>
+      <article className='g-panel g-art'>
+        <h1>{post.title}</h1>
+        <div className='meta'>
+          <span className='g-chip'>{date}</span>
+          <span className='g-chip'>{post.visibility.toUpperCase()}</span>
+          {post.tags.map((tag: string) => (
+            <span
+              key={tag}
+              className='g-chip'
+              style={{
+                color: 'var(--g-violet)',
+                borderColor: 'var(--g-violet)',
+              }}
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+        <Markdown content={post.contentMdx} />
+      </article>
+
+      <div className='g-list-head' style={{ paddingBottom: 8 }}>
+        <h1 style={{ fontSize: 16 }}>COMMENTS · {data.comments.total}</h1>
       </div>
-      <Markdown content={post.contentMdx} />
-      <Link to='/blog' className='mt-4 inline-block'>
-        <span className='opacity-70'>&gt;&nbsp;&nbsp;&nbsp;</span>
-        <span className='underline opacity-70 hover:opacity-100'>cd ..</span>
-      </Link>
       <Comments
         key={post.slug}
         slug={post.slug}

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -1,9 +1,9 @@
 import type { PostSummary, SessionUser } from '@blog/shared';
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useEffect } from 'react';
 import { z } from 'zod';
 import { getBlogListServerFn } from '../../lib/blog-service.js';
+import { tagColor } from '../../lib/tag-color.js';
 
 type BlogGroup = {
   year: string;
@@ -49,6 +49,21 @@ function getDevScopeHint(sessionUser: SessionUser | null | undefined): string {
   return '当前身份：member；可见范围：public/member';
 }
 
+const VIS_CLASS: Record<PostSummary['visibility'], string> = {
+  public: '',
+  member: 'g-vis mem',
+  vip: 'g-vis vip',
+  admin: 'g-vis adm',
+  password: 'g-vis pw',
+};
+const VIS_TEXT: Record<PostSummary['visibility'], string> = {
+  public: '',
+  member: 'MEMBER',
+  vip: 'VIP',
+  admin: 'ADMIN',
+  password: 'PASSWORD',
+};
+
 export const Route = createFileRoute('/blog/')({
   head: () => ({
     meta: [
@@ -77,88 +92,82 @@ function BlogListPage() {
   const devScopeHint = getDevScopeHint(data.sessionUser);
 
   // Conventional blog pagination: the page scrolls naturally; jump back to the
-  // top on each page change so the new page starts at its first post. (Without
-  // this, clicking "next" while scrolled to the bottom leaves the reader past a
-  // shorter page — the original "bounce".)
+  // top on each page change so the new page starts at its first post.
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-run on page change, value unused in body on purpose
   useEffect(() => {
     document.querySelector('main')?.scrollTo({ top: 0 });
   }, [data.page]);
 
   return (
-    <div className='mx-auto flex w-full max-w-[80ch] flex-col gap-8 self-start pt-8'>
-      <div className='w-full'>
-        {showDevHint ? (
-          <div className='mb-8 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900'>
-            {devScopeHint}
-          </div>
-        ) : null}
-        {blogGroups.map((group) => (
-          <div key={group.year}>
-            <div className='mb-4 text-3xl'>{group.year}</div>
-            {group.blogs.map((blog: PostSummary) => (
-              <div
-                key={blog.slug}
-                className='mt-2 mb-6 opacity-70 hover:opacity-100'
-              >
-                <Link
-                  to='/blog/$slug'
-                  params={{ slug: blog.slug }}
-                  className='flex items-center gap-2'
-                >
-                  <span className='text-lg leading-[1.2em]'>{blog.title}</span>
-                  <span className='text-sm opacity-50'>
-                    {new Date(blog.publishedAt).toLocaleDateString('en-US', {
-                      month: 'short',
-                      day: 'numeric',
-                    })}
-                  </span>
-                </Link>
-              </div>
-            ))}
-          </div>
-        ))}
+    <div className='g-page'>
+      <div className='g-list-head'>
+        <h1>Blog</h1>
+        <span className='g-cnt'>
+          — {data.total} POSTS / {data.totalPages} PAGES
+        </span>
       </div>
-      {data.totalPages > 1 ? (
-        <nav
-          className='flex w-full items-center justify-center gap-4 text-sm sm:gap-6'
-          aria-label='Pagination'
-        >
-          {data.page > 1 ? (
+
+      {showDevHint ? <div className='g-devhint'>{devScopeHint}</div> : null}
+
+      {blogGroups.map((group) => (
+        <div key={group.year}>
+          <div className='g-yr'>{group.year}</div>
+          {group.blogs.map((blog: PostSummary) => (
             <Link
-              to='/blog'
-              search={{ page: data.page - 1 }}
-              className='inline-flex items-center gap-1 opacity-60 hover:opacity-100'
+              key={blog.slug}
+              to='/blog/$slug'
+              params={{ slug: blog.slug }}
+              className='g-row'
             >
-              <ChevronLeft size={14} /> prev
+              <span className='no'>№{String(data.total).padStart(3, '0')}</span>
+              <span className='t'>
+                {blog.title}
+                {blog.visibility !== 'public' ? (
+                  <span className={VIS_CLASS[blog.visibility]}>
+                    {VIS_TEXT[blog.visibility]}
+                  </span>
+                ) : null}
+              </span>
+              <span className='tags'>
+                {blog.tags.map((tag: string) => (
+                  <span
+                    key={tag}
+                    className='g-chip'
+                    style={{ color: tagColor(tag), borderColor: tagColor(tag) }}
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </span>
+              <span className='d'>
+                {new Date(blog.publishedAt).toISOString().slice(5, 10)}
+              </span>
+            </Link>
+          ))}
+        </div>
+      ))}
+
+      {data.totalPages > 1 ? (
+        <nav className='g-pager' aria-label='Pagination'>
+          {data.page > 1 ? (
+            <Link to='/blog' search={{ page: data.page - 1 }}>
+              ← prev
             </Link>
           ) : (
-            <span className='inline-flex items-center gap-1 opacity-30'>
-              <ChevronLeft size={14} /> prev
-            </span>
+            <span style={{ opacity: 0.4 }}>← prev</span>
           )}
-          <span className='opacity-60'>
-            page {data.page} / {data.totalPages}
+          <span className='cur'>
+            {data.page} / {data.totalPages}
           </span>
           {data.page < data.totalPages ? (
-            <Link
-              to='/blog'
-              search={{ page: data.page + 1 }}
-              className='inline-flex items-center gap-1 opacity-60 hover:opacity-100'
-            >
-              next <ChevronRight size={14} />
+            <Link to='/blog' search={{ page: data.page + 1 }}>
+              next →
             </Link>
           ) : (
-            <span className='inline-flex items-center gap-1 opacity-30'>
-              next <ChevronRight size={14} />
-            </span>
+            <span style={{ opacity: 0.4 }}>next →</span>
           )}
         </nav>
       ) : null}
-      <Link to='/' className='mt-4 inline-block'>
-        <span className='opacity-70'>&gt;&nbsp;&nbsp;&nbsp;</span>
-        <span className='underline opacity-70 hover:opacity-100'>cd ..</span>
-      </Link>
     </div>
   );
 }

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,25 +1,71 @@
+import type { PostSummary } from '@blog/shared';
 import { createFileRoute, Link } from '@tanstack/react-router';
+import { getBlogListServerFn } from '../lib/blog-service.js';
+import { PROJECTS } from '../lib/projects.js';
 
 export const Route = createFileRoute('/')({
   head: () => ({
     meta: [{ title: "Home | PerfectPan's Blog" }],
   }),
+  loader: async () => {
+    // Guest-scoped first page powers the LATEST panel.
+    return getBlogListServerFn({ data: { page: 1 } });
+  },
   component: HomePage,
 });
 
 function HomePage() {
+  const data = Route.useLoaderData();
+  const latest = data.posts.slice(0, 4);
+
   return (
-    <div className='flex flex-col items-center'>
-      <img className='m-0' src='/images/xm.jpg' alt='' />
-      <div className='mt-8 text-[2.5rem] font-black'>
-        是个什么都不会的废物.jpg
-      </div>
-      <div className='flex w-full justify-around'>
-        <div className='mx-1 mt-8 flex-1 rounded-md bg-slate-100 text-center font-semibold uppercase tracking-wider leading-[5rem] shadow-md transition-shadow hover:shadow-lg dark:bg-wash-dark dark:text-white dark:opacity-80'>
-          <Link to='/blog'>Blog</Link>
+    <div className='g-page'>
+      <div className='g-hero'>
+        <div className='g-sun' aria-hidden='true' />
+        <div className='g-kicker'>NIGHT DRIVE · SINCE 2019</div>
+        <h1>PERFECTPAN</h1>
+        <p>
+          是个什么都不会的废物.jpg ——
+          但夜里还在写代码。算法竞赛旧题解、TypeScript 类型体操、Cloudflare
+          $0/月 工程实践，一路霓虹。
+        </p>
+        <div className='cta'>
+          <Link to='/blog' className='g-btn g-btn-grad'>
+            进入博客 →
+          </Link>
+          <Link to='/projects' className='g-btn'>
+            看看项目
+          </Link>
         </div>
-        <div className='mx-1 mt-8 flex-1 rounded-md bg-slate-100 text-center font-semibold uppercase tracking-wider leading-[5rem] shadow-md transition-shadow hover:shadow-lg dark:bg-wash-dark dark:text-white dark:opacity-80'>
-          <Link to='/projects'>Projects</Link>
+      </div>
+      <div className='g-home-grid'>
+        <div className='g-panel g-hpanel'>
+          <h3>LATEST / 最新</h3>
+          {latest.map((post: PostSummary, index: number) => (
+            <div className='g-hitem' key={post.slug}>
+              <span className='no'>
+                {String(data.total - index).padStart(3, '0')}
+              </span>
+              <Link className='t' to='/blog/$slug' params={{ slug: post.slug }}>
+                {post.title}
+              </Link>
+            </div>
+          ))}
+        </div>
+        <div className='g-panel g-hpanel'>
+          <h3 className='c'>DATA / 数据</h3>
+          <div className='g-hstat'>
+            <b>{data.total}</b>
+            <span>篇文章</span>
+          </div>
+          <div className='g-hstat'>
+            <b>{PROJECTS.length}</b>
+            <span>个开源项目</span>
+          </div>
+          <div className='g-hstat'>
+            <b>$0</b>
+            <span>每月托管费</span>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -34,96 +34,100 @@ function LoginPage() {
 
   if (sessionData?.user?.id || isSessionPending) {
     return (
-      <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-        <p className='opacity-70'>Checking session...</p>
-      </section>
+      <div className='g-page'>
+        <p className='g-hint pt-8 text-center'>Checking session…</p>
+      </div>
     );
   }
 
   return (
-    <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>登录</h1>
-      <p className='mb-6 opacity-70'>支持邮箱密码和 GitHub OAuth。</p>
+    <div className='g-page'>
+      <div className='g-auth'>
+        <div className='g-auth-head'>
+          <h1>登录</h1>
+          <span className='g-cnt'>AUTH / 01</span>
+        </div>
+        <div className='g-panel g-auth-card'>
+          <span className='g-glowline' aria-hidden='true' />
+          <form
+            method='post'
+            onSubmit={(event) => {
+              event.preventDefault();
+              setError(null);
+              startTransition(async () => {
+                const result = await authClient.signIn.email({
+                  email,
+                  password,
+                  callbackURL: '/blog',
+                });
 
-      {error ? (
-        <p role='alert' className='mb-4 text-sm text-red-700 dark:text-red-300'>
-          {error}
-        </p>
-      ) : null}
+                if (result.error) {
+                  setError(result.error.message ?? '登录失败');
+                  return;
+                }
 
-      <form
-        className='grid max-w-[420px] gap-3'
-        method='post'
-        onSubmit={(event) => {
-          event.preventDefault();
-          setError(null);
-          startTransition(async () => {
-            const result = await authClient.signIn.email({
-              email,
-              password,
-              callbackURL: '/blog',
-            });
-
-            if (result.error) {
-              setError(result.error.message ?? '登录失败');
-              return;
-            }
-
-            navigate({ to: '/blog' });
-          });
-        }}
-      >
-        <label htmlFor='email' className='font-semibold'>
-          Email
-        </label>
-        <input
-          id='email'
-          name='email'
-          type='email'
-          required
-          autoComplete='email'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-        />
-        <label htmlFor='password' className='font-semibold'>
-          Password
-        </label>
-        <input
-          id='password'
-          name='password'
-          type='password'
-          required
-          autoComplete='current-password'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={password}
-          onChange={(event) => setPassword(event.target.value)}
-        />
-        <button
-          type='submit'
-          className='rounded-md bg-black px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90 dark:bg-neutral-900'
-          disabled={isPending}
-        >
-          {isPending ? 'Signing in...' : 'Sign In'}
-        </button>
-      </form>
-
-      <button
-        type='button'
-        className='mt-3 rounded-md border border-slate-300 px-4 py-2 font-semibold transition-colors hover:bg-gray-100 dark:border-slate-700 dark:hover:bg-slate-800'
-        onClick={async () => {
-          setError(null);
-          const result = await authClient.signIn.social({
-            provider: 'github',
-            callbackURL: '/blog',
-          });
-          if (result.error) {
-            setError(result.error.message ?? 'GitHub 登录失败');
-          }
-        }}
-      >
-        Continue with GitHub
-      </button>
-    </section>
+                navigate({ to: '/blog' });
+              });
+            }}
+          >
+            <div className='g-field'>
+              <label htmlFor='email'>EMAIL</label>
+              <input
+                id='email'
+                name='email'
+                type='email'
+                required
+                autoComplete='email'
+                className='g-input'
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+              />
+            </div>
+            <div className='g-field'>
+              <label htmlFor='password'>PASSWORD</label>
+              <input
+                id='password'
+                name='password'
+                type='password'
+                required
+                autoComplete='current-password'
+                className='g-input'
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+            </div>
+            <div className='g-actions'>
+              <button
+                type='submit'
+                className='g-btn g-btn-grad'
+                disabled={isPending}
+              >
+                {isPending ? '登录中…' : '登录'}
+              </button>
+              <button
+                type='button'
+                className='g-btn'
+                onClick={async () => {
+                  setError(null);
+                  const result = await authClient.signIn.social({
+                    provider: 'github',
+                    callbackURL: '/blog',
+                  });
+                  if (result.error) {
+                    setError(result.error.message ?? 'GitHub 登录失败');
+                  }
+                }}
+              >
+                GitHub 登录
+              </button>
+            </div>
+            {error ? <p className='g-err'>{error}</p> : null}
+          </form>
+          <p className='g-aside'>
+            没有账号？<a href='/signup'>注册 →</a>
+          </p>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/routes/projects.tsx
+++ b/apps/web/src/routes/projects.tsx
@@ -1,6 +1,6 @@
-import { createFileRoute, Link } from '@tanstack/react-router';
-import { ExternalLink, Github } from 'lucide-react';
+import { createFileRoute } from '@tanstack/react-router';
 import { PROJECTS, type Project } from '../lib/projects.js';
+import { tagColor } from '../lib/tag-color.js';
 
 export const Route = createFileRoute('/projects')({
   head: () => ({
@@ -25,67 +25,43 @@ function ProjectsPage() {
   const projects = sortProjects(PROJECTS);
 
   return (
-    <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>Projects</h1>
-      <p className='mb-8 opacity-70'>我做过的一些东西，按需更新。</p>
-
-      <div className='grid gap-4 sm:grid-cols-2'>
+    <div className='g-page'>
+      <div className='g-list-head'>
+        <h1>Projects</h1>
+        <span className='g-cnt'>— {PROJECTS.length} WORKS</span>
+      </div>
+      <div className='g-proj-grid'>
         {projects.map((project) => (
-          <article
-            key={project.name}
-            className='flex flex-col rounded-lg border border-slate-200 bg-white/60 p-5 transition-shadow hover:shadow-md dark:border-slate-700 dark:bg-wash-dark'
-          >
-            <div className='mb-1 flex items-center gap-2'>
-              <h2 className='text-lg font-semibold'>{project.name}</h2>
-              {project.featured ? (
-                <span className='rounded-full bg-black px-2 py-[2px] text-[10px] font-semibold text-white dark:bg-neutral-100 dark:text-neutral-900'>
-                  FEATURED
-                </span>
-              ) : null}
-            </div>
-            <p className='mb-4 flex-grow text-sm opacity-70'>
-              {project.description}
-            </p>
-            <div className='mb-4 flex flex-wrap gap-1.5'>
+          <div className='g-panel g-proj-card' key={project.name}>
+            <h2>
+              {project.name}
+              {project.featured ? <span className='feat'>FEATURED</span> : null}
+            </h2>
+            <p>{project.description}</p>
+            <div className='tags'>
               {project.tags.map((tag) => (
                 <span
                   key={tag}
-                  className='rounded-md border border-slate-200 px-2 py-[2px] text-[11px] opacity-70 dark:border-slate-700'
+                  className='g-chip'
+                  style={{ color: tagColor(tag), borderColor: tagColor(tag) }}
                 >
                   {tag}
                 </span>
               ))}
             </div>
-            <div className='flex items-center gap-4 text-sm'>
-              <a
-                href={project.repo}
-                target='_blank'
-                rel='noreferrer'
-                className='inline-flex items-center gap-1 opacity-70 hover:opacity-100'
-              >
-                <Github size={15} />
-                Code
+            <div className='links'>
+              <a href={project.repo} target='_blank' rel='noreferrer'>
+                CODE ↗
               </a>
               {project.demo ? (
-                <a
-                  href={project.demo}
-                  target='_blank'
-                  rel='noreferrer'
-                  className='inline-flex items-center gap-1 opacity-70 hover:opacity-100'
-                >
-                  <ExternalLink size={15} />
-                  Demo
+                <a href={project.demo} target='_blank' rel='noreferrer'>
+                  DEMO ↗
                 </a>
               ) : null}
             </div>
-          </article>
+          </div>
         ))}
       </div>
-
-      <Link to='/' className='mt-8 inline-block'>
-        <span className='opacity-70'>&gt;&nbsp;&nbsp;&nbsp;</span>
-        <span className='underline opacity-70 hover:opacity-100'>cd ..</span>
-      </Link>
     </div>
   );
 }

--- a/apps/web/src/routes/signup.tsx
+++ b/apps/web/src/routes/signup.tsx
@@ -35,93 +35,111 @@ function SignUpPage() {
 
   if (sessionData?.user?.id || isSessionPending) {
     return (
-      <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-        <p className='opacity-70'>Checking session...</p>
-      </section>
+      <div className='g-page'>
+        <p className='g-hint pt-8 text-center'>Checking session…</p>
+      </div>
     );
   }
 
   return (
-    <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>注册</h1>
-      <p className='mb-6 opacity-70'>注册后默认角色为 member，可在后台升权。</p>
+    <div className='g-page'>
+      <div className='g-auth'>
+        <div className='g-auth-head'>
+          <h1>注册</h1>
+          <span className='g-cnt'>AUTH / 02</span>
+        </div>
+        <div className='g-panel g-auth-card'>
+          <span className='g-glowline' aria-hidden='true' />
+          <form
+            method='post'
+            onSubmit={(event) => {
+              event.preventDefault();
+              setError(null);
+              startTransition(async () => {
+                const result = await authClient.signUp.email({
+                  email,
+                  password,
+                  name,
+                  callbackURL: '/blog',
+                });
 
-      {error ? (
-        <p role='alert' className='mb-4 text-sm text-red-700 dark:text-red-300'>
-          {error}
-        </p>
-      ) : null}
+                if (result.error) {
+                  setError(result.error.message ?? '注册失败');
+                  return;
+                }
 
-      <form
-        className='grid max-w-[420px] gap-3'
-        method='post'
-        onSubmit={(event) => {
-          event.preventDefault();
-          setError(null);
-          startTransition(async () => {
-            const result = await authClient.signUp.email({
-              email,
-              password,
-              name,
-              callbackURL: '/blog',
-            });
-
-            if (result.error) {
-              setError(result.error.message ?? '注册失败');
-              return;
-            }
-
-            navigate({ to: '/blog' });
-          });
-        }}
-      >
-        <label htmlFor='name' className='font-semibold'>
-          Name
-        </label>
-        <input
-          id='name'
-          name='name'
-          type='text'
-          required
-          autoComplete='name'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={name}
-          onChange={(event) => setName(event.target.value)}
-        />
-        <label htmlFor='email' className='font-semibold'>
-          Email
-        </label>
-        <input
-          id='email'
-          name='email'
-          type='email'
-          required
-          autoComplete='email'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-        />
-        <label htmlFor='password' className='font-semibold'>
-          Password
-        </label>
-        <input
-          id='password'
-          name='password'
-          type='password'
-          required
-          autoComplete='new-password'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={password}
-          onChange={(event) => setPassword(event.target.value)}
-        />
-        <button
-          type='submit'
-          className='rounded-md bg-black px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90 dark:bg-neutral-900'
-          disabled={isPending}
-        >
-          {isPending ? 'Creating account...' : 'Sign Up'}
-        </button>
-      </form>
-    </section>
+                navigate({ to: '/blog' });
+              });
+            }}
+          >
+            <div className='g-field'>
+              <label htmlFor='name'>NAME</label>
+              <input
+                id='name'
+                name='name'
+                type='text'
+                required
+                autoComplete='name'
+                className='g-input'
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+              />
+            </div>
+            <div className='g-field'>
+              <label htmlFor='email'>EMAIL</label>
+              <input
+                id='email'
+                name='email'
+                type='email'
+                required
+                autoComplete='email'
+                className='g-input'
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+              />
+            </div>
+            <div className='g-field'>
+              <label htmlFor='password'>PASSWORD</label>
+              <input
+                id='password'
+                name='password'
+                type='password'
+                required
+                autoComplete='new-password'
+                className='g-input'
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+            </div>
+            <div className='g-actions'>
+              <button
+                type='submit'
+                className='g-btn g-btn-grad'
+                disabled={isPending}
+              >
+                {isPending ? '创建中…' : '创建账号'}
+              </button>
+              <button
+                type='button'
+                className='g-btn'
+                onClick={async () => {
+                  setError(null);
+                  const result = await authClient.signIn.social({
+                    provider: 'github',
+                    callbackURL: '/blog',
+                  });
+                  if (result.error) {
+                    setError(result.error.message ?? 'GitHub 注册失败');
+                  }
+                }}
+              >
+                GitHub 注册
+              </button>
+            </div>
+            {error ? <p className='g-err'>{error}</p> : null}
+          </form>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/routes/unlock/$slug.tsx
+++ b/apps/web/src/routes/unlock/$slug.tsx
@@ -78,48 +78,42 @@ function UnlockPage() {
     search.error === 'missing'
       ? '请输入访问密码'
       : search.error === 'invalid'
-        ? '密码错误，请重试'
+        ? '密码错误，请重试（连续失败会触发限流）'
         : undefined;
 
   return (
-    <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>输入文章访问密码</h1>
-      <p className='mb-6 opacity-70'>这篇文章使用了单文密码保护。</p>
-
-      {errorLabel ? (
-        <p role='alert' className='mb-4 text-sm text-red-700 dark:text-red-300'>
-          {errorLabel}
-        </p>
-      ) : null}
-
-      <form method='post' className='grid max-w-[420px] gap-3'>
-        <label htmlFor='password' className='font-semibold'>
-          Password
-        </label>
-        <input
-          id='password'
-          name='password'
-          type='password'
-          required
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-        />
-        <button
-          type='submit'
-          className='rounded-md bg-black px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90 dark:bg-neutral-900'
-        >
-          Unlock
-        </button>
-      </form>
-
-      <p className='mt-4'>
-        <Link
-          to='/blog/$slug'
-          params={{ slug }}
-          className='opacity-70 hover:opacity-100'
-        >
-          返回文章页
-        </Link>
-      </p>
-    </section>
+    <div className='g-page'>
+      <div className='g-auth'>
+        <div className='g-auth-head'>
+          <h1>解锁文章</h1>
+          <span className='g-cnt'>AUTH / 03</span>
+        </div>
+        <div className='g-panel g-auth-card'>
+          <span className='g-glowline' aria-hidden='true' />
+          <form method='post'>
+            <div className='g-field'>
+              <label htmlFor='password'>POST PASSWORD</label>
+              <input
+                id='password'
+                name='password'
+                type='password'
+                required
+                className='g-input'
+              />
+            </div>
+            {errorLabel ? <p className='g-err'>{errorLabel}</p> : null}
+            <div className='g-actions'>
+              <button type='submit' className='g-btn g-btn-grad'>
+                解锁
+              </button>
+              <Link to='/blog/$slug' params={{ slug }} className='g-btn'>
+                ← 返回文章
+              </Link>
+            </div>
+          </form>
+          <p className='g-aside'>验证后 24 小时内免密阅读本篇。</p>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -144,3 +144,980 @@ html.dark ::-webkit-scrollbar-thumb {
 html.dark ::-webkit-scrollbar-thumb:hover {
   background: rgb(148 163 184 / 0.55);
 }
+
+/* =====================================================================
+ * THEME G — Synthwave night drive (UX redesign direction G)
+ * Night-violet base, pink→violet→cyan gradients, striped sunset sun,
+ * perspective grid hero, faint scanlines. Neon on the bones only —
+ * body text stays plain for readability. Dark-native (no toggle).
+ * =================================================================== */
+:root {
+  --background: 252 45% 10%;
+  --foreground: 250 60% 92%;
+  --card: 252 35% 14%;
+  --card-foreground: 250 60% 92%;
+  --popover: 252 40% 12%;
+  --popover-foreground: 250 60% 92%;
+  --primary: 314 100% 65%;
+  --primary-foreground: 252 45% 10%;
+  --secondary: 252 30% 18%;
+  --secondary-foreground: 250 60% 92%;
+  --muted: 252 30% 18%;
+  --muted-foreground: 250 25% 62%;
+  --accent: 252 30% 22%;
+  --accent-foreground: 250 60% 92%;
+  --destructive: 314 100% 65%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 251 30% 26%;
+  --input: 251 30% 26%;
+  --ring: 314 100% 65%;
+  --radius: 0.75rem;
+
+  --g-bg: #120e24;
+  --g-panel: rgba(233, 228, 255, 0.045);
+  --g-panel-line: rgba(233, 228, 255, 0.13);
+  --g-ink: #e9e4ff;
+  --g-dim: #9c93c9;
+  --g-faint: #5e5690;
+  --g-pink: #ff4fd8;
+  --g-violet: #8b6cff;
+  --g-cyan: #3ee6d2;
+  --g-grad: linear-gradient(92deg, #ff4fd8 0%, #8b6cff 52%, #3ee6d2 100%);
+  --g-sans:
+    "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", system-ui, sans-serif;
+  --g-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}
+
+html {
+  background-color: var(--g-bg);
+  scrollbar-color: #3a3160 var(--g-bg);
+}
+
+html body {
+  font-family: var(--g-sans);
+  background:
+    radial-gradient(
+      1100px 500px at 85% -10%,
+      rgba(255, 79, 216, 0.14),
+      transparent 60%
+    ),
+    radial-gradient(
+      900px 500px at 10% 110%,
+      rgba(62, 230, 210, 0.1),
+      transparent 60%
+    ),
+    var(--g-bg);
+  background-attachment: fixed;
+  color: var(--g-ink);
+  font-size: 15px;
+  line-height: 1.85;
+  position: relative;
+}
+
+/* faint CRT scanlines */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 90;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.1) 0 1px,
+    transparent 1px 3px
+  );
+  mix-blend-mode: multiply;
+  opacity: 0.45;
+}
+
+::selection {
+  background: rgba(255, 79, 216, 0.35);
+}
+
+/* ---------- shell ---------- */
+.g-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+}
+.g-main {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.g-head {
+  padding: 24px 0 20px;
+}
+.g-head-in {
+  max-width: 1060px;
+  margin: 0 auto;
+  padding: 0 24px;
+  display: flex;
+  align-items: center;
+  gap: 26px;
+  flex-wrap: wrap;
+}
+.g-logo {
+  font-size: 17px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  color: var(--g-ink);
+}
+.g-logo b {
+  background: var(--g-grad);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.g-logo:hover {
+  text-decoration: none;
+}
+.g-head nav {
+  display: flex;
+  gap: 20px;
+  font-size: 13.5px;
+}
+.g-head nav a {
+  color: var(--g-dim);
+}
+.g-head nav a:hover {
+  color: var(--g-ink);
+  text-decoration: none;
+}
+.g-head nav a.on {
+  color: var(--g-ink);
+  border-bottom: 2px solid transparent;
+  border-image: var(--g-grad) 1;
+  padding-bottom: 2px;
+}
+.g-head .tools {
+  margin-left: auto;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.g-tool {
+  font-family: var(--g-sans);
+  font-size: 12px;
+  color: var(--g-dim);
+  background: none;
+  border: 1px solid var(--g-panel-line);
+  border-radius: 999px;
+  padding: 5px 14px;
+  cursor: pointer;
+}
+.g-tool:hover {
+  color: var(--g-cyan);
+  border-color: rgba(62, 230, 210, 0.5);
+  box-shadow: 0 0 14px rgba(62, 230, 210, 0.2);
+  text-decoration: none;
+}
+.g-user {
+  display: none;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--g-dim);
+}
+@media (min-width: 768px) {
+  .g-user {
+    display: inline-flex;
+  }
+}
+.g-role {
+  font-family: var(--g-mono);
+  font-size: 10px;
+  background: var(--g-grad);
+  color: #140f26;
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.g-foot {
+  max-width: 1060px;
+  margin: 0 auto;
+  padding: 20px 24px 40px;
+  font-family: var(--g-mono);
+  font-size: 11px;
+  color: var(--g-faint);
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.g-foot :where(a) {
+  color: var(--g-dim);
+}
+.g-foot :where(a):hover {
+  color: var(--g-cyan);
+}
+
+/* ---------- shared ---------- */
+.g-page {
+  max-width: 1060px;
+  margin: 0 auto;
+  padding: 0 24px 80px;
+}
+.g-panel {
+  background: var(--g-panel);
+  border: 1px solid var(--g-panel-line);
+  border-radius: 14px;
+  backdrop-filter: blur(6px);
+}
+.g-btn {
+  font-family: var(--g-sans);
+  font-size: 13.5px;
+  font-weight: 700;
+  cursor: pointer;
+  color: var(--g-ink);
+  background: none;
+  border: 1px solid var(--g-panel-line);
+  border-radius: 999px;
+  padding: 10px 24px;
+  transition:
+    box-shadow 0.15s,
+    border-color 0.15s;
+}
+.g-btn:hover {
+  border-color: var(--g-cyan);
+  box-shadow: 0 0 18px rgba(62, 230, 210, 0.28);
+  text-decoration: none;
+}
+.g-btn-grad {
+  background: var(--g-grad);
+  color: #140f26;
+  border: 0;
+}
+.g-btn-grad:hover {
+  box-shadow: 0 0 24px rgba(255, 79, 216, 0.45);
+  color: #140f26;
+}
+.g-chip {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--g-mono);
+  font-size: 11px;
+  border: 1px solid var(--g-panel-line);
+  border-radius: 999px;
+  padding: 1px 11px;
+  color: var(--g-dim);
+  white-space: nowrap;
+}
+.g-vis {
+  font-family: var(--g-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  margin-left: 12px;
+}
+.g-vis.mem {
+  color: var(--g-cyan);
+}
+.g-vis.vip {
+  color: var(--g-violet);
+}
+.g-vis.pw {
+  color: var(--g-pink);
+}
+.g-vis.adm {
+  color: var(--g-dim);
+}
+
+/* ---------- home hero ---------- */
+.g-hero {
+  position: relative;
+  border: 1px solid var(--g-panel-line);
+  border-radius: 18px;
+  background:
+    linear-gradient(180deg, rgba(255, 79, 216, 0.06), rgba(18, 14, 36, 0) 40%),
+    var(--g-panel);
+  overflow: hidden;
+  padding: 56px 46px 130px;
+  margin-top: 10px;
+}
+.g-sun {
+  position: absolute;
+  right: 70px;
+  top: 40px;
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #ffe29a 0%, #ff9a5c 34%, #ff4fd8 100%);
+  box-shadow:
+    0 0 60px rgba(255, 79, 216, 0.35),
+    0 0 130px rgba(255, 79, 216, 0.18);
+}
+.g-sun::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent 0 12px,
+    var(--g-bg) 12px 16px
+  );
+  mask: linear-gradient(180deg, transparent 42%, #000 46%);
+  -webkit-mask: linear-gradient(180deg, transparent 42%, #000 46%);
+}
+@media (prefers-reduced-motion: reduce) {
+  .g-sun {
+    animation: none;
+  }
+}
+.g-hero::after {
+  content: "";
+  position: absolute;
+  left: -24%;
+  right: -24%;
+  bottom: -58px;
+  height: 130px;
+  background:
+    linear-gradient(rgba(62, 230, 210, 0.22) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(139, 108, 255, 0.22) 1px, transparent 1px);
+  background-size:
+    46px 32px,
+    46px 32px;
+  transform: perspective(340px) rotateX(48deg);
+  -webkit-mask-image: linear-gradient(180deg, transparent, #000 55%);
+  mask-image: linear-gradient(180deg, transparent, #000 55%);
+  pointer-events: none;
+}
+.g-kicker {
+  font-family: var(--g-mono);
+  font-size: 11.5px;
+  letter-spacing: 0.4em;
+  color: var(--g-cyan);
+}
+.g-hero h1 {
+  margin-top: 16px;
+  font-size: clamp(42px, 7vw, 72px);
+  font-weight: 900;
+  line-height: 1.06;
+  background: var(--g-grad);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  filter: drop-shadow(0 0 22px rgba(255, 79, 216, 0.25));
+}
+.g-hero p {
+  margin-top: 18px;
+  color: var(--g-dim);
+  max-width: 52ch;
+}
+.g-hero .cta {
+  margin-top: 30px;
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+  position: relative;
+  z-index: 2;
+}
+@media (max-width: 720px) {
+  .g-hero {
+    padding: 40px 26px 110px;
+  }
+  .g-sun {
+    right: 22px;
+    width: 100px;
+    height: 100px;
+    top: 28px;
+  }
+}
+
+.g-home-grid {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  gap: 18px;
+  margin-top: 18px;
+}
+.g-hpanel {
+  padding: 22px 26px;
+}
+.g-hpanel h3 {
+  font-size: 12px;
+  letter-spacing: 0.3em;
+  font-family: var(--g-mono);
+  color: var(--g-pink);
+  margin-bottom: 12px;
+}
+.g-hpanel h3.c {
+  color: var(--g-cyan);
+}
+.g-hitem {
+  display: flex;
+  gap: 14px;
+  align-items: baseline;
+  padding: 8px 0;
+  border-bottom: 1px dashed rgba(233, 228, 255, 0.09);
+}
+.g-hitem:last-child {
+  border-bottom: 0;
+}
+.g-hitem .no {
+  font-family: var(--g-mono);
+  font-size: 11px;
+  color: var(--g-faint);
+}
+.g-hitem .t {
+  flex: 1;
+  color: var(--g-ink);
+  font-weight: 600;
+  font-size: 14.5px;
+}
+.g-hitem .t:hover {
+  color: var(--g-pink);
+  text-shadow: 0 0 12px rgba(255, 79, 216, 0.4);
+  text-decoration: none;
+}
+.g-hstat {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 0;
+  border-bottom: 1px dashed rgba(233, 228, 255, 0.09);
+}
+.g-hstat:last-child {
+  border-bottom: 0;
+}
+.g-hstat b {
+  font-size: 25px;
+  font-weight: 800;
+  background: var(--g-grad);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.g-hstat :where(span) {
+  font-size: 12.5px;
+  color: var(--g-dim);
+}
+@media (max-width: 860px) {
+  .g-home-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ---------- blog list ---------- */
+.g-list-head {
+  padding: 34px 0 18px;
+  display: flex;
+  align-items: baseline;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+.g-list-head h1 {
+  font-size: 36px;
+  font-weight: 900;
+}
+.g-cnt {
+  font-family: var(--g-mono);
+  font-size: 11.5px;
+  color: var(--g-faint);
+  letter-spacing: 0.14em;
+}
+.g-yr {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 24px 6px 10px;
+  font-family: var(--g-mono);
+  font-size: 12px;
+  letter-spacing: 0.4em;
+  color: var(--g-faint);
+}
+.g-yr::after {
+  content: "";
+  flex: 1;
+  border-top: 1px dashed rgba(233, 228, 255, 0.14);
+}
+.g-row {
+  display: grid;
+  grid-template-columns: 56px 1fr auto 84px;
+  gap: 18px;
+  align-items: center;
+  padding: 13px 16px;
+  border-radius: 12px;
+  border: 1px solid transparent;
+}
+a.g-row {
+  color: var(--g-ink);
+}
+a.g-row:hover {
+  background: var(--g-panel);
+  border-color: var(--g-panel-line);
+  box-shadow: 0 0 24px rgba(139, 108, 255, 0.12);
+  text-decoration: none;
+}
+.g-row .no {
+  font-family: var(--g-mono);
+  font-size: 12px;
+  color: var(--g-faint);
+}
+.g-row .t {
+  font-weight: 600;
+  font-size: 15.5px;
+}
+.g-row .tags {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+.g-row .d {
+  font-family: var(--g-mono);
+  font-size: 11px;
+  color: var(--g-faint);
+  text-align: right;
+}
+.g-pager {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 30px;
+}
+.g-pager :where(a),
+.g-pager :where(span) {
+  font-family: var(--g-mono);
+  font-size: 12px;
+  color: var(--g-dim);
+  background: none;
+  border: 1px solid var(--g-panel-line);
+  border-radius: 8px;
+  padding: 5px 14px;
+}
+.g-pager .cur {
+  background: var(--g-grad);
+  color: #140f26;
+  border-color: transparent;
+  font-weight: 700;
+}
+.g-pager :where(a):hover {
+  border-color: var(--g-cyan);
+  color: var(--g-cyan);
+  text-decoration: none;
+}
+.g-devhint {
+  font-family: var(--g-mono);
+  font-size: 12px;
+  color: var(--g-faint);
+  border: 1px dashed var(--g-panel-line);
+  padding: 8px 14px;
+  margin: 14px 0;
+}
+@media (max-width: 720px) {
+  .g-row {
+    grid-template-columns: 44px 1fr;
+  }
+  .g-row .tags,
+  .g-row .d {
+    display: none;
+  }
+}
+
+/* ---------- article ---------- */
+.g-art {
+  padding: 36px 44px 44px;
+  margin-top: 6px;
+}
+.g-art h1 {
+  font-size: clamp(26px, 4vw, 38px);
+  font-weight: 900;
+  line-height: 1.3;
+}
+.g-art .meta {
+  display: flex;
+  gap: 10px;
+  margin: 16px 0 6px;
+  flex-wrap: wrap;
+}
+
+.md {
+  margin-top: 28px;
+  max-width: 70ch;
+  font-size: 16px;
+}
+.md p {
+  margin: 17px 0;
+  color: #d6cff2;
+}
+.md h2 {
+  font-size: 20px;
+  font-weight: 800;
+  margin: 38px 0 12px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  scroll-margin-top: 20px;
+}
+.md h2 .no {
+  font-family: var(--g-mono);
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--g-pink);
+  letter-spacing: 0.2em;
+}
+.md h2::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(139, 108, 255, 0.4), transparent);
+}
+.md h2 a {
+  color: inherit;
+}
+.md ul {
+  margin: 14px 0;
+  list-style: none;
+}
+.md ul li {
+  padding: 7px 0 7px 26px;
+  position: relative;
+  color: #d6cff2;
+}
+.md ul li::before {
+  content: "◈";
+  position: absolute;
+  left: 0;
+  color: var(--g-cyan);
+  font-size: 12px;
+}
+.md :where(a) {
+  color: var(--g-cyan);
+}
+.md blockquote {
+  border-left: 3px solid;
+  border-image: linear-gradient(180deg, #ff4fd8, #8b6cff) 1;
+  background: rgba(139, 108, 255, 0.08);
+  padding: 12px 22px;
+  margin: 22px 0;
+  color: var(--g-dim);
+  border-radius: 0 10px 10px 0;
+}
+.md :where(code.g-inline) {
+  font-family: var(--g-mono);
+  font-size: 0.85em;
+  color: var(--g-cyan);
+  background: rgba(62, 230, 210, 0.08);
+  border: 1px solid rgba(62, 230, 210, 0.18);
+  border-radius: 6px;
+  padding: 1px 7px;
+}
+
+.g-code {
+  position: relative;
+  margin: 24px 0;
+}
+.g-code-copy {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  z-index: 10;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid rgba(255, 79, 216, 0.35);
+  background: rgba(18, 14, 36, 0.9);
+  color: var(--g-pink);
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: 10.5px;
+  font-family: var(--g-mono);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.g-code:hover .g-code-copy,
+.g-code-copy:focus-visible {
+  opacity: 1;
+}
+@media not (hover: hover) {
+  .g-code-copy {
+    opacity: 0.75;
+  }
+}
+.md pre.g-pre {
+  font-family: var(--g-mono);
+  font-size: 13px;
+  line-height: 1.8;
+  color: #e4def9;
+  background: #0d0a1c;
+  border: 1px solid rgba(233, 228, 255, 0.12);
+  border-radius: 12px;
+  box-shadow: inset 0 0 40px rgba(139, 108, 255, 0.07);
+  padding: 20px 22px;
+  overflow-x: auto;
+  margin: 0;
+}
+.md pre.g-pre code {
+  background: none;
+  padding: 0;
+}
+.md pre.g-pre {
+  /* biome-ignore lint/complexity/noImportantStyles: shiki writes an inline light bg; the panel is night violet. */
+  background: #0d0a1c !important;
+}
+.md pre.g-pre span {
+  /* biome-ignore lint/complexity/noImportantStyles: force shiki dark tokens (SSR-safe). */
+  color: var(--shiki-dark) !important;
+}
+
+/* ---------- comments ---------- */
+.g-cmt {
+  padding: 16px 20px;
+  margin: 12px 0;
+}
+.g-cmt.reply {
+  margin-left: 44px;
+  border-left: 2px solid rgba(139, 108, 255, 0.5);
+}
+.g-cmt-h {
+  display: flex;
+  gap: 12px;
+  font-family: var(--g-mono);
+  font-size: 11.5px;
+  color: var(--g-dim);
+  margin-bottom: 6px;
+  flex-wrap: wrap;
+}
+.g-cmt-h .who {
+  color: var(--g-cyan);
+}
+.g-cmt-b p {
+  margin: 0 0 6px;
+  font-size: 14.5px;
+  color: #d6cff2;
+}
+.g-cmt-b p:last-child {
+  margin-bottom: 0;
+}
+.g-cmt-b :where(code) {
+  font-family: var(--g-mono);
+  font-size: 0.85em;
+  color: var(--g-cyan);
+  background: rgba(62, 230, 210, 0.08);
+  border: 1px solid rgba(62, 230, 210, 0.18);
+  border-radius: 6px;
+  padding: 0 5px;
+}
+.g-cmt-b blockquote {
+  border-left: 2px solid var(--g-panel-line);
+  padding-left: 12px;
+  color: var(--g-dim);
+}
+.g-cmt-ops {
+  display: flex;
+  gap: 14px;
+  font-family: var(--g-mono);
+  font-size: 11.5px;
+  margin-top: 8px;
+}
+.g-cmt-ops :where(button) {
+  color: var(--g-dim);
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font-family: var(--g-mono);
+  font-size: 11.5px;
+  padding: 0;
+}
+.g-cmt-ops :where(button):hover {
+  color: var(--g-cyan);
+}
+.g-cmt-form textarea {
+  width: 100%;
+  resize: vertical;
+  font-family: var(--g-sans);
+  font-size: 14.5px;
+  color: var(--g-ink);
+  background: rgba(10, 7, 22, 0.6);
+  border: 1px solid var(--g-panel-line);
+  border-radius: 10px;
+  padding: 11px 15px;
+}
+.g-cmt-form textarea:focus {
+  outline: none;
+  border-color: rgba(62, 230, 210, 0.55);
+  box-shadow: 0 0 16px rgba(62, 230, 210, 0.15);
+}
+.g-cmt-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 8px;
+}
+.g-hint {
+  font-size: 12px;
+  color: var(--g-faint);
+}
+.g-hint .err {
+  color: var(--g-pink);
+  margin-left: 8px;
+}
+
+/* ---------- projects ---------- */
+.g-proj-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 18px;
+}
+.g-proj-card {
+  padding: 24px 26px;
+  position: relative;
+  overflow: hidden;
+}
+.g-proj-card::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--g-grad);
+  opacity: 0.65;
+}
+.g-proj-card h2 {
+  font-size: 18px;
+  font-weight: 800;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.g-proj-card h2 .feat {
+  font-size: 10px;
+  font-family: var(--g-mono);
+  letter-spacing: 0.2em;
+  color: var(--g-pink);
+  border: 1px solid rgba(255, 79, 216, 0.4);
+  border-radius: 999px;
+  padding: 0 10px;
+}
+.g-proj-card p {
+  margin-top: 8px;
+  font-size: 13.5px;
+  color: var(--g-dim);
+}
+.g-proj-card .tags {
+  margin: 14px 0;
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.g-proj-card .links {
+  display: flex;
+  gap: 16px;
+  font-family: var(--g-mono);
+  font-size: 12px;
+}
+.g-proj-card .links a {
+  color: var(--g-dim);
+}
+.g-proj-card .links a:hover {
+  color: var(--g-cyan);
+  text-decoration: none;
+}
+@media (max-width: 860px) {
+  .g-proj-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ---------- auth ---------- */
+.g-auth {
+  max-width: 440px;
+  margin: 40px auto 0;
+}
+.g-auth-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding-bottom: 10px;
+}
+.g-auth-head h1 {
+  font-size: 24px;
+  font-weight: 900;
+}
+.g-auth-card {
+  padding: 34px 36px 36px;
+  position: relative;
+}
+.g-glowline {
+  position: absolute;
+  top: 0;
+  left: 24px;
+  right: 24px;
+  height: 2px;
+  background: var(--g-grad);
+  border-radius: 2px;
+}
+.g-field {
+  margin: 16px 0;
+}
+.g-field label {
+  display: block;
+  font-family: var(--g-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.24em;
+  color: var(--g-faint);
+  margin-bottom: 6px;
+}
+.g-input {
+  width: 100%;
+  font-family: var(--g-sans);
+  font-size: 14.5px;
+  color: var(--g-ink);
+  background: rgba(10, 7, 22, 0.6);
+  border: 1px solid var(--g-panel-line);
+  border-radius: 10px;
+  padding: 11px 15px;
+}
+.g-input:focus {
+  outline: none;
+  border-color: rgba(62, 230, 210, 0.55);
+  box-shadow: 0 0 16px rgba(62, 230, 210, 0.15);
+}
+.g-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 24px;
+  flex-wrap: wrap;
+}
+.g-err {
+  margin-top: 16px;
+  font-size: 13px;
+  color: var(--g-pink);
+  border: 1px solid rgba(255, 79, 216, 0.4);
+  background: rgba(255, 79, 216, 0.07);
+  border-radius: 10px;
+  padding: 8px 14px;
+}
+.g-aside {
+  margin-top: 20px;
+  font-size: 13px;
+  color: var(--g-dim);
+}
+.g-aside :where(a) {
+  color: var(--g-pink);
+}
+
+/* ---------- 404 ---------- */
+.g-nf {
+  text-align: center;
+  padding: 80px 0 40px;
+}
+.g-nf .code {
+  font-size: 96px;
+  font-weight: 900;
+  background: var(--g-grad);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  filter: drop-shadow(0 0 24px rgba(255, 79, 216, 0.3));
+}
+.g-nf p {
+  color: var(--g-dim);
+  margin: 14px 0 28px;
+}

--- a/tests/e2e/admin-flow.spec.ts
+++ b/tests/e2e/admin-flow.spec.ts
@@ -19,7 +19,7 @@ test('admin can create a post that appears on the blog', async ({ page }) => {
   await page.locator('#password').fill(ADMIN_PASSWORD);
   await page.locator('form button[type="submit"]').click();
 
-  const loggedIn = page.getByRole('link', { name: /logout/i });
+  const loggedIn = page.getByTestId('nav-logout');
   try {
     await expect(loggedIn).toBeVisible({ timeout: 8000 });
   } catch {

--- a/tests/e2e/auth-logout.spec.ts
+++ b/tests/e2e/auth-logout.spec.ts
@@ -8,18 +8,20 @@ function createUniqueEmail(): string {
 test('signup then logout returns to guest header state', async ({ page }) => {
   await page.goto('/signup', { waitUntil: 'domcontentloaded' });
 
-  await page.getByLabel('Name').fill('E2E Logout');
-  await page.getByLabel('Email').fill(createUniqueEmail());
-  await page.getByLabel('Password').fill('Playwright!12345');
-  await page.getByRole('button', { name: 'Sign Up' }).click();
+  // Form anchors are theme-stable: field ids on /signup + the submit button.
+  // Header anchors use data-testid because each UX theme words them
+  // differently (login / 入会 / SIGN IN …).
+  await page.locator('#name').fill('E2E Logout');
+  await page.locator('#email').fill(createUniqueEmail());
+  await page.locator('#password').fill('Playwright!12345');
+  await page.locator('form button[type="submit"]').click();
 
   await page.waitForURL('**/blog');
-  await expect(page.getByRole('link', { name: 'Logout' })).toBeVisible();
+  await expect(page.getByTestId('nav-logout')).toBeVisible();
 
-  await page.getByRole('link', { name: 'Logout' }).click();
+  await page.getByTestId('nav-logout').click();
 
   await page.waitForURL('**/blog');
-  await expect(page.getByRole('link', { name: 'Login' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Sign Up' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Logout' })).toHaveCount(0);
+  await expect(page.getByTestId('nav-login')).toBeVisible();
+  await expect(page.getByTestId('nav-logout')).toHaveCount(0);
 });


### PR DESCRIPTION
## What — UX 改版方向 G「霓虹夜行」落地

把原型 `prototypes/g-synthwave.html` 落到真实应用：夜紫底 + 粉→紫→青渐层，霓虹只做骨架、正文素净。

- **首页**：**CSS 条纹落日**（黄→粉渐层圆 + 横纹 mask + 辉光）+ **透视地平线网格** hero + 渐层巨型词标；玻璃面板（最新/数据）
- **全站**：极淡 CRT 扫描线、玻璃圆角面板、粉/青双色 hover 辉光、当前页渐层下划线
- **博客列表**：年份虚线带 + 玻璃行 hover 辉光；标签 = 霓虹色 chip（粉/紫/青/黄按标签名确定性配色）；MEMBER/VIP/PASSWORD 小字色标
- **文章页**：渐层尾巴二级标题 + ◈ 列表符 + 渐层左边框引用块 + 夜色代码面板（局部强制 shiki 暗色 token，SSR 安全）
- **登录/注册/解锁**：渐层顶线玻璃卡（AUTH 01-03）；**404 = 渐层巨型数字**
- 夜紫 #120E24 暗色原生（隐藏主题切换）；reduced-motion 友好

## 不变的东西

路由 / loader / 鉴权 / 评论 / 搜索逻辑未动；首页新增只读 loader。Admin 沿用现有样式。

## 验证

- [x] typecheck / lint / test 36 passed / build + 体积 **1024.5 KiB gzip**
- [x] 生产构建 wrangler dev 受控探针：/blog 4/4 clean；文章页 #418 与 master 基线一致（评论区相对时间 SSR/CSR 差异，既有问题，见 #99 PR 说明）
- [x] DOM/CSS 断言：夜紫底 rgb(18,14,36)、落日、渐层字、扫描线、代码面板 rgb(13,10,28) + 青 token

> 7 个候选方向之一（A–G）。预览用 Workers Builds preview URL。