### PR TITLE
feat(web): ship terminal + journal as switchable dual themes

### DIFF
--- a/apps/web/src/components/comments.tsx
+++ b/apps/web/src/components/comments.tsx
@@ -20,14 +20,6 @@ type CommentsProps = {
 
 const PAGE_SIZE = 20;
 
-function getInitials(name: string): string {
-  const trimmed = name.trim();
-  if (!trimmed) {
-    return '?';
-  }
-  return trimmed.slice(0, 1).toUpperCase();
-}
-
 function formatRelative(iso: string): string {
   const then = new Date(iso).getTime();
   if (Number.isNaN(then)) {
@@ -54,24 +46,6 @@ function formatRelative(iso: string): string {
     day: 'numeric',
     year: 'numeric',
   });
-}
-
-function Avatar({ name, image }: { name: string; image: string | null }) {
-  if (image) {
-    return (
-      <img
-        src={image}
-        alt={name}
-        loading='lazy'
-        className='h-8 w-8 shrink-0 rounded-full bg-zinc-100 dark:bg-zinc-800'
-      />
-    );
-  }
-  return (
-    <div className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-zinc-200 text-xs font-semibold text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300'>
-      {getInitials(name)}
-    </div>
-  );
 }
 
 type ComposerProps = {
@@ -107,26 +81,25 @@ function Composer({
   }
 
   return (
-    <form onSubmit={handleSubmit} className='flex flex-col gap-2'>
+    <form onSubmit={handleSubmit} className='th-cmt-form flex flex-col gap-2'>
       <textarea
         value={body}
         onChange={(event) => setBody(event.target.value)}
         placeholder={placeholder}
         rows={compact ? 2 : 3}
         maxLength={2000}
-        className='w-full resize-y rounded-md border border-zinc-300 bg-transparent px-3 py-2 text-sm outline-none transition-colors focus:border-zinc-400 dark:border-zinc-600 dark:focus:border-zinc-400'
       />
       <div className='flex items-center justify-between gap-2'>
-        <span className='text-xs opacity-50'>
+        <span className='th-cmt-hint'>
           {remaining < 200 ? `${remaining} 字剩余` : '支持 Markdown'}
-          {error ? <span className='ml-2 text-red-500'>{error}</span> : null}
+          {error ? <span className='th-err ml-2 inline'>{error}</span> : null}
         </span>
         <button
           type='submit'
           disabled={submitting || !body.trim()}
-          className='rounded-md bg-black px-3 py-1 text-xs font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-neutral-900'
+          className='th-btn th-btn-primary'
         >
-          {submitting ? '发送中…' : '发送'}
+          {submitting ? '发送中…' : 'reply'}
         </button>
       </div>
     </form>
@@ -191,7 +164,7 @@ function CommentItem({
       ) : null}
 
       {thread.replies.length > 0 ? (
-        <ul className='ml-10 flex flex-col gap-2 border-l border-zinc-200 pl-4 dark:border-zinc-700'>
+        <ul className='th-cmt-replies'>
           {thread.replies.map((reply) => {
             const replyCanAct =
               sessionUser != null &&
@@ -201,6 +174,7 @@ function CommentItem({
                 key={reply.id}
                 comment={reply}
                 canAct={replyCanAct}
+                canReply={false}
                 onReply={undefined}
                 onDelete={async () => {
                   if (!window.confirm('删除这条回复？')) {
@@ -233,49 +207,39 @@ function CommentView({
   onDelete,
 }: CommentViewProps) {
   return (
-    <div className='flex gap-3'>
-      <Avatar name={comment.author.name} image={comment.author.image} />
-      <div className='min-w-0 flex-1'>
-        <div className='flex flex-wrap items-center gap-x-2 gap-y-0.5'>
-          <span className='text-sm font-semibold'>{comment.author.name}</span>
-          {comment.author.role === 'admin' ? (
-            <span className='rounded bg-zinc-900 px-1.5 py-0.5 text-[10px] font-semibold text-white dark:bg-white dark:text-zinc-900'>
-              Author
-            </span>
-          ) : null}
-          {comment.status !== 'visible' ? (
-            <span className='rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'>
-              {comment.status}
-            </span>
-          ) : null}
-          <span className='text-xs opacity-50'>
-            {formatRelative(comment.createdAt)}
-          </span>
-        </div>
-        <div className='mt-1'>
-          <CommentMarkdown content={comment.body} />
-        </div>
-        <div className='mt-1 flex gap-3 text-xs'>
-          {canReply && onReply ? (
-            <button
-              type='button'
-              onClick={onReply}
-              className='opacity-50 transition-opacity hover:opacity-100'
-            >
-              回复
-            </button>
-          ) : null}
-          {canAct ? (
-            <button
-              type='button'
-              onClick={() => onDelete()}
-              className='text-red-500/70 transition-colors hover:text-red-500'
-            >
-              删除
-            </button>
-          ) : null}
-        </div>
+    <div className='th-cmt'>
+      <div className='th-cmt-head'>
+        <span className='who'>{comment.author.name}</span>
+        {comment.author.role === 'admin' ? (
+          <span className='th-role-badge'>AUTHOR</span>
+        ) : null}
+        {comment.status !== 'visible' ? (
+          <span className='th-perm-pw'>{comment.status}</span>
+        ) : null}
+        <span>{formatRelative(comment.createdAt)}</span>
       </div>
+      <div className='th-cmt-body'>
+        <CommentMarkdown content={comment.body} />
+      </div>
+      {canReply && onReply ? (
+        <div className='th-cmt-ops'>
+          <button type='button' onClick={onReply}>
+            reply
+          </button>
+          {canAct ? (
+            <button type='button' className='del' onClick={() => onDelete()}>
+              rm
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+      {!(canReply && onReply) && canAct ? (
+        <div className='th-cmt-ops'>
+          <button type='button' className='del' onClick={() => onDelete()}>
+            rm
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -316,7 +280,7 @@ export function Comments({
     setReplySubmitting((prev) => new Set(prev).add(parentId));
     try {
       const { comment } = await createCommentServerFn({
-        data: { slug, parentId, body },
+        data: { slug, body, parentId },
       });
       setThreads((prev) =>
         prev.map((thread) =>
@@ -375,10 +339,12 @@ export function Comments({
   }
 
   return (
-    <section className='mt-12'>
-      <h2 className='mb-4 text-lg font-black'>
-        评论 {total > 0 ? <span className='opacity-50'>({total})</span> : null}
-      </h2>
+    <section className='mt-10'>
+      <div className='th-prompt mb-4'>
+        <span className='th-prompt-p'>~ %</span>{' '}
+        <span className='th-cmd'>comments --on {slug}</span>{' '}
+        <span className='th-comment'>({total})</span>
+      </div>
 
       {sessionUser ? (
         <div className='mb-6'>
@@ -389,24 +355,17 @@ export function Comments({
           />
         </div>
       ) : (
-        <p className='mb-6 text-sm opacity-60'>
-          <Link to='/login' className='underline hover:opacity-100'>
-            登录
-          </Link>{' '}
-          后即可评论。
+        <p className='th-comment mb-6'>
+          # <Link to='/login'>login</Link> 后即可评论。
         </p>
       )}
 
-      {topError ? (
-        <p className='mb-4 text-sm text-red-500'>{topError}</p>
-      ) : null}
+      {topError ? <p className='th-err mb-4'>{topError}</p> : null}
 
       {threads.length === 0 ? (
-        <p className='py-8 text-center text-sm opacity-50'>
-          还没有评论，来抢沙发。
-        </p>
+        <p className='th-comment py-8 text-center'># 还没有评论，来抢沙发。</p>
       ) : (
-        <ul className='flex flex-col gap-5'>
+        <ul className='flex flex-col gap-3'>
           {threads.map((thread) => (
             <CommentItem
               key={thread.id}
@@ -428,9 +387,9 @@ export function Comments({
             type='button'
             onClick={handleLoadMore}
             disabled={loadingMore}
-            className='text-sm opacity-60 transition-opacity hover:opacity-100 disabled:opacity-40'
+            className='th-btn'
           >
-            {loadingMore ? '加载中…' : '加载更多'}
+            {loadingMore ? '加载中…' : 'tail -f'}
           </button>
         </div>
       ) : null}

--- a/apps/web/src/components/dark-mode.tsx
+++ b/apps/web/src/components/dark-mode.tsx
@@ -13,14 +13,9 @@ export function DarkMode() {
   const ref = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
-    if (isDarkMode) {
-      document.documentElement.classList.add('dark');
-      document.body.classList.add('dark:bg-wash-dark', 'dark:text-white');
-      return;
-    }
-
-    document.documentElement.classList.remove('dark');
-    document.body.classList.remove('dark:bg-wash-dark', 'dark:text-white');
+    // The terminal theme carries its own dark palette via html.dark custom
+    // properties; no legacy body utility classes are needed.
+    document.documentElement.classList.toggle('dark', isDarkMode);
   }, [isDarkMode]);
 
   const onTrigger = async () => {

--- a/apps/web/src/components/dark-mode.tsx
+++ b/apps/web/src/components/dark-mode.tsx
@@ -31,15 +31,19 @@ export function DarkMode() {
       return;
     }
 
+    // Capture the anchor rect BEFORE starting the transition: by the time
+    // `.ready` resolves, the dark-mode class swap may have shifted layout
+    // (scrollbar / reflow), which moved the measured origin off the icon.
+    // This is the ordering the Chrome view-transition docs recommend.
+    const { top, left, width, height } = ref.current.getBoundingClientRect();
+    const x = left + width / 2;
+    const y = top + height / 2;
+
     await doc.startViewTransition(() => {
       flushSync(() => {
         setIsDarkMode(newIsDarkMode);
       });
     }).ready;
-
-    const { top, left, width, height } = ref.current.getBoundingClientRect();
-    const x = left + width / 2;
-    const y = top + height / 2;
     const right = window.innerWidth - left;
     const bottom = window.innerHeight - top;
     const maxRadius = Math.hypot(Math.max(left, right), Math.max(top, bottom));

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -1,10 +1,39 @@
+import { Link } from '@tanstack/react-router';
+import { authClient } from '../lib/auth-client.js';
+
+/**
+ * tmux-style status bar: session name + clickable windows on the left, site
+ * info on the right. Doubles as secondary navigation (the active window is
+ * highlighted by the current route).
+ */
 export function Footer() {
+  const { data: sessionData } = authClient.useSession();
+  const isAdmin = sessionData?.user?.role === 'admin';
+
   return (
-    <footer className='p-6 text-center'>
-      © {new Date().getFullYear()}, Built with{' '}
-      <a className='text-blue-500' href='https://tanstack.com/start/latest'>
-        TanStack Start
-      </a>
+    <footer className='th-tmux'>
+      <span className='th-tmux-sess'>blog</span>
+      <nav aria-label='站点窗口' className='flex flex-wrap items-center gap-1'>
+        <Link to='/' className='th-tmux-win'>
+          0:home
+        </Link>
+        <Link to='/blog' className='th-tmux-win'>
+          1:posts
+        </Link>
+        <Link to='/projects' className='th-tmux-win'>
+          2:projects
+        </Link>
+        {isAdmin ? (
+          <Link to='/admin' className='th-tmux-win'>
+            3:admin
+          </Link>
+        ) : null}
+      </nav>
+      <span className='th-tmux-right'>
+        <span>perfectpan.org</span>
+        <span>⌘K = grep</span>
+        <span>© {new Date().getFullYear()}</span>
+      </span>
     </footer>
   );
 }

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -1,6 +1,7 @@
 import { Link } from '@tanstack/react-router';
 import { Github, LogOut, Rss, Search, UserRound } from 'lucide-react';
 import { authClient } from '../lib/auth-client.js';
+import { DarkMode } from './dark-mode.js';
 import { searchPalette } from './search-palette-store.js';
 
 function getRoleLabel(role?: string | null): string {
@@ -60,6 +61,7 @@ export function Header() {
             </Link>
           </>
         )}
+        <DarkMode />
         <button
           type='button'
           aria-label='Search posts (Cmd+K)'

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -1,8 +1,6 @@
 import { Link } from '@tanstack/react-router';
 import { Github, LogOut, Rss, Search, UserRound } from 'lucide-react';
 import { authClient } from '../lib/auth-client.js';
-import { DarkMode } from './dark-mode.js';
-import { MenuLink } from './menu.js';
 import { searchPalette } from './search-palette-store.js';
 
 function getRoleLabel(role?: string | null): string {
@@ -17,78 +15,73 @@ function getRoleLabel(role?: string | null): string {
   return 'MEMBER';
 }
 
+/** Terminal title bar: window dots + session name + right-aligned tools. */
 export function Header() {
   const { data: sessionData } = authClient.useSession();
   const sessionUser = sessionData?.user ?? null;
 
   return (
-    <header className='border-b border-slate-200 bg-white shadow-md dark:border-slate-300/10 dark:bg-slate-900'>
-      <div className='mx-4 flex h-16 items-center sm:mx-6'>
-        <Link
-          to='/'
-          className='rounded-md border-10 border-black bg-black px-1 font-bold text-white dark:border-neutral-900 dark:bg-neutral-900'
-        >
-          PerfectPan
-        </Link>
-        <div className='m-0 flex list-none items-center pl-1'>
-          <MenuLink href='/' name='Home' />
-          <MenuLink href='/blog' name='Blog' />
-          <MenuLink href='/projects' name='Projects' />
-          {sessionUser?.role === 'admin' ? (
-            <MenuLink href='/admin' name='Admin' />
-          ) : null}
-        </div>
-        <div className='ml-auto flex items-center gap-2 sm:gap-3'>
-          {sessionUser ? (
-            <div className='hidden items-center gap-2 rounded-full border border-slate-300 px-3 py-1 text-xs text-gray-700 md:flex dark:border-slate-600 dark:text-slate-200'>
-              <UserRound size={14} className='opacity-70' />
-              <span className='max-w-[220px] truncate'>
-                {sessionUser.email}
-              </span>
-              <span className='rounded-full bg-black px-2 py-[2px] text-[10px] font-semibold text-white dark:bg-neutral-100 dark:text-neutral-900'>
-                {getRoleLabel(sessionUser.role)}
-              </span>
-            </div>
-          ) : null}
-          {sessionUser ? (
-            <Link
-              to='/logout'
-              className='inline-flex items-center gap-1 rounded-md border border-slate-300 px-2 py-1 text-sm opacity-85 transition-opacity hover:opacity-100 dark:border-slate-600'
-            >
-              <LogOut size={14} />
-              <span className='hidden sm:inline'>Logout</span>
+    <header className='th-titlebar'>
+      <span className='th-dot th-dot-r' aria-hidden='true' />
+      <span className='th-dot th-dot-y' aria-hidden='true' />
+      <span className='th-dot th-dot-g' aria-hidden='true' />
+      <span className='th-term-title'>
+        <b>perfectpan@blog</b> —{' '}
+        <span className='th-path'>~/perfectpan.org</span>
+      </span>
+
+      <div className='th-tools'>
+        {sessionUser ? (
+          <span className='th-user-chip'>
+            <UserRound size={13} aria-hidden='true' />
+            <span className='max-w-[220px] truncate'>{sessionUser.email}</span>
+            <span className='th-role-badge'>
+              {getRoleLabel(sessionUser.role)}
+            </span>
+          </span>
+        ) : null}
+        {sessionUser ? (
+          <Link to='/logout' className='th-tool-btn' aria-label='Logout'>
+            <LogOut size={15} aria-hidden='true' />
+            <span className='hidden sm:inline'>logout</span>
+          </Link>
+        ) : (
+          <>
+            <Link to='/login' className='th-tool-btn'>
+              login
             </Link>
-          ) : (
-            <>
-              <Link to='/login' className='opacity-70 hover:opacity-100'>
-                Login
-              </Link>
-              <Link to='/signup' className='opacity-70 hover:opacity-100'>
-                Sign Up
-              </Link>
-            </>
-          )}
-          <button
-            type='button'
-            aria-label='Search posts (Cmd+K)'
-            onClick={() => searchPalette.open()}
-            className='inline-flex items-center opacity-70 transition-opacity hover:opacity-100'
-          >
-            <Search size={22} />
-          </button>
-          <DarkMode />
-          <a
-            href='https://github.com/PerfectPan'
-            target='_blank'
-            rel='noreferrer'
-            className='flex items-center'
-          >
-            <Github size={22} className='opacity-70 hover:opacity-100' />
-          </a>
-          <a href='/rss.xml' target='_blank' rel='noreferrer'>
-            <Rss size={24} className='opacity-70 hover:opacity-100' />
-          </a>
-        </div>
+            <Link to='/signup' className='th-tool-btn'>
+              signup
+            </Link>
+          </>
+        )}
+        <button
+          type='button'
+          aria-label='Search posts (Cmd+K)'
+          onClick={() => searchPalette.open()}
+          className='th-tool-btn'
+        >
+          <Search size={15} aria-hidden='true' />
+          <span className='hidden sm:inline'>grep</span>
+        </button>
+        <a
+          href='https://github.com/PerfectPan'
+          target='_blank'
+          rel='noreferrer'
+          aria-label='GitHub'
+          className='th-tool-btn'
+        >
+          <Github size={15} aria-hidden='true' />
+        </a>
+        <a
+          href='/rss.xml'
+          target='_blank'
+          rel='noreferrer'
+          aria-label='RSS'
+          className='th-tool-btn'
+        >
+          <Rss size={15} aria-hidden='true' />
+        </a>
       </div>
     </header>
   );

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -41,16 +41,21 @@ export function Header() {
           </span>
         ) : null}
         {sessionUser ? (
-          <Link to='/logout' className='th-tool-btn' aria-label='Logout'>
+          <Link
+            to='/logout'
+            data-testid='nav-logout'
+            className='th-tool-btn'
+            aria-label='Logout'
+          >
             <LogOut size={15} aria-hidden='true' />
             <span className='hidden sm:inline'>logout</span>
           </Link>
         ) : (
           <>
-            <Link to='/login' className='th-tool-btn'>
+            <Link to='/login' data-testid='nav-login' className='th-tool-btn'>
               login
             </Link>
-            <Link to='/signup' className='th-tool-btn'>
+            <Link to='/signup' data-testid='nav-signup' className='th-tool-btn'>
               signup
             </Link>
           </>

--- a/apps/web/src/components/layout.tsx
+++ b/apps/web/src/components/layout.tsx
@@ -7,21 +7,18 @@ type AppLayoutProps = {
 };
 
 /**
- * App shell. The header sits OUTSIDE the scroll container (`main`), so page
- * overscroll only rubber-bands the content — the pinned header never moves
- * (no macOS "fixed header drags on overscroll"). Window doesn't scroll; route
- * scroll reset/restore for `main` is handled by TanStack via
- * `scrollToTopSelectors: ['main']` in router.tsx.
+ * App shell (terminal theme). The title bar sits OUTSIDE the scroll container
+ * (`main`), so page overscroll only rubber-bands the content — the pinned bar
+ * never moves. Window doesn't scroll; route scroll reset/restore for `main` is
+ * handled by TanStack via `scrollToTopSelectors: ['main']` in router.tsx.
  */
 export function AppLayout({ children }: AppLayoutProps) {
   return (
-    <div className='flex h-dvh flex-col'>
+    <div className='th-shell'>
       <Header />
-      <main className='flex-1 overflow-y-auto'>
+      <main className='th-main'>
         <div className='flex min-h-full flex-col'>
-          <div className='flex flex-grow items-center justify-center px-6 *:min-h-64 *:min-w-64'>
-            {children}
-          </div>
+          <div className='flex-grow'>{children}</div>
           <Footer />
         </div>
       </main>

--- a/apps/web/src/components/layout.tsx
+++ b/apps/web/src/components/layout.tsx
@@ -1,25 +1,44 @@
 import type { ReactNode } from 'react';
-import { Footer } from './footer.js';
-import { Header } from './header.js';
+import { useSkin } from '../skins/context.js';
+import { JournalFooter } from '../skins/journal/footer.js';
+import { JournalHeader } from '../skins/journal/header.js';
+import { TerminalFooter } from '../skins/terminal/footer.js';
+import { TerminalHeader } from '../skins/terminal/header.js';
 
 type AppLayoutProps = {
   children: ReactNode;
 };
 
 /**
- * App shell (terminal theme). The title bar sits OUTSIDE the scroll container
- * (`main`), so page overscroll only rubber-bands the content — the pinned bar
- * never moves. Window doesn't scroll; route scroll reset/restore for `main` is
- * handled by TanStack via `scrollToTopSelectors: ['main']` in router.tsx.
+ * App shell, skinnable (terminal / journal). The header sits OUTSIDE the
+ * scroll container (`main`), so page overscroll only rubber-bands the content.
+ * Window doesn't scroll; route scroll reset/restore for `main` is handled by
+ * TanStack via `scrollToTopSelectors: ['main']` in router.tsx.
  */
 export function AppLayout({ children }: AppLayoutProps) {
+  const { skin } = useSkin();
+
+  if (skin === 'journal') {
+    return (
+      <div className='j-shell'>
+        <JournalHeader />
+        <main className='j-main'>
+          <div className='flex min-h-full flex-col'>
+            <div className='flex-grow'>{children}</div>
+            <JournalFooter />
+          </div>
+        </main>
+      </div>
+    );
+  }
+
   return (
     <div className='th-shell'>
-      <Header />
+      <TerminalHeader />
       <main className='th-main'>
         <div className='flex min-h-full flex-col'>
           <div className='flex-grow'>{children}</div>
-          <Footer />
+          <TerminalFooter />
         </div>
       </main>
     </div>

--- a/apps/web/src/components/markdown.tsx
+++ b/apps/web/src/components/markdown.tsx
@@ -18,8 +18,30 @@ import { createHighlighterCore } from 'shiki/core';
 // recommended engine for edge runtimes. Don't switch back to oniguruma.
 import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
 
+type Skin = 'terminal' | 'journal';
+
 type MarkdownProps = {
   content: string;
+  skin?: Skin;
+};
+
+/** Per-skin class names for the code block chrome + inline code. */
+const SKIN_CLASSES: Record<
+  Skin,
+  { wrap: string; copy: string; pre: string; inline: string }
+> = {
+  terminal: {
+    wrap: 'th-code group relative',
+    copy: 'th-code-copy',
+    pre: 'shiki th-pre w-full overflow-x-auto',
+    inline: 'md-inline',
+  },
+  journal: {
+    wrap: 'j-code group relative',
+    copy: 'j-code-copy',
+    pre: 'shiki j-pre w-full overflow-x-auto',
+    inline: 'j-inline',
+  },
 };
 
 function scrollToHeading(id: string) {
@@ -62,7 +84,7 @@ const highlighter = await createHighlighterCore({
  * Wraps a highlighted <pre> with a Copy button. Reads the rendered textContent
  * (post-shiki) so it works regardless of how the code was tokenized.
  */
-function CodeBlock({ children }: { children?: ReactNode }) {
+function CodeBlock({ children, skin }: { children?: ReactNode; skin: Skin }) {
   const preRef = useRef<HTMLPreElement>(null);
   const [copied, setCopied] = useState(false);
 
@@ -78,24 +100,41 @@ function CodeBlock({ children }: { children?: ReactNode }) {
   }, []);
 
   return (
-    <div className='th-code group relative'>
+    <div
+      className={
+        skin === 'terminal'
+          ? SKIN_CLASSES.terminal.wrap
+          : SKIN_CLASSES.journal.wrap
+      }
+    >
       <button
         type='button'
         onClick={onCopy}
         aria-label='Copy code'
-        className='th-code-copy'
+        className={
+          skin === 'terminal'
+            ? SKIN_CLASSES.terminal.copy
+            : SKIN_CLASSES.journal.copy
+        }
       >
         {copied ? <Check size={12} /> : <Copy size={12} />}
         {copied ? 'Copied' : 'Copy'}
       </button>
-      <pre ref={preRef} className='shiki th-pre w-full overflow-x-auto'>
+      <pre
+        ref={preRef}
+        className={
+          skin === 'terminal'
+            ? SKIN_CLASSES.terminal.pre
+            : SKIN_CLASSES.journal.pre
+        }
+      >
         {children}
       </pre>
     </div>
   );
 }
 
-export function Markdown({ content }: MarkdownProps) {
+export function Markdown({ content, skin = 'terminal' }: MarkdownProps) {
   useEffect(() => {
     const hash = window.location.hash;
     if (!hash.startsWith('#')) {
@@ -152,12 +191,20 @@ export function Markdown({ content }: MarkdownProps) {
           ),
           strong: ({ children }) => <b className='font-bold'>{children}</b>,
           ul: ({ children }) => <ul>{children}</ul>,
-          pre: ({ children }) => <CodeBlock>{children}</CodeBlock>,
+          pre: ({ children }) => <CodeBlock skin={skin}>{children}</CodeBlock>,
           code: ({ className, children }) =>
             /language-/.test(className ?? '') ? (
               <code className={className}>{children}</code>
             ) : (
-              <code className='md-inline'>{children}</code>
+              <code
+                className={
+                  skin === 'terminal'
+                    ? SKIN_CLASSES.terminal.inline
+                    : SKIN_CLASSES.journal.inline
+                }
+              >
+                {children}
+              </code>
             ),
         }}
       >

--- a/apps/web/src/components/markdown.tsx
+++ b/apps/web/src/components/markdown.tsx
@@ -78,20 +78,17 @@ function CodeBlock({ children }: { children?: ReactNode }) {
   }, []);
 
   return (
-    <div className='group relative mb-2'>
+    <div className='th-code group relative'>
       <button
         type='button'
         onClick={onCopy}
         aria-label='Copy code'
-        className='absolute right-2 top-2 z-10 inline-flex items-center gap-1 rounded border border-slate-300 bg-white/70 px-1.5 py-0.5 text-xs opacity-0 backdrop-blur transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100 hover-none:opacity-70 dark:border-slate-700 dark:bg-slate-900/70'
+        className='th-code-copy'
       >
         {copied ? <Check size={12} /> : <Copy size={12} />}
         {copied ? 'Copied' : 'Copy'}
       </button>
-      <pre
-        ref={preRef}
-        className='shiki w-full overflow-x-auto whitespace-pre-wrap rounded-md bg-zinc-50 p-4 dark:bg-shiki-dark'
-      >
+      <pre ref={preRef} className='shiki th-pre w-full overflow-x-auto'>
         {children}
       </pre>
     </div>
@@ -112,7 +109,7 @@ export function Markdown({ content }: MarkdownProps) {
   }, []);
 
   return (
-    <article>
+    <article className='md'>
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkMath]}
         rehypePlugins={[
@@ -133,10 +130,7 @@ export function Markdown({ content }: MarkdownProps) {
             const id = typeof children === 'string' ? children : '';
 
             return (
-              <h2
-                id={id}
-                className='mb-6 mt-14 scroll-mt-20 text-balance text-2xl leading-none font-black first:mt-0'
-              >
+              <h2 id={id} className='scroll-mt-20'>
                 <a
                   href={`#${id}`}
                   onClick={(event) => {
@@ -150,24 +144,21 @@ export function Markdown({ content }: MarkdownProps) {
               </h2>
             );
           },
-          p: ({ children }) => <p className='mb-6 leading-7'>{children}</p>,
+          p: ({ children }) => <p>{children}</p>,
           a: ({ href, children }) => (
-            <a
-              href={href}
-              className='text-blue-700/80 transition-colors duration-300 ease-in-out hover:text-blue-700'
-              target='_blank'
-              rel='noreferrer'
-            >
+            <a href={href} target='_blank' rel='noreferrer'>
               {children}
             </a>
           ),
-          strong: ({ children }) => (
-            <b className='font-extrabold'>{children}</b>
-          ),
-          ul: ({ children }) => (
-            <ul className='mb-4 ml-4 list-disc'>{children}</ul>
-          ),
+          strong: ({ children }) => <b className='font-bold'>{children}</b>,
+          ul: ({ children }) => <ul>{children}</ul>,
           pre: ({ children }) => <CodeBlock>{children}</CodeBlock>,
+          code: ({ className, children }) =>
+            /language-/.test(className ?? '') ? (
+              <code className={className}>{children}</code>
+            ) : (
+              <code className='md-inline'>{children}</code>
+            ),
         }}
       >
         {content}

--- a/apps/web/src/components/search-palette.tsx
+++ b/apps/web/src/components/search-palette.tsx
@@ -70,19 +70,16 @@ export function SearchPalette() {
         next ? searchPalette.open() : searchPalette.close()
       }
     >
-      <DialogContent className='overflow-hidden p-0'>
-        <Command
-          shouldFilter={false}
-          className='[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-4 [&_[cmdk-input-wrapper]_svg]:w-4 [&_[cmdk-input]]:h-11 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-2'
-        >
+      <DialogContent className='th-pal overflow-hidden p-0'>
+        <Command shouldFilter={false} className='th-pal-cmd'>
           <CommandInput
             value={query}
             onValueChange={setQuery}
-            placeholder='Search posts…'
+            placeholder="grep -ri '关键词' ~/posts"
           />
           <CommandList>
             <CommandEmpty>
-              {query.trim() ? 'No posts found.' : 'Type to search posts…'}
+              {query.trim() ? '# no matches found' : '# type to grep ~/posts'}
             </CommandEmpty>
             <CommandGroup>
               {results.map((post) => (
@@ -91,25 +88,20 @@ export function SearchPalette() {
                   value={post.slug}
                   onSelect={() => go(post.slug)}
                 >
-                  <div className='flex min-w-0 flex-col gap-0.5'>
-                    <span className='font-medium'>{post.title}</span>
-                    {post.description ? (
-                      <span className='line-clamp-1 text-xs text-muted-foreground'>
-                        {post.description}
-                      </span>
-                    ) : null}
-                  </div>
-                  <span className='ml-auto shrink-0 pl-2 text-xs text-muted-foreground'>
-                    {new Date(post.publishedAt).toLocaleDateString('en-US', {
-                      month: 'short',
-                      day: 'numeric',
-                      year: 'numeric',
-                    })}
+                  <span className='th-pal-date'>
+                    {new Date(post.publishedAt).toISOString().slice(0, 7)}
                   </span>
+                  <span className='th-pal-title'>{post.title}</span>
+                  {post.visibility !== 'public' ? (
+                    <span className='th-pal-vis'>{post.visibility}</span>
+                  ) : null}
                 </CommandItem>
               ))}
             </CommandGroup>
           </CommandList>
+          <div className='th-pal-foot'>
+            ↑↓ 选择 · ↵ 打开 · esc 关闭 · 结果按当前身份过滤
+          </div>
         </Command>
       </DialogContent>
     </Dialog>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -26,7 +26,7 @@ export const Route = createRootRoute({
       },
       {
         name: 'theme-color',
-        content: '#000000',
+        content: '#0A0F14',
       },
     ],
     links: [
@@ -38,11 +38,17 @@ export const Route = createRootRoute({
   errorComponent: ({ error }) => (
     <RootDocument>
       <AppLayout>
-        <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-          <h2 className='mb-4 text-3xl'>Request Failed</h2>
-          <p className='mb-4 opacity-70'>{String(error)}</p>
-          <Link to='/blog' className='opacity-70 hover:opacity-100'>
-            Back to blog
+        <div className='th-page'>
+          <div className='th-prompt'>
+            <span className='th-prompt-u'>guest</span>
+            <span className='th-prompt-at'>@</span>
+            <span className='th-prompt-h'>perfectpan.org</span>{' '}
+            <span className='th-prompt-p'>~ %</span>{' '}
+            <span className='th-cmd'>curl -I $(hostname)</span>
+          </div>
+          <p className='th-out th-nf-big'>Request failed: {String(error)}</p>
+          <Link to='/blog' className='th-cd'>
+            cd ~/blog
           </Link>
         </div>
       </AppLayout>
@@ -51,12 +57,24 @@ export const Route = createRootRoute({
   notFoundComponent: () => (
     <RootDocument>
       <AppLayout>
-        <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-          <h2 className='mb-4 text-3xl'>404 Not Found</h2>
-          <p className='mb-4 opacity-70'>你闯入了无人之境...</p>
-          <Link to='/blog' className='opacity-70 hover:opacity-100'>
-            Back to blog
-          </Link>
+        <div className='th-page'>
+          <div className='th-prompt'>
+            <span className='th-prompt-u'>guest</span>
+            <span className='th-prompt-at'>@</span>
+            <span className='th-prompt-h'>perfectpan.org</span>{' '}
+            <span className='th-prompt-p'>~ %</span>{' '}
+            <span className='th-cmd'>cd /nowhere</span>
+          </div>
+          <p className='th-out th-nf-big'>
+            bash: cd: /nowhere: No such file or directory
+          </p>
+          <p className='th-out th-comment'># 你闯入了无人之境。</p>
+          <p className='th-out mt-4'>
+            <Link to='/blog' className='th-cd'>
+              cd ~/blog
+            </Link>
+            <span className='th-comment'> ← 回到博客列表</span>
+          </p>
         </div>
       </AppLayout>
     </RootDocument>
@@ -86,7 +104,9 @@ function RootComponent() {
 
 function RootDocument({ children }: { children: ReactNode }) {
   return (
-    <html lang='zh-CN'>
+    // Terminal theme is dark-native: render with .dark so existing dark:
+    // variants and shiki dual-themes apply without a client-side flash.
+    <html lang='zh-CN' className='dark'>
       <head>
         <HeadContent />
       </head>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -26,7 +26,7 @@ export const Route = createRootRoute({
       },
       {
         name: 'theme-color',
-        content: '#0A0F14',
+        content: '#F4F2EC',
       },
     ],
     links: [

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,14 +1,23 @@
 import {
   createRootRoute,
   HeadContent,
-  Link,
   Outlet,
   Scripts,
 } from '@tanstack/react-router';
 import { type ReactNode, useEffect } from 'react';
 import { AppLayout } from '../components/layout.js';
 import { SearchPalette } from '../components/search-palette.js';
+import { SkinProvider, useSkin } from '../skins/context.js';
+import { JournalError, JournalNotFound } from '../skins/journal/misc.js';
+import { TerminalError, TerminalNotFound } from '../skins/terminal/misc.js';
 import '../styles.css';
+
+/**
+ * Runs before first paint: if the cookie picks the journal skin, hide the
+ * body so the terminal-themed SSR HTML never flashes; React applies the
+ * journal skin right after hydration and SkinProvider removes this style.
+ */
+const SKIN_BOOT_SCRIPT = `(function(){try{if(/(?:^|;\\s*)blog-skin=journal(?:;|$)/.test(document.cookie)){var s=document.createElement('style');s.id='skin-boot';s.textContent='body{visibility:hidden}';document.head.appendChild(s);}}catch(e){}})();`;
 
 export const Route = createRootRoute({
   head: () => ({
@@ -37,46 +46,20 @@ export const Route = createRootRoute({
   }),
   errorComponent: ({ error }) => (
     <RootDocument>
-      <AppLayout>
-        <div className='th-page'>
-          <div className='th-prompt'>
-            <span className='th-prompt-u'>guest</span>
-            <span className='th-prompt-at'>@</span>
-            <span className='th-prompt-h'>perfectpan.org</span>{' '}
-            <span className='th-prompt-p'>~ %</span>{' '}
-            <span className='th-cmd'>curl -I $(hostname)</span>
-          </div>
-          <p className='th-out th-nf-big'>Request failed: {String(error)}</p>
-          <Link to='/blog' className='th-cd'>
-            cd ~/blog
-          </Link>
-        </div>
-      </AppLayout>
+      <SkinPage>
+        <AppLayout>
+          <SkinError error={error} />
+        </AppLayout>
+      </SkinPage>
     </RootDocument>
   ),
   notFoundComponent: () => (
     <RootDocument>
-      <AppLayout>
-        <div className='th-page'>
-          <div className='th-prompt'>
-            <span className='th-prompt-u'>guest</span>
-            <span className='th-prompt-at'>@</span>
-            <span className='th-prompt-h'>perfectpan.org</span>{' '}
-            <span className='th-prompt-p'>~ %</span>{' '}
-            <span className='th-cmd'>cd /nowhere</span>
-          </div>
-          <p className='th-out th-nf-big'>
-            bash: cd: /nowhere: No such file or directory
-          </p>
-          <p className='th-out th-comment'># 你闯入了无人之境。</p>
-          <p className='th-out mt-4'>
-            <Link to='/blog' className='th-cd'>
-              cd ~/blog
-            </Link>
-            <span className='th-comment'> ← 回到博客列表</span>
-          </p>
-        </div>
-      </AppLayout>
+      <SkinPage>
+        <AppLayout>
+          <SkinNotFound />
+        </AppLayout>
+      </SkinPage>
     </RootDocument>
   ),
   component: RootComponent,
@@ -94,18 +77,46 @@ function RootComponent() {
 
   return (
     <RootDocument>
-      <AppLayout>
-        <Outlet />
-      </AppLayout>
-      <SearchPalette />
+      <SkinPage>
+        <AppLayout>
+          <Outlet />
+        </AppLayout>
+        <SearchPalette />
+      </SkinPage>
     </RootDocument>
+  );
+}
+
+/**
+ * SSR always renders the default (terminal) skin — the framework's
+ * per-request context proved unreliable on workerd — and the provider applies
+ * the cookie skin immediately after hydration (see context.tsx), so the boot
+ * script above is the only thing a journal user ever sees pre-skin.
+ */
+function SkinPage({ children }: { children: ReactNode }) {
+  return <SkinProvider initial='terminal'>{children}</SkinProvider>;
+}
+
+function SkinNotFound() {
+  const { skin } = useSkin();
+  return skin === 'journal' ? <JournalNotFound /> : <TerminalNotFound />;
+}
+
+function SkinError({ error }: { error: unknown }) {
+  const { skin } = useSkin();
+  return skin === 'journal' ? (
+    <JournalError error={error} />
+  ) : (
+    <TerminalError error={error} />
   );
 }
 
 function RootDocument({ children }: { children: ReactNode }) {
   return (
-    <html lang='zh-CN'>
+    <html lang='zh-CN' data-theme='terminal'>
       <head>
+        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static, code-reviewed boot script (no user input). */}
+        <script dangerouslySetInnerHTML={{ __html: SKIN_BOOT_SCRIPT }} />
         <HeadContent />
       </head>
       <body>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -104,9 +104,7 @@ function RootComponent() {
 
 function RootDocument({ children }: { children: ReactNode }) {
   return (
-    // Terminal theme is dark-native: render with .dark so existing dark:
-    // variants and shiki dual-themes apply without a client-side flash.
-    <html lang='zh-CN' className='dark'>
+    <html lang='zh-CN'>
       <head>
         <HeadContent />
       </head>

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -1,14 +1,10 @@
 import { type CommentThread, canAccessVisibility } from '@blog/shared';
-import {
-  createFileRoute,
-  Link,
-  notFound,
-  redirect,
-} from '@tanstack/react-router';
-import { Comments } from '../../components/comments.js';
-import { Markdown } from '../../components/markdown.js';
+import { createFileRoute, notFound, redirect } from '@tanstack/react-router';
 import { getBlogPostServerFn } from '../../lib/blog-service.js';
 import { getCommentsServerFn } from '../../lib/comments-service.js';
+import { useSkin } from '../../skins/context.js';
+import { JournalArticle } from '../../skins/journal/article.js';
+import { TerminalArticle } from '../../skins/terminal/article.js';
 
 export const Route = createFileRoute('/blog/$slug')({
   head: () => ({
@@ -65,61 +61,30 @@ export const Route = createFileRoute('/blog/$slug')({
 
 function BlogDetailPage() {
   const data = Route.useLoaderData();
+  const { skin } = useSkin();
   const post = data.post;
   if (!post) {
     return null;
   }
 
-  const date = new Date(post.publishedAt).toLocaleDateString('en-US', {
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
-  });
-
-  return (
-    <div className='th-page'>
-      <div className='th-prompt'>
-        <span className='th-prompt-u'>perfectpan</span>
-        <span className='th-prompt-at'>@</span>
-        <span className='th-prompt-h'>blog</span>{' '}
-        <span className='th-prompt-p'>~/posts %</span>{' '}
-        <span className='th-cmd'>
-          cat {new Date(post.publishedAt).getFullYear()}/{post.slug}.md
-        </span>
-      </div>
-
-      <div className='th-art-head'>
-        <h1 className='th-art-title'>{post.title}</h1>
-        <div className='th-art-meta'>
-          <span>{date}</span>
-          <span>·</span>
-          <span>{post.visibility}</span>
-          {post.tags.length > 0 ? (
-            <>
-              <span>·</span>
-              <span>#{post.tags.join(' #')}</span>
-            </>
-          ) : null}
-        </div>
-      </div>
-      <Markdown content={post.contentMdx} />
-      <div className='th-prompt mt-6'>
-        <span className='th-prompt-u'>perfectpan</span>
-        <span className='th-prompt-at'>@</span>
-        <span className='th-prompt-h'>blog</span>{' '}
-        <span className='th-prompt-p'>~/posts %</span>{' '}
-        <Link to='/blog' className='th-cmd th-cmd-dim'>
-          cd ..
-        </Link>
-      </div>
-      <Comments
-        key={post.slug}
-        slug={post.slug}
-        initialComments={data.comments.comments}
-        initialHasMore={data.comments.hasMore}
-        initialTotal={data.comments.total}
+  if (skin === 'journal') {
+    return (
+      <JournalArticle
+        post={post}
+        comments={data.comments.comments}
+        hasMoreComments={data.comments.hasMore}
+        totalComments={data.comments.total}
         sessionUser={data.sessionUser}
       />
-    </div>
+    );
+  }
+  return (
+    <TerminalArticle
+      post={post}
+      comments={data.comments.comments}
+      hasMoreComments={data.comments.hasMore}
+      totalComments={data.comments.total}
+      sessionUser={data.sessionUser}
+    />
   );
 }

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -77,16 +77,41 @@ function BlogDetailPage() {
   });
 
   return (
-    <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <div className='m-auto mb-8 flex flex-col gap-2'>
-        <div className='text-3xl font-black'>{post.title}</div>
-        <div className='opacity-60'>{date}</div>
+    <div className='th-page'>
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>perfectpan</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>blog</span>{' '}
+        <span className='th-prompt-p'>~/posts %</span>{' '}
+        <span className='th-cmd'>
+          cat {new Date(post.publishedAt).getFullYear()}/{post.slug}.md
+        </span>
+      </div>
+
+      <div className='th-art-head'>
+        <h1 className='th-art-title'>{post.title}</h1>
+        <div className='th-art-meta'>
+          <span>{date}</span>
+          <span>·</span>
+          <span>{post.visibility}</span>
+          {post.tags.length > 0 ? (
+            <>
+              <span>·</span>
+              <span>#{post.tags.join(' #')}</span>
+            </>
+          ) : null}
+        </div>
       </div>
       <Markdown content={post.contentMdx} />
-      <Link to='/blog' className='mt-4 inline-block'>
-        <span className='opacity-70'>&gt;&nbsp;&nbsp;&nbsp;</span>
-        <span className='underline opacity-70 hover:opacity-100'>cd ..</span>
-      </Link>
+      <div className='th-prompt mt-6'>
+        <span className='th-prompt-u'>perfectpan</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>blog</span>{' '}
+        <span className='th-prompt-p'>~/posts %</span>{' '}
+        <Link to='/blog' className='th-cmd th-cmd-dim'>
+          cd ..
+        </Link>
+      </div>
       <Comments
         key={post.slug}
         slug={post.slug}

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -1,37 +1,11 @@
-import type { PostSummary, SessionUser } from '@blog/shared';
-import { createFileRoute, Link } from '@tanstack/react-router';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import type { SessionUser } from '@blog/shared';
+import { createFileRoute } from '@tanstack/react-router';
 import { useEffect } from 'react';
 import { z } from 'zod';
 import { getBlogListServerFn } from '../../lib/blog-service.js';
-
-type BlogGroup = {
-  year: string;
-  blogs: PostSummary[];
-};
-
-function groupByYear(posts: PostSummary[]): BlogGroup[] {
-  const groups = new Map<string, PostSummary[]>();
-
-  for (const post of posts) {
-    const year = new Date(post.publishedAt).getFullYear().toString();
-    const existing = groups.get(year);
-    if (existing) {
-      existing.push(post);
-    } else {
-      groups.set(year, [post]);
-    }
-  }
-
-  return [...groups.entries()]
-    .sort((a, b) => Number(b[0]) - Number(a[0]))
-    .map(([year, blogs]) => ({
-      year,
-      blogs: [...blogs].sort((a, b) =>
-        b.publishedAt.localeCompare(a.publishedAt),
-      ),
-    }));
-}
+import { useSkin } from '../../skins/context.js';
+import { JournalBlogList } from '../../skins/journal/blog-list.js';
+import { TerminalBlogList } from '../../skins/terminal/blog-list.js';
 
 function getDevScopeHint(sessionUser: SessionUser | null | undefined): string {
   if (!sessionUser) {
@@ -48,22 +22,6 @@ function getDevScopeHint(sessionUser: SessionUser | null | undefined): string {
 
   return '当前身份：member；可见范围：public/member';
 }
-
-/** Visibility → permission bits: owner / member / guest read permission. */
-const PERM_CLASS: Record<PostSummary['visibility'], string> = {
-  public: 'th-perm th-perm-pub',
-  member: 'th-perm th-perm-mem',
-  vip: 'th-perm th-perm-vip',
-  admin: 'th-perm th-perm-adm',
-  password: 'th-perm th-perm-pw',
-};
-const PERM_BITS: Record<PostSummary['visibility'], string> = {
-  public: '-r--r--r--',
-  member: '-r--r-----',
-  vip: '-r----r--',
-  admin: '-r--------',
-  password: '-r--------',
-};
 
 export const Route = createFileRoute('/blog/')({
   head: () => ({
@@ -88,121 +46,31 @@ export const Route = createFileRoute('/blog/')({
 
 function BlogListPage() {
   const data = Route.useLoaderData();
-  const blogGroups = groupByYear(data.posts);
+  const { skin } = useSkin();
   const showDevHint = data.isDev;
   const devScopeHint = getDevScopeHint(data.sessionUser);
 
   // Conventional blog pagination: the page scrolls naturally; jump back to the
-  // top on each page change so the new page starts at its first post. (Without
-  // this, clicking "next" while scrolled to the bottom leaves the reader past a
-  // shorter page — the original "bounce".)
+  // top on each page change so the new page starts at its first post.
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-run on page change, value unused in body on purpose
   useEffect(() => {
     document.querySelector('main')?.scrollTo({ top: 0 });
   }, [data.page]);
 
+  if (skin === 'journal') {
+    return (
+      <JournalBlogList
+        data={data}
+        showDevHint={showDevHint}
+        devScopeHint={devScopeHint}
+      />
+    );
+  }
   return (
-    <div className='th-page'>
-      <div className='th-prompt'>
-        <span className='th-prompt-u'>perfectpan</span>
-        <span className='th-prompt-at'>@</span>
-        <span className='th-prompt-h'>blog</span>{' '}
-        <span className='th-prompt-p'>~/posts %</span>{' '}
-        <span className='th-cmd'>ls -la --group-directories-first</span>
-      </div>
-
-      {showDevHint ? (
-        <div className='th-devhint mt-4'>{devScopeHint}</div>
-      ) : null}
-
-      <div className='th-ls'>
-        <div className='th-ls-row th-ls-head'>
-          <span>perms</span>
-          <span>date</span>
-          <span>vis</span>
-          <span>title</span>
-          <span className='text-right'>tags</span>
-        </div>
-        {blogGroups.map((group) => (
-          <div key={group.year}>
-            <div className='th-ls-row'>
-              <span className='th-ls-year'>{group.year}</span>
-            </div>
-            {group.blogs.map((blog: PostSummary) => (
-              <Link
-                key={blog.slug}
-                to='/blog/$slug'
-                params={{ slug: blog.slug }}
-                className='th-ls-row'
-              >
-                <span className={PERM_CLASS[blog.visibility]}>
-                  {PERM_BITS[blog.visibility]}
-                </span>
-                <span className='th-ls-date'>
-                  {new Date(blog.publishedAt).toLocaleDateString('en-US', {
-                    month: '2-digit',
-                    day: '2-digit',
-                  })}
-                </span>
-                <span className='th-ls-vis th-comment'>{blog.visibility}</span>
-                <span className='th-ls-title'>{blog.title}</span>
-                <span className='th-ls-tags text-right'>
-                  {blog.tags.join(' · ')}
-                </span>
-              </Link>
-            ))}
-          </div>
-        ))}
-      </div>
-
-      {data.totalPages > 1 ? (
-        <nav className='th-pager' aria-label='Pagination'>
-          {data.page > 1 ? (
-            <Link to='/blog' search={{ page: data.page - 1 }}>
-              <ChevronLeft size={14} className='inline' aria-hidden='true' />{' '}
-              prev
-            </Link>
-          ) : (
-            <span className='th-pager-off'>
-              <ChevronLeft size={14} className='inline' aria-hidden='true' />{' '}
-              prev
-            </span>
-          )}
-          <span>
-            page {data.page} / {data.totalPages}
-          </span>
-          {data.page < data.totalPages ? (
-            <Link to='/blog' search={{ page: data.page + 1 }}>
-              next{' '}
-              <ChevronRight size={14} className='inline' aria-hidden='true' />
-            </Link>
-          ) : (
-            <span className='th-pager-off'>
-              next{' '}
-              <ChevronRight size={14} className='inline' aria-hidden='true' />
-            </span>
-          )}
-        </nav>
-      ) : null}
-
-      <p className='th-legend'>
-        # perms = 可见性：owner / member / guest 读权限
-        <br /># <span className='th-perm-pub'>-r--r--r--</span> 公开 ·{' '}
-        <span className='th-perm-mem'>-r--r-----</span> 登录可见 ·{' '}
-        <span className='th-perm-vip'>-r----r--</span> VIP ·{' '}
-        <span className='th-perm-pw'>-r--------</span> 需密码
-      </p>
-
-      <hr className='th-hr' />
-      <div className='th-prompt'>
-        <span className='th-prompt-u'>perfectpan</span>
-        <span className='th-prompt-at'>@</span>
-        <span className='th-prompt-h'>blog</span>{' '}
-        <span className='th-prompt-p'>~/posts %</span>{' '}
-        <Link to='/' className='th-cmd th-cmd-dim'>
-          cd ..
-        </Link>
-      </div>
-    </div>
+    <TerminalBlogList
+      data={data}
+      showDevHint={showDevHint}
+      devScopeHint={devScopeHint}
+    />
   );
 }

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -49,6 +49,22 @@ function getDevScopeHint(sessionUser: SessionUser | null | undefined): string {
   return '当前身份：member；可见范围：public/member';
 }
 
+/** Visibility → permission bits: owner / member / guest read permission. */
+const PERM_CLASS: Record<PostSummary['visibility'], string> = {
+  public: 'th-perm th-perm-pub',
+  member: 'th-perm th-perm-mem',
+  vip: 'th-perm th-perm-vip',
+  admin: 'th-perm th-perm-adm',
+  password: 'th-perm th-perm-pw',
+};
+const PERM_BITS: Record<PostSummary['visibility'], string> = {
+  public: '-r--r--r--',
+  member: '-r--r-----',
+  vip: '-r----r--',
+  admin: '-r--------',
+  password: '-r--------',
+};
+
 export const Route = createFileRoute('/blog/')({
   head: () => ({
     meta: [
@@ -86,79 +102,107 @@ function BlogListPage() {
   }, [data.page]);
 
   return (
-    <div className='mx-auto flex w-full max-w-[80ch] flex-col gap-8 self-start pt-8'>
-      <div className='w-full'>
-        {showDevHint ? (
-          <div className='mb-8 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900'>
-            {devScopeHint}
-          </div>
-        ) : null}
+    <div className='th-page'>
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>perfectpan</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>blog</span>{' '}
+        <span className='th-prompt-p'>~/posts %</span>{' '}
+        <span className='th-cmd'>ls -la --group-directories-first</span>
+      </div>
+
+      {showDevHint ? (
+        <div className='th-devhint mt-4'>{devScopeHint}</div>
+      ) : null}
+
+      <div className='th-ls'>
+        <div className='th-ls-row th-ls-head'>
+          <span>perms</span>
+          <span>date</span>
+          <span>vis</span>
+          <span>title</span>
+          <span className='text-right'>tags</span>
+        </div>
         {blogGroups.map((group) => (
           <div key={group.year}>
-            <div className='mb-4 text-3xl'>{group.year}</div>
+            <div className='th-ls-row'>
+              <span className='th-ls-year'>{group.year}</span>
+            </div>
             {group.blogs.map((blog: PostSummary) => (
-              <div
+              <Link
                 key={blog.slug}
-                className='mt-2 mb-6 opacity-70 hover:opacity-100'
+                to='/blog/$slug'
+                params={{ slug: blog.slug }}
+                className='th-ls-row'
               >
-                <Link
-                  to='/blog/$slug'
-                  params={{ slug: blog.slug }}
-                  className='flex items-center gap-2'
-                >
-                  <span className='text-lg leading-[1.2em]'>{blog.title}</span>
-                  <span className='text-sm opacity-50'>
-                    {new Date(blog.publishedAt).toLocaleDateString('en-US', {
-                      month: 'short',
-                      day: 'numeric',
-                    })}
-                  </span>
-                </Link>
-              </div>
+                <span className={PERM_CLASS[blog.visibility]}>
+                  {PERM_BITS[blog.visibility]}
+                </span>
+                <span className='th-ls-date'>
+                  {new Date(blog.publishedAt).toLocaleDateString('en-US', {
+                    month: '2-digit',
+                    day: '2-digit',
+                  })}
+                </span>
+                <span className='th-ls-vis th-comment'>{blog.visibility}</span>
+                <span className='th-ls-title'>{blog.title}</span>
+                <span className='th-ls-tags text-right'>
+                  {blog.tags.join(' · ')}
+                </span>
+              </Link>
             ))}
           </div>
         ))}
       </div>
+
       {data.totalPages > 1 ? (
-        <nav
-          className='flex w-full items-center justify-center gap-4 text-sm sm:gap-6'
-          aria-label='Pagination'
-        >
+        <nav className='th-pager' aria-label='Pagination'>
           {data.page > 1 ? (
-            <Link
-              to='/blog'
-              search={{ page: data.page - 1 }}
-              className='inline-flex items-center gap-1 opacity-60 hover:opacity-100'
-            >
-              <ChevronLeft size={14} /> prev
+            <Link to='/blog' search={{ page: data.page - 1 }}>
+              <ChevronLeft size={14} className='inline' aria-hidden='true' />{' '}
+              prev
             </Link>
           ) : (
-            <span className='inline-flex items-center gap-1 opacity-30'>
-              <ChevronLeft size={14} /> prev
+            <span className='th-pager-off'>
+              <ChevronLeft size={14} className='inline' aria-hidden='true' />{' '}
+              prev
             </span>
           )}
-          <span className='opacity-60'>
+          <span>
             page {data.page} / {data.totalPages}
           </span>
           {data.page < data.totalPages ? (
-            <Link
-              to='/blog'
-              search={{ page: data.page + 1 }}
-              className='inline-flex items-center gap-1 opacity-60 hover:opacity-100'
-            >
-              next <ChevronRight size={14} />
+            <Link to='/blog' search={{ page: data.page + 1 }}>
+              next{' '}
+              <ChevronRight size={14} className='inline' aria-hidden='true' />
             </Link>
           ) : (
-            <span className='inline-flex items-center gap-1 opacity-30'>
-              next <ChevronRight size={14} />
+            <span className='th-pager-off'>
+              next{' '}
+              <ChevronRight size={14} className='inline' aria-hidden='true' />
             </span>
           )}
         </nav>
       ) : null}
-      <Link to='/' className='mt-4 inline-block'>
-        <span className='opacity-70'>&gt;&nbsp;&nbsp;&nbsp;</span>
-        <span className='underline opacity-70 hover:opacity-100'>cd ..</span>
-      </Link>
+
+      <p className='th-legend'>
+        # perms = 可见性：owner / member / guest 读权限
+        <br /># <span className='th-perm-pub'>-r--r--r--</span> 公开 ·{' '}
+        <span className='th-perm-mem'>-r--r-----</span> 登录可见 ·{' '}
+        <span className='th-perm-vip'>-r----r--</span> VIP ·{' '}
+        <span className='th-perm-pw'>-r--------</span> 需密码
+      </p>
+
+      <hr className='th-hr' />
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>perfectpan</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>blog</span>{' '}
+        <span className='th-prompt-p'>~/posts %</span>{' '}
+        <Link to='/' className='th-cmd th-cmd-dim'>
+          cd ..
+        </Link>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,59 +1,26 @@
-import { createFileRoute, Link } from '@tanstack/react-router';
+import { createFileRoute } from '@tanstack/react-router';
+import { getBlogListServerFn } from '../lib/blog-service.js';
+import { useSkin } from '../skins/context.js';
+import { JournalHomePage } from '../skins/journal/home.js';
+import { TerminalHomePage } from '../skins/terminal/home.js';
 
 export const Route = createFileRoute('/')({
   head: () => ({
     meta: [{ title: "Home | PerfectPan's Blog" }],
   }),
+  loader: async () => {
+    // Guest-scoped first page powers the journal home's LATEST panel.
+    return getBlogListServerFn({ data: { page: 1 } });
+  },
   component: HomePage,
 });
 
-const FIGLET = `  ____              _   _        _   ____  __  __ ____
- |  _ \\ _   _  __ _| |_| |__    / \\ |  _ \\|  \\/  |  _ \\
- | |_) | | | |/ _\` | __| '_ \\  / _ \\| |_) | |\\/| | |_) |
- |  __/| |_| | (_| | |_| | | |/ ___ \\  __/| |  | |  __/
- |_|    \\__,_|\\__,_|\\__|_| |_/_/   \\_\\_|  |_|  |_|_|   `;
-
 function HomePage() {
-  return (
-    <div className='th-page'>
-      <div className='th-prompt'>
-        <span className='th-prompt-u'>perfectpan</span>
-        <span className='th-prompt-at'>@</span>
-        <span className='th-prompt-h'>blog</span>{' '}
-        <span className='th-prompt-p'>~ %</span>{' '}
-        <span className='th-cmd'>whoami --verbose</span>
-      </div>
-      <div className='th-out'>
-        <div className='th-hero-name'>PerfectPan</div>
-        <p className='th-hero-desc'>
-          写代码的人。算法竞赛退役选手，现在的兴趣在前端工程、类型体操和把东西跑在
-          Cloudflare 免费额度上。
-        </p>
-        <pre className='th-figlet' aria-hidden='true'>
-          {FIGLET}
-          <b>.dev</b>
-        </pre>
-      </div>
-      <div className='th-prompt mt-6'>
-        <span className='th-prompt-u'>perfectpan</span>
-        <span className='th-prompt-at'>@</span>
-        <span className='th-prompt-h'>blog</span>{' '}
-        <span className='th-prompt-p'>~ %</span>{' '}
-        <span className='th-cmd'>cat motd.txt</span>
-      </div>
-      <p className='th-out th-comment'>
-        # 是个什么都不会的废物.jpg —— 但还在写。
-      </p>
-      <div className='th-home-links'>
-        <Link to='/blog'>
-          <span className='k'>open blog/</span>
-          <small>算法 / TypeScript / 随笔</small>
-        </Link>
-        <Link to='/projects'>
-          <span className='k'>open projects/</span>
-          <small>Rust / TS / Moonbit 开源项目</small>
-        </Link>
-      </div>
-    </div>
-  );
+  const { skin } = useSkin();
+  const data = Route.useLoaderData();
+
+  if (skin === 'journal') {
+    return <JournalHomePage data={data} />;
+  }
+  return <TerminalHomePage />;
 }

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -7,20 +7,52 @@ export const Route = createFileRoute('/')({
   component: HomePage,
 });
 
+const FIGLET = `  ____              _   _        _   ____  __  __ ____
+ |  _ \\ _   _  __ _| |_| |__    / \\ |  _ \\|  \\/  |  _ \\
+ | |_) | | | |/ _\` | __| '_ \\  / _ \\| |_) | |\\/| | |_) |
+ |  __/| |_| | (_| | |_| | | |/ ___ \\  __/| |  | |  __/
+ |_|    \\__,_|\\__,_|\\__|_| |_/_/   \\_\\_|  |_|  |_|_|   `;
+
 function HomePage() {
   return (
-    <div className='flex flex-col items-center'>
-      <img className='m-0' src='/images/xm.jpg' alt='' />
-      <div className='mt-8 text-[2.5rem] font-black'>
-        是个什么都不会的废物.jpg
+    <div className='th-page'>
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>perfectpan</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>blog</span>{' '}
+        <span className='th-prompt-p'>~ %</span>{' '}
+        <span className='th-cmd'>whoami --verbose</span>
       </div>
-      <div className='flex w-full justify-around'>
-        <div className='mx-1 mt-8 flex-1 rounded-md bg-slate-100 text-center font-semibold uppercase tracking-wider leading-[5rem] shadow-md transition-shadow hover:shadow-lg dark:bg-wash-dark dark:text-white dark:opacity-80'>
-          <Link to='/blog'>Blog</Link>
-        </div>
-        <div className='mx-1 mt-8 flex-1 rounded-md bg-slate-100 text-center font-semibold uppercase tracking-wider leading-[5rem] shadow-md transition-shadow hover:shadow-lg dark:bg-wash-dark dark:text-white dark:opacity-80'>
-          <Link to='/projects'>Projects</Link>
-        </div>
+      <div className='th-out'>
+        <div className='th-hero-name'>PerfectPan</div>
+        <p className='th-hero-desc'>
+          写代码的人。算法竞赛退役选手，现在的兴趣在前端工程、类型体操和把东西跑在
+          Cloudflare 免费额度上。
+        </p>
+        <pre className='th-figlet' aria-hidden='true'>
+          {FIGLET}
+          <b>.dev</b>
+        </pre>
+      </div>
+      <div className='th-prompt mt-6'>
+        <span className='th-prompt-u'>perfectpan</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>blog</span>{' '}
+        <span className='th-prompt-p'>~ %</span>{' '}
+        <span className='th-cmd'>cat motd.txt</span>
+      </div>
+      <p className='th-out th-comment'>
+        # 是个什么都不会的废物.jpg —— 但还在写。
+      </p>
+      <div className='th-home-links'>
+        <Link to='/blog'>
+          <span className='k'>open blog/</span>
+          <small>算法 / TypeScript / 随笔</small>
+        </Link>
+        <Link to='/projects'>
+          <span className='k'>open projects/</span>
+          <small>Rust / TS / Moonbit 开源项目</small>
+        </Link>
       </div>
     </div>
   );

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -34,25 +34,26 @@ function LoginPage() {
 
   if (sessionData?.user?.id || isSessionPending) {
     return (
-      <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-        <p className='opacity-70'>Checking session...</p>
-      </section>
+      <div className='th-page'>
+        <p className='th-comment'># checking session…</p>
+      </div>
     );
   }
 
   return (
-    <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>登录</h1>
-      <p className='mb-6 opacity-70'>支持邮箱密码和 GitHub OAuth。</p>
-
-      {error ? (
-        <p role='alert' className='mb-4 text-sm text-red-700 dark:text-red-300'>
-          {error}
-        </p>
-      ) : null}
-
+    <div className='th-page'>
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>guest</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>perfectpan.org</span>{' '}
+        <span className='th-prompt-p'>~ %</span>{' '}
+        <span className='th-cmd'>ssh member@perfectpan.org</span>
+      </div>
+      <p className='th-out th-comment mt-2'>
+        # 邮箱密码登录；或者走 GitHub OAuth。
+      </p>
       <form
-        className='grid max-w-[420px] gap-3'
+        className='mt-4'
         method='post'
         onSubmit={(event) => {
           event.preventDefault();
@@ -73,57 +74,63 @@ function LoginPage() {
           });
         }}
       >
-        <label htmlFor='email' className='font-semibold'>
-          Email
-        </label>
-        <input
-          id='email'
-          name='email'
-          type='email'
-          required
-          autoComplete='email'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-        />
-        <label htmlFor='password' className='font-semibold'>
-          Password
-        </label>
-        <input
-          id='password'
-          name='password'
-          type='password'
-          required
-          autoComplete='current-password'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={password}
-          onChange={(event) => setPassword(event.target.value)}
-        />
-        <button
-          type='submit'
-          className='rounded-md bg-black px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90 dark:bg-neutral-900'
-          disabled={isPending}
-        >
-          {isPending ? 'Signing in...' : 'Sign In'}
-        </button>
+        <div className='th-field'>
+          <label htmlFor='email'>email</label>
+          <input
+            id='email'
+            name='email'
+            type='email'
+            required
+            autoComplete='email'
+            className='th-input'
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+          />
+        </div>
+        <div className='th-field'>
+          <label htmlFor='password'>password</label>
+          <input
+            id='password'
+            name='password'
+            type='password'
+            required
+            autoComplete='current-password'
+            className='th-input'
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+          />
+        </div>
+        <div className='mt-5 flex flex-wrap gap-3'>
+          <button
+            type='submit'
+            className='th-btn th-btn-primary'
+            disabled={isPending}
+          >
+            {isPending ? 'signing in…' : 'sign in'}
+          </button>
+          <button
+            type='button'
+            className='th-btn'
+            onClick={async () => {
+              setError(null);
+              const result = await authClient.signIn.social({
+                provider: 'github',
+                callbackURL: '/blog',
+              });
+              if (result.error) {
+                setError(result.error.message ?? 'GitHub 登录失败');
+              }
+            }}
+          >
+            continue with github
+          </button>
+        </div>
+        {error ? <p className='th-err'>{error}</p> : null}
       </form>
-
-      <button
-        type='button'
-        className='mt-3 rounded-md border border-slate-300 px-4 py-2 font-semibold transition-colors hover:bg-gray-100 dark:border-slate-700 dark:hover:bg-slate-800'
-        onClick={async () => {
-          setError(null);
-          const result = await authClient.signIn.social({
-            provider: 'github',
-            callbackURL: '/blog',
-          });
-          if (result.error) {
-            setError(result.error.message ?? 'GitHub 登录失败');
-          }
-        }}
-      >
-        Continue with GitHub
-      </button>
-    </section>
+      <p className='th-out mt-4'>
+        <span className='th-comment'># 还没有账号？</span>{' '}
+        <a href='/signup'>signup</a>
+      </p>
+    </div>
   );
 }

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -1,6 +1,7 @@
-import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import { useEffect, useState, useTransition } from 'react';
-import { authClient } from '../lib/auth-client.js';
+import { createFileRoute } from '@tanstack/react-router';
+import { useSkin } from '../skins/context.js';
+import { JournalLoginPage } from '../skins/journal/auth.js';
+import { TerminalLoginPage } from '../skins/terminal/auth.js';
 
 export const Route = createFileRoute('/login')({
   server: {
@@ -18,119 +19,6 @@ export const Route = createFileRoute('/login')({
 });
 
 function LoginPage() {
-  const navigate = useNavigate();
-  const { data: sessionData, isPending: isSessionPending } =
-    authClient.useSession();
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [error, setError] = useState<string | null>(null);
-  const [isPending, startTransition] = useTransition();
-
-  useEffect(() => {
-    if (sessionData?.user?.id) {
-      navigate({ to: '/blog', replace: true });
-    }
-  }, [navigate, sessionData?.user?.id]);
-
-  if (sessionData?.user?.id || isSessionPending) {
-    return (
-      <div className='th-page'>
-        <p className='th-comment'># checking session…</p>
-      </div>
-    );
-  }
-
-  return (
-    <div className='th-page'>
-      <div className='th-prompt'>
-        <span className='th-prompt-u'>guest</span>
-        <span className='th-prompt-at'>@</span>
-        <span className='th-prompt-h'>perfectpan.org</span>{' '}
-        <span className='th-prompt-p'>~ %</span>{' '}
-        <span className='th-cmd'>ssh member@perfectpan.org</span>
-      </div>
-      <p className='th-out th-comment mt-2'>
-        # 邮箱密码登录；或者走 GitHub OAuth。
-      </p>
-      <form
-        className='mt-4'
-        method='post'
-        onSubmit={(event) => {
-          event.preventDefault();
-          setError(null);
-          startTransition(async () => {
-            const result = await authClient.signIn.email({
-              email,
-              password,
-              callbackURL: '/blog',
-            });
-
-            if (result.error) {
-              setError(result.error.message ?? '登录失败');
-              return;
-            }
-
-            navigate({ to: '/blog' });
-          });
-        }}
-      >
-        <div className='th-field'>
-          <label htmlFor='email'>email</label>
-          <input
-            id='email'
-            name='email'
-            type='email'
-            required
-            autoComplete='email'
-            className='th-input'
-            value={email}
-            onChange={(event) => setEmail(event.target.value)}
-          />
-        </div>
-        <div className='th-field'>
-          <label htmlFor='password'>password</label>
-          <input
-            id='password'
-            name='password'
-            type='password'
-            required
-            autoComplete='current-password'
-            className='th-input'
-            value={password}
-            onChange={(event) => setPassword(event.target.value)}
-          />
-        </div>
-        <div className='mt-5 flex flex-wrap gap-3'>
-          <button
-            type='submit'
-            className='th-btn th-btn-primary'
-            disabled={isPending}
-          >
-            {isPending ? 'signing in…' : 'sign in'}
-          </button>
-          <button
-            type='button'
-            className='th-btn'
-            onClick={async () => {
-              setError(null);
-              const result = await authClient.signIn.social({
-                provider: 'github',
-                callbackURL: '/blog',
-              });
-              if (result.error) {
-                setError(result.error.message ?? 'GitHub 登录失败');
-              }
-            }}
-          >
-            continue with github
-          </button>
-        </div>
-        {error ? <p className='th-err'>{error}</p> : null}
-      </form>
-      <p className='th-out mt-4'>
-        <span className='th-comment'># 还没有账号？</span>{' '}
-        <a href='/signup'>signup</a>
-      </p>
-    </div>
-  );
+  const { skin } = useSkin();
+  return skin === 'journal' ? <JournalLoginPage /> : <TerminalLoginPage />;
 }

--- a/apps/web/src/routes/projects.tsx
+++ b/apps/web/src/routes/projects.tsx
@@ -1,5 +1,7 @@
-import { createFileRoute, Link } from '@tanstack/react-router';
-import { PROJECTS, type Project } from '../lib/projects.js';
+import { createFileRoute } from '@tanstack/react-router';
+import { useSkin } from '../skins/context.js';
+import { JournalProjectsPage } from '../skins/journal/projects.js';
+import { TerminalProjectsPage } from '../skins/terminal/projects.js';
 
 export const Route = createFileRoute('/projects')({
   head: () => ({
@@ -11,73 +13,11 @@ export const Route = createFileRoute('/projects')({
   component: ProjectsPage,
 });
 
-function sortProjects(projects: Project[]): Project[] {
-  return [...projects].sort((a, b) => {
-    if (Boolean(a.featured) === Boolean(b.featured)) {
-      return a.name.localeCompare(b.name);
-    }
-    return a.featured ? -1 : 1;
-  });
-}
-
 function ProjectsPage() {
-  const projects = sortProjects(PROJECTS);
-
-  return (
-    <div className='th-page'>
-      <div className='th-prompt'>
-        <span className='th-prompt-u'>perfectpan</span>
-        <span className='th-prompt-at'>@</span>
-        <span className='th-prompt-h'>blog</span>{' '}
-        <span className='th-prompt-p'>~ %</span>{' '}
-        <span className='th-cmd'>ls -la ~/projects</span>
-      </div>
-
-      <div className='th-ls mt-3'>
-        <div className='th-ls-proj th-ls-proj-head'>
-          <span>star</span>
-          <span>project</span>
-          <span className='text-right'>stack</span>
-          <span>link</span>
-        </div>
-        {projects.map((project) => (
-          <div key={project.name} className='th-ls-proj'>
-            <span className={project.featured ? 'th-perm-pw' : 'th-comment'}>
-              {project.featured ? '★' : ' '}
-            </span>
-            <span>
-              <span className='th-ls-title'>{project.name}</span>
-              <span className='th-comment'> — {project.description}</span>
-            </span>
-            <span className='th-ls-tags text-right'>
-              {project.tags.join(' · ')}
-            </span>
-            <span className='th-ls-link'>
-              <a href={project.repo} target='_blank' rel='noreferrer'>
-                code ↗
-              </a>
-              {project.demo ? (
-                <>
-                  {' '}
-                  <a href={project.demo} target='_blank' rel='noreferrer'>
-                    demo ↗
-                  </a>
-                </>
-              ) : null}
-            </span>
-          </div>
-        ))}
-      </div>
-
-      <div className='th-prompt mt-6'>
-        <span className='th-prompt-u'>perfectpan</span>
-        <span className='th-prompt-at'>@</span>
-        <span className='th-prompt-h'>blog</span>{' '}
-        <span className='th-prompt-p'>~ %</span>{' '}
-        <Link to='/' className='th-cmd th-cmd-dim'>
-          cd ..
-        </Link>
-      </div>
-    </div>
+  const { skin } = useSkin();
+  return skin === 'journal' ? (
+    <JournalProjectsPage />
+  ) : (
+    <TerminalProjectsPage />
   );
 }

--- a/apps/web/src/routes/projects.tsx
+++ b/apps/web/src/routes/projects.tsx
@@ -1,5 +1,4 @@
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { ExternalLink, Github } from 'lucide-react';
 import { PROJECTS, type Project } from '../lib/projects.js';
 
 export const Route = createFileRoute('/projects')({
@@ -25,67 +24,60 @@ function ProjectsPage() {
   const projects = sortProjects(PROJECTS);
 
   return (
-    <div className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>Projects</h1>
-      <p className='mb-8 opacity-70'>我做过的一些东西，按需更新。</p>
+    <div className='th-page'>
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>perfectpan</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>blog</span>{' '}
+        <span className='th-prompt-p'>~ %</span>{' '}
+        <span className='th-cmd'>ls -la ~/projects</span>
+      </div>
 
-      <div className='grid gap-4 sm:grid-cols-2'>
+      <div className='th-ls mt-3'>
+        <div className='th-ls-proj th-ls-proj-head'>
+          <span>star</span>
+          <span>project</span>
+          <span className='text-right'>stack</span>
+          <span>link</span>
+        </div>
         {projects.map((project) => (
-          <article
-            key={project.name}
-            className='flex flex-col rounded-lg border border-slate-200 bg-white/60 p-5 transition-shadow hover:shadow-md dark:border-slate-700 dark:bg-wash-dark'
-          >
-            <div className='mb-1 flex items-center gap-2'>
-              <h2 className='text-lg font-semibold'>{project.name}</h2>
-              {project.featured ? (
-                <span className='rounded-full bg-black px-2 py-[2px] text-[10px] font-semibold text-white dark:bg-neutral-100 dark:text-neutral-900'>
-                  FEATURED
-                </span>
-              ) : null}
-            </div>
-            <p className='mb-4 flex-grow text-sm opacity-70'>
-              {project.description}
-            </p>
-            <div className='mb-4 flex flex-wrap gap-1.5'>
-              {project.tags.map((tag) => (
-                <span
-                  key={tag}
-                  className='rounded-md border border-slate-200 px-2 py-[2px] text-[11px] opacity-70 dark:border-slate-700'
-                >
-                  {tag}
-                </span>
-              ))}
-            </div>
-            <div className='flex items-center gap-4 text-sm'>
-              <a
-                href={project.repo}
-                target='_blank'
-                rel='noreferrer'
-                className='inline-flex items-center gap-1 opacity-70 hover:opacity-100'
-              >
-                <Github size={15} />
-                Code
+          <div key={project.name} className='th-ls-proj'>
+            <span className={project.featured ? 'th-perm-pw' : 'th-comment'}>
+              {project.featured ? '★' : ' '}
+            </span>
+            <span>
+              <span className='th-ls-title'>{project.name}</span>
+              <span className='th-comment'> — {project.description}</span>
+            </span>
+            <span className='th-ls-tags text-right'>
+              {project.tags.join(' · ')}
+            </span>
+            <span className='th-ls-link'>
+              <a href={project.repo} target='_blank' rel='noreferrer'>
+                code ↗
               </a>
               {project.demo ? (
-                <a
-                  href={project.demo}
-                  target='_blank'
-                  rel='noreferrer'
-                  className='inline-flex items-center gap-1 opacity-70 hover:opacity-100'
-                >
-                  <ExternalLink size={15} />
-                  Demo
-                </a>
+                <>
+                  {' '}
+                  <a href={project.demo} target='_blank' rel='noreferrer'>
+                    demo ↗
+                  </a>
+                </>
               ) : null}
-            </div>
-          </article>
+            </span>
+          </div>
         ))}
       </div>
 
-      <Link to='/' className='mt-8 inline-block'>
-        <span className='opacity-70'>&gt;&nbsp;&nbsp;&nbsp;</span>
-        <span className='underline opacity-70 hover:opacity-100'>cd ..</span>
-      </Link>
+      <div className='th-prompt mt-6'>
+        <span className='th-prompt-u'>perfectpan</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>blog</span>{' '}
+        <span className='th-prompt-p'>~ %</span>{' '}
+        <Link to='/' className='th-cmd th-cmd-dim'>
+          cd ..
+        </Link>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/routes/signup.tsx
+++ b/apps/web/src/routes/signup.tsx
@@ -1,6 +1,7 @@
-import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import { useEffect, useState, useTransition } from 'react';
-import { authClient } from '../lib/auth-client.js';
+import { createFileRoute } from '@tanstack/react-router';
+import { useSkin } from '../skins/context.js';
+import { JournalSignupPage } from '../skins/journal/auth.js';
+import { TerminalSignupPage } from '../skins/terminal/auth.js';
 
 export const Route = createFileRoute('/signup')({
   server: {
@@ -18,130 +19,6 @@ export const Route = createFileRoute('/signup')({
 });
 
 function SignUpPage() {
-  const navigate = useNavigate();
-  const { data: sessionData, isPending: isSessionPending } =
-    authClient.useSession();
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [name, setName] = useState('');
-  const [error, setError] = useState<string | null>(null);
-  const [isPending, startTransition] = useTransition();
-
-  useEffect(() => {
-    if (sessionData?.user?.id) {
-      navigate({ to: '/blog', replace: true });
-    }
-  }, [navigate, sessionData?.user?.id]);
-
-  if (sessionData?.user?.id || isSessionPending) {
-    return (
-      <div className='th-page'>
-        <p className='th-comment'># checking session…</p>
-      </div>
-    );
-  }
-
-  return (
-    <div className='th-page'>
-      <div className='th-prompt'>
-        <span className='th-prompt-u'>guest</span>
-        <span className='th-prompt-at'>@</span>
-        <span className='th-prompt-h'>perfectpan.org</span>{' '}
-        <span className='th-prompt-p'>~ %</span>{' '}
-        <span className='th-cmd'>useradd --join</span>
-      </div>
-      <p className='th-out th-comment mt-2'>
-        # 注册成为 member，可读 member 可见性的文章。
-      </p>
-      <form
-        className='mt-4'
-        method='post'
-        onSubmit={(event) => {
-          event.preventDefault();
-          setError(null);
-          startTransition(async () => {
-            const result = await authClient.signUp.email({
-              email,
-              password,
-              name,
-              callbackURL: '/blog',
-            });
-
-            if (result.error) {
-              setError(result.error.message ?? '注册失败');
-              return;
-            }
-
-            navigate({ to: '/blog' });
-          });
-        }}
-      >
-        <div className='th-field'>
-          <label htmlFor='name'>name</label>
-          <input
-            id='name'
-            name='name'
-            type='text'
-            required
-            autoComplete='name'
-            className='th-input'
-            value={name}
-            onChange={(event) => setName(event.target.value)}
-          />
-        </div>
-        <div className='th-field'>
-          <label htmlFor='email'>email</label>
-          <input
-            id='email'
-            name='email'
-            type='email'
-            required
-            autoComplete='email'
-            className='th-input'
-            value={email}
-            onChange={(event) => setEmail(event.target.value)}
-          />
-        </div>
-        <div className='th-field'>
-          <label htmlFor='password'>password</label>
-          <input
-            id='password'
-            name='password'
-            type='password'
-            required
-            autoComplete='new-password'
-            className='th-input'
-            value={password}
-            onChange={(event) => setPassword(event.target.value)}
-          />
-        </div>
-        <div className='mt-5 flex flex-wrap gap-3'>
-          <button
-            type='submit'
-            className='th-btn th-btn-primary'
-            disabled={isPending}
-          >
-            {isPending ? 'creating…' : 'create account'}
-          </button>
-          <button
-            type='button'
-            className='th-btn'
-            onClick={async () => {
-              setError(null);
-              const result = await authClient.signIn.social({
-                provider: 'github',
-                callbackURL: '/blog',
-              });
-              if (result.error) {
-                setError(result.error.message ?? 'GitHub 注册失败');
-              }
-            }}
-          >
-            continue with github
-          </button>
-        </div>
-        {error ? <p className='th-err'>{error}</p> : null}
-      </form>
-    </div>
-  );
+  const { skin } = useSkin();
+  return skin === 'journal' ? <JournalSignupPage /> : <TerminalSignupPage />;
 }

--- a/apps/web/src/routes/signup.tsx
+++ b/apps/web/src/routes/signup.tsx
@@ -35,25 +35,26 @@ function SignUpPage() {
 
   if (sessionData?.user?.id || isSessionPending) {
     return (
-      <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-        <p className='opacity-70'>Checking session...</p>
-      </section>
+      <div className='th-page'>
+        <p className='th-comment'># checking session…</p>
+      </div>
     );
   }
 
   return (
-    <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>注册</h1>
-      <p className='mb-6 opacity-70'>注册后默认角色为 member，可在后台升权。</p>
-
-      {error ? (
-        <p role='alert' className='mb-4 text-sm text-red-700 dark:text-red-300'>
-          {error}
-        </p>
-      ) : null}
-
+    <div className='th-page'>
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>guest</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>perfectpan.org</span>{' '}
+        <span className='th-prompt-p'>~ %</span>{' '}
+        <span className='th-cmd'>useradd --join</span>
+      </div>
+      <p className='th-out th-comment mt-2'>
+        # 注册成为 member，可读 member 可见性的文章。
+      </p>
       <form
-        className='grid max-w-[420px] gap-3'
+        className='mt-4'
         method='post'
         onSubmit={(event) => {
           event.preventDefault();
@@ -75,53 +76,72 @@ function SignUpPage() {
           });
         }}
       >
-        <label htmlFor='name' className='font-semibold'>
-          Name
-        </label>
-        <input
-          id='name'
-          name='name'
-          type='text'
-          required
-          autoComplete='name'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={name}
-          onChange={(event) => setName(event.target.value)}
-        />
-        <label htmlFor='email' className='font-semibold'>
-          Email
-        </label>
-        <input
-          id='email'
-          name='email'
-          type='email'
-          required
-          autoComplete='email'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-        />
-        <label htmlFor='password' className='font-semibold'>
-          Password
-        </label>
-        <input
-          id='password'
-          name='password'
-          type='password'
-          required
-          autoComplete='new-password'
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-          value={password}
-          onChange={(event) => setPassword(event.target.value)}
-        />
-        <button
-          type='submit'
-          className='rounded-md bg-black px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90 dark:bg-neutral-900'
-          disabled={isPending}
-        >
-          {isPending ? 'Creating account...' : 'Sign Up'}
-        </button>
+        <div className='th-field'>
+          <label htmlFor='name'>name</label>
+          <input
+            id='name'
+            name='name'
+            type='text'
+            required
+            autoComplete='name'
+            className='th-input'
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+          />
+        </div>
+        <div className='th-field'>
+          <label htmlFor='email'>email</label>
+          <input
+            id='email'
+            name='email'
+            type='email'
+            required
+            autoComplete='email'
+            className='th-input'
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+          />
+        </div>
+        <div className='th-field'>
+          <label htmlFor='password'>password</label>
+          <input
+            id='password'
+            name='password'
+            type='password'
+            required
+            autoComplete='new-password'
+            className='th-input'
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+          />
+        </div>
+        <div className='mt-5 flex flex-wrap gap-3'>
+          <button
+            type='submit'
+            className='th-btn th-btn-primary'
+            disabled={isPending}
+          >
+            {isPending ? 'creating…' : 'create account'}
+          </button>
+          <button
+            type='button'
+            className='th-btn'
+            onClick={async () => {
+              setError(null);
+              const result = await authClient.signIn.social({
+                provider: 'github',
+                callbackURL: '/blog',
+              });
+              if (result.error) {
+                setError(result.error.message ?? 'GitHub 注册失败');
+              }
+            }}
+          >
+            continue with github
+          </button>
+        </div>
+        {error ? <p className='th-err'>{error}</p> : null}
       </form>
-    </section>
+    </div>
   );
 }

--- a/apps/web/src/routes/unlock/$slug.tsx
+++ b/apps/web/src/routes/unlock/$slug.tsx
@@ -82,44 +82,43 @@ function UnlockPage() {
         : undefined;
 
   return (
-    <section className='mx-auto w-full self-start max-w-[80ch] pt-8'>
-      <h1 className='mb-2 text-3xl font-black'>输入文章访问密码</h1>
-      <p className='mb-6 opacity-70'>这篇文章使用了单文密码保护。</p>
-
-      {errorLabel ? (
-        <p role='alert' className='mb-4 text-sm text-red-700 dark:text-red-300'>
-          {errorLabel}
-        </p>
-      ) : null}
-
-      <form method='post' className='grid max-w-[420px] gap-3'>
-        <label htmlFor='password' className='font-semibold'>
-          Password
-        </label>
-        <input
-          id='password'
-          name='password'
-          type='password'
-          required
-          className='rounded-md border border-slate-300 px-3 py-2 dark:border-slate-700 dark:bg-wash-dark'
-        />
-        <button
-          type='submit'
-          className='rounded-md bg-black px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90 dark:bg-neutral-900'
-        >
-          Unlock
-        </button>
-      </form>
-
-      <p className='mt-4'>
-        <Link
-          to='/blog/$slug'
-          params={{ slug }}
-          className='opacity-70 hover:opacity-100'
-        >
-          返回文章页
-        </Link>
+    <div className='th-page'>
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>guest</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>perfectpan.org</span>{' '}
+        <span className='th-prompt-p'>~ %</span>{' '}
+        <span className='th-cmd'>cat posts/{slug}.md</span>
+      </div>
+      <p className='th-out'>
+        <span className='th-nf-big'>
+          cat: posts/{slug}.md: Permission denied
+        </span>
       </p>
-    </section>
+      <p className='th-out th-comment'>
+        # 这篇文章是密码保护的。输入单文密码后 24 小时内免密阅读。
+      </p>
+      <form method='post' className='mt-4'>
+        <div className='th-field'>
+          <label htmlFor='password'>password for this post</label>
+          <input
+            id='password'
+            name='password'
+            type='password'
+            required
+            className='th-input'
+          />
+        </div>
+        <div className='mt-5 flex flex-wrap items-center gap-3'>
+          <button type='submit' className='th-btn th-btn-primary'>
+            sudo unlock
+          </button>
+          <Link to='/blog/$slug' params={{ slug }} className='th-cd'>
+            ← 返回文章
+          </Link>
+        </div>
+        {errorLabel ? <p className='th-err'>{errorLabel}</p> : null}
+      </form>
+    </div>
   );
 }

--- a/apps/web/src/routes/unlock/$slug.tsx
+++ b/apps/web/src/routes/unlock/$slug.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link } from '@tanstack/react-router';
+import { createFileRoute, useParams } from '@tanstack/react-router';
 import {
   buildUnlockCookieHeader,
   createUnlockCookieValue,
@@ -8,6 +8,9 @@ import {
   isUnlockRateLimited,
   recordUnlockFailure,
 } from '../../lib/unlock-rate-limit.js';
+import { useSkin } from '../../skins/context.js';
+import { JournalUnlockPage } from '../../skins/journal/auth.js';
+import { TerminalUnlockPage } from '../../skins/terminal/auth.js';
 
 function getClientIp(request: Request): string | null {
   const forwardedFor = request.headers.get('x-forwarded-for');
@@ -72,53 +75,12 @@ export const Route = createFileRoute('/unlock/$slug')({
 });
 
 function UnlockPage() {
-  const { slug } = Route.useParams();
-  const search = Route.useSearch() as { error?: string };
-  const errorLabel =
-    search.error === 'missing'
-      ? '请输入访问密码'
-      : search.error === 'invalid'
-        ? '密码错误，请重试'
-        : undefined;
-
-  return (
-    <div className='th-page'>
-      <div className='th-prompt'>
-        <span className='th-prompt-u'>guest</span>
-        <span className='th-prompt-at'>@</span>
-        <span className='th-prompt-h'>perfectpan.org</span>{' '}
-        <span className='th-prompt-p'>~ %</span>{' '}
-        <span className='th-cmd'>cat posts/{slug}.md</span>
-      </div>
-      <p className='th-out'>
-        <span className='th-nf-big'>
-          cat: posts/{slug}.md: Permission denied
-        </span>
-      </p>
-      <p className='th-out th-comment'>
-        # 这篇文章是密码保护的。输入单文密码后 24 小时内免密阅读。
-      </p>
-      <form method='post' className='mt-4'>
-        <div className='th-field'>
-          <label htmlFor='password'>password for this post</label>
-          <input
-            id='password'
-            name='password'
-            type='password'
-            required
-            className='th-input'
-          />
-        </div>
-        <div className='mt-5 flex flex-wrap items-center gap-3'>
-          <button type='submit' className='th-btn th-btn-primary'>
-            sudo unlock
-          </button>
-          <Link to='/blog/$slug' params={{ slug }} className='th-cd'>
-            ← 返回文章
-          </Link>
-        </div>
-        {errorLabel ? <p className='th-err'>{errorLabel}</p> : null}
-      </form>
-    </div>
+  const { skin } = useSkin();
+  const { slug } = useParams({ from: '/unlock/$slug' });
+  const search = Route.useSearch() as Record<string, string | undefined>;
+  return skin === 'journal' ? (
+    <JournalUnlockPage slug={slug} search={search} />
+  ) : (
+    <TerminalUnlockPage slug={slug} search={search} />
   );
 }

--- a/apps/web/src/skins/context.tsx
+++ b/apps/web/src/skins/context.tsx
@@ -1,0 +1,71 @@
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+export type Skin = 'terminal' | 'journal';
+
+const SkinContext = createContext<{
+  skin: Skin;
+  setSkin: (next: Skin) => void;
+}>({ skin: 'terminal', setSkin: () => {} });
+
+export const SKIN_COOKIE = 'blog-skin';
+
+export function readSkinFromCookie(cookie: string | null): Skin {
+  return /(?:^|;\s*)blog-skin=journal(?:;|$)/.test(cookie ?? '')
+    ? 'journal'
+    : 'terminal';
+}
+
+/**
+ * Runtime skin switcher for the two UX themes (terminal / journal). The
+ * initial value comes from the root loader (cookie), so SSR and the first
+ * client render agree — no flash, no hydration mismatch. Switching updates
+ * <html data-theme>, persists the cookie, and drops `dark` when entering the
+ * light-only journal skin.
+ */
+export function SkinProvider({
+  initial,
+  children,
+}: {
+  initial: Skin;
+  children: ReactNode;
+}) {
+  const [skin, setSkinState] = useState<Skin>(initial);
+
+  // SSR renders the default skin (per-request context is unreliable on
+  // workerd); apply the cookie skin right after hydration. __root's boot
+  // script hid the body for non-default skins so nothing flashes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: run once per page load; `initial` is a mount-time constant.
+  useEffect(() => {
+    const fromCookie = readSkinFromCookie(document.cookie);
+    if (fromCookie !== initial) {
+      setSkin(fromCookie);
+    }
+    document.getElementById('skin-boot')?.remove();
+  }, []);
+
+  const setSkin = useCallback((next: Skin) => {
+    setSkinState(next);
+    document.documentElement.dataset.theme = next;
+    if (next === 'journal') {
+      // Journal is light-only; leave no stale dark class behind.
+      document.documentElement.classList.remove('dark');
+    }
+    // biome-ignore lint/suspicious/noDocumentCookie: skin preference is a non-sensitive UI cookie; document.cookie is the only dependency-free writer here.
+    document.cookie = `${SKIN_COOKIE}=${next}; path=/; max-age=31536000; samesite=lax`;
+  }, []);
+
+  const value = useMemo(() => ({ skin, setSkin }), [skin, setSkin]);
+  return <SkinContext.Provider value={value}>{children}</SkinContext.Provider>;
+}
+
+export function useSkin() {
+  return useContext(SkinContext);
+}

--- a/apps/web/src/skins/journal/article.tsx
+++ b/apps/web/src/skins/journal/article.tsx
@@ -1,0 +1,70 @@
+import type { CommentThread, SessionUser } from '@blog/shared';
+import { Link } from '@tanstack/react-router';
+import { Markdown } from '../../components/markdown.js';
+import { JournalComments } from './comments.js';
+
+const VIS_TEXT: Record<string, string> = {
+  public: '',
+  member: '会员可见',
+  vip: 'VIP 可见',
+  admin: '仅后台',
+  password: '密码保护',
+};
+
+export function JournalArticle({
+  post,
+  comments,
+  hasMoreComments,
+  totalComments,
+  sessionUser,
+}: {
+  post: {
+    slug: string;
+    title: string;
+    contentMdx: string;
+    publishedAt: string;
+    visibility: string;
+    tags: string[];
+  };
+  comments: CommentThread[];
+  hasMoreComments: boolean;
+  totalComments: number;
+  sessionUser: SessionUser | null;
+}) {
+  const date = new Date(post.publishedAt).toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+  return (
+    <div className='j-sheet'>
+      <article className='j-article'>
+        <h1 className='j-entry-title'>{post.title}</h1>
+        <p className='j-entry-meta'>
+          <span>{date}</span>
+          {post.visibility !== 'public' ? (
+            <span> · {VIS_TEXT[post.visibility]}</span>
+          ) : null}
+          {post.tags.length > 0 ? (
+            <span> · {post.tags.join(' / ')}</span>
+          ) : null}
+        </p>
+        <Markdown content={post.contentMdx} />
+        <div className='j-backlink'>
+          <Link to='/blog'>← Back to blog</Link>
+        </div>
+      </article>
+      <div className='j-letters'>
+        <JournalComments
+          key={post.slug}
+          slug={post.slug}
+          initialComments={comments}
+          initialHasMore={hasMoreComments}
+          initialTotal={totalComments}
+          sessionUser={sessionUser}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/skins/journal/auth.tsx
+++ b/apps/web/src/skins/journal/auth.tsx
@@ -1,0 +1,291 @@
+import { Link, useNavigate } from '@tanstack/react-router';
+import { useEffect, useState, useTransition } from 'react';
+import { authClient } from '../../lib/auth-client.js';
+
+export function JournalLoginPage() {
+  const navigate = useNavigate();
+  const { data: sessionData, isPending: isSessionPending } =
+    authClient.useSession();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (sessionData?.user?.id) {
+      navigate({ to: '/blog', replace: true });
+    }
+  }, [navigate, sessionData?.user?.id]);
+
+  if (sessionData?.user?.id || isSessionPending) {
+    return (
+      <div className='j-sheet'>
+        <p className='j-aside'>Checking session...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className='j-sheet'>
+      <div className='j-gate'>
+        <div className='j-gate-card'>
+          <span className='j-seal' aria-hidden='true'>
+            潘
+          </span>
+          <h1>登录</h1>
+          <p className='sub'>支持邮箱密码和 GitHub OAuth。</p>
+          <form
+            method='post'
+            onSubmit={(event) => {
+              event.preventDefault();
+              setError(null);
+              startTransition(async () => {
+                const result = await authClient.signIn.email({
+                  email,
+                  password,
+                  callbackURL: '/blog',
+                });
+
+                if (result.error) {
+                  setError(result.error.message ?? '登录失败');
+                  return;
+                }
+
+                navigate({ to: '/blog' });
+              });
+            }}
+          >
+            <div className='j-field'>
+              <label htmlFor='email'>Email</label>
+              <input
+                id='email'
+                name='email'
+                type='email'
+                required
+                autoComplete='email'
+                className='j-input'
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+              />
+            </div>
+            <div className='j-field'>
+              <label htmlFor='password'>Password</label>
+              <input
+                id='password'
+                name='password'
+                type='password'
+                required
+                autoComplete='current-password'
+                className='j-input'
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+            </div>
+            <div className='j-actions'>
+              <button
+                type='submit'
+                className='j-btn j-btn-red'
+                disabled={isPending}
+              >
+                {isPending ? 'Signing in...' : 'Sign In'}
+              </button>
+              <button
+                type='button'
+                className='j-btn'
+                onClick={async () => {
+                  setError(null);
+                  const result = await authClient.signIn.social({
+                    provider: 'github',
+                    callbackURL: '/blog',
+                  });
+                  if (result.error) {
+                    setError(result.error.message ?? 'GitHub 登录失败');
+                  }
+                }}
+              >
+                Continue with GitHub
+              </button>
+            </div>
+            {error ? <p className='j-err mt-4'>{error}</p> : null}
+          </form>
+          <p className='j-aside'>
+            还没有账号？{' '}
+            <a href='/signup' style={{ color: 'var(--j-red)' }}>
+              Sign Up
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function JournalSignupPage() {
+  const navigate = useNavigate();
+  const { data: sessionData, isPending: isSessionPending } =
+    authClient.useSession();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [name, setName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (sessionData?.user?.id) {
+      navigate({ to: '/blog', replace: true });
+    }
+  }, [navigate, sessionData?.user?.id]);
+
+  if (sessionData?.user?.id || isSessionPending) {
+    return (
+      <div className='j-sheet'>
+        <p className='j-aside'>Checking session...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className='j-sheet'>
+      <div className='j-gate'>
+        <div className='j-gate-card'>
+          <span className='j-seal' aria-hidden='true'>
+            潘
+          </span>
+          <h1>注册</h1>
+          <p className='sub'>注册后默认角色为 member，可在后台升权。</p>
+          <form
+            method='post'
+            onSubmit={(event) => {
+              event.preventDefault();
+              setError(null);
+              startTransition(async () => {
+                const result = await authClient.signUp.email({
+                  email,
+                  password,
+                  name,
+                  callbackURL: '/blog',
+                });
+
+                if (result.error) {
+                  setError(result.error.message ?? '注册失败');
+                  return;
+                }
+
+                navigate({ to: '/blog' });
+              });
+            }}
+          >
+            <div className='j-field'>
+              <label htmlFor='name'>Name</label>
+              <input
+                id='name'
+                name='name'
+                type='text'
+                required
+                autoComplete='name'
+                className='j-input'
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+              />
+            </div>
+            <div className='j-field'>
+              <label htmlFor='email'>Email</label>
+              <input
+                id='email'
+                name='email'
+                type='email'
+                required
+                autoComplete='email'
+                className='j-input'
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+              />
+            </div>
+            <div className='j-field'>
+              <label htmlFor='password'>Password</label>
+              <input
+                id='password'
+                name='password'
+                type='password'
+                required
+                autoComplete='new-password'
+                className='j-input'
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+            </div>
+            <div className='j-actions'>
+              <button
+                type='submit'
+                className='j-btn j-btn-red'
+                disabled={isPending}
+              >
+                {isPending ? 'Creating account...' : 'Sign Up'}
+              </button>
+            </div>
+            {error ? <p className='j-err mt-4'>{error}</p> : null}
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function JournalUnlockPage({
+  slug,
+  search,
+}: {
+  slug: string;
+  search?: Record<string, string | undefined>;
+}) {
+  const { error: searchError } = (search ?? {}) as { error?: string };
+  const errorLabel =
+    searchError === 'missing'
+      ? '请输入访问密码'
+      : searchError === 'invalid'
+        ? '密码错误，请重试'
+        : undefined;
+
+  return (
+    <div className='j-sheet'>
+      <div className='j-gate'>
+        <div className='j-gate-card text-center'>
+          <div className='j-lockmark' aria-hidden='true'>
+            锁
+          </div>
+          <h1>输入文章访问密码</h1>
+          <p className='sub'>这篇文章使用了单文密码保护。</p>
+          <form method='post' className='text-left'>
+            <div className='j-field'>
+              <label htmlFor='password'>Password</label>
+              <input
+                id='password'
+                name='password'
+                type='password'
+                required
+                className='j-input'
+              />
+            </div>
+            {errorLabel ? (
+              <p className='j-err text-center'>{errorLabel}</p>
+            ) : null}
+            <div className='j-actions justify-center'>
+              <button type='submit' className='j-btn j-btn-red'>
+                Unlock
+              </button>
+            </div>
+          </form>
+          <p className='j-aside'>
+            <Link
+              to='/blog/$slug'
+              params={{ slug }}
+              style={{ color: 'var(--j-indigo)' }}
+            >
+              返回文章页
+            </Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/skins/journal/blog-list.tsx
+++ b/apps/web/src/skins/journal/blog-list.tsx
@@ -1,0 +1,122 @@
+import type { PostSummary } from '@blog/shared';
+import { Link } from '@tanstack/react-router';
+
+function groupByYear(
+  posts: PostSummary[],
+): { year: string; blogs: PostSummary[] }[] {
+  const groups = new Map<string, PostSummary[]>();
+  for (const post of posts) {
+    const year = new Date(post.publishedAt).getFullYear().toString();
+    const existing = groups.get(year);
+    if (existing) existing.push(post);
+    else groups.set(year, [post]);
+  }
+  return [...groups.entries()]
+    .sort((a, b) => Number(b[0]) - Number(a[0]))
+    .map(([year, blogs]) => ({
+      year,
+      blogs: [...blogs].sort((a, b) =>
+        b.publishedAt.localeCompare(a.publishedAt),
+      ),
+    }));
+}
+
+const NOTE_CLASS: Record<PostSummary['visibility'], string> = {
+  public: '',
+  member: 'j-note mem',
+  vip: 'j-note vip',
+  admin: 'j-note adm',
+  password: 'j-note pw',
+};
+const NOTE_TEXT: Record<PostSummary['visibility'], string> = {
+  public: '',
+  member: '会员',
+  vip: 'VIP',
+  admin: '仅后台',
+  password: '密码',
+};
+
+export function JournalBlogList({
+  data,
+  showDevHint,
+  devScopeHint,
+}: {
+  data: {
+    posts: PostSummary[];
+    total: number;
+    page: number;
+    totalPages: number;
+  };
+  showDevHint: boolean;
+  devScopeHint: string;
+}) {
+  const blogGroups = groupByYear(data.posts);
+  let runningIndex = 0;
+
+  return (
+    <div className='j-sheet'>
+      <h1 className='j-entry-title text-center'>Blog</h1>
+      <p className='j-entry-meta text-center'>按年份归档 · 自新迄旧</p>
+
+      {showDevHint ? <div className='j-devhint'>{devScopeHint}</div> : null}
+
+      {blogGroups.map((group) => (
+        <div key={group.year}>
+          <div className='j-juan'>
+            <h2 style={{ letterSpacing: '0.18em' }}>{group.year}</h2>
+            <span className='sub'>{group.blogs.length} 篇</span>
+          </div>
+          {group.blogs.map((blog: PostSummary) => {
+            runningIndex += 1;
+            return (
+              <div className='j-toc-line' key={blog.slug}>
+                <Link to='/blog/$slug' params={{ slug: blog.slug }}>
+                  <span className='t'>
+                    {blog.title}
+                    {blog.visibility !== 'public' ? (
+                      <span className={NOTE_CLASS[blog.visibility]}>
+                        {NOTE_TEXT[blog.visibility]}
+                      </span>
+                    ) : null}
+                  </span>
+                  <span className='dots' />
+                </Link>
+                <span className='n'>
+                  {new Date(blog.publishedAt).toLocaleDateString('en-US', {
+                    month: 'short',
+                    day: 'numeric',
+                  })}
+                </span>
+                <span className='n' style={{ color: 'var(--j-faint)' }}>
+                  {String(runningIndex).padStart(3, '0')}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      ))}
+
+      {data.totalPages > 1 ? (
+        <nav className='j-pager' aria-label='Pagination'>
+          {data.page > 1 ? (
+            <Link to='/blog' search={{ page: data.page - 1 }}>
+              ← prev
+            </Link>
+          ) : (
+            <span>← prev</span>
+          )}
+          <span>
+            page {data.page} / {data.totalPages}
+          </span>
+          {data.page < data.totalPages ? (
+            <Link to='/blog' search={{ page: data.page + 1 }}>
+              next →
+            </Link>
+          ) : (
+            <span>next →</span>
+          )}
+        </nav>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/skins/journal/comments.tsx
+++ b/apps/web/src/skins/journal/comments.tsx
@@ -1,0 +1,407 @@
+'use client';
+
+import type { Comment, CommentThread, SessionUser } from '@blog/shared';
+import { Link } from '@tanstack/react-router';
+import { useState } from 'react';
+import { CommentMarkdown } from '../../components/comment-markdown.js';
+import {
+  createCommentServerFn,
+  deleteCommentServerFn,
+  getCommentsServerFn,
+} from '../../lib/comments-service.js';
+
+type CommentsProps = {
+  slug: string;
+  initialComments: CommentThread[];
+  initialHasMore: boolean;
+  initialTotal: number;
+  sessionUser: SessionUser | null;
+};
+
+const PAGE_SIZE = 20;
+
+function formatRelative(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) {
+    return iso;
+  }
+  const seconds = Math.floor((Date.now() - then) / 1000);
+  if (seconds < 60) {
+    return '刚刚';
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes} 分钟前`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours} 小时前`;
+  }
+  const days = Math.floor(hours / 24);
+  if (days < 30) {
+    return `${days} 天前`;
+  }
+  return new Date(iso).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+type ComposerProps = {
+  placeholder: string;
+  submitting: boolean;
+  onSubmit: (body: string) => Promise<void>;
+  compact?: boolean;
+};
+
+function Composer({
+  placeholder,
+  submitting,
+  onSubmit,
+  compact,
+}: ComposerProps) {
+  const [body, setBody] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const remaining = 2000 - body.length;
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    const trimmed = body.trim();
+    if (!trimmed || submitting) {
+      return;
+    }
+    setError(null);
+    try {
+      await onSubmit(trimmed);
+      setBody('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '评论失败，请重试');
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className='j-cmt-form flex flex-col gap-2'>
+      <textarea
+        value={body}
+        onChange={(event) => setBody(event.target.value)}
+        placeholder={placeholder}
+        rows={compact ? 2 : 3}
+        maxLength={2000}
+      />
+      <div className='j-cmt-foot'>
+        <span className='j-cmt-hint'>
+          {remaining < 200 ? `${remaining} 字剩余` : '支持 Markdown'}
+          {error ? <span className='j-err'>{error}</span> : null}
+        </span>
+        <button
+          type='submit'
+          disabled={submitting || !body.trim()}
+          className='j-btn j-btn-red'
+        >
+          {submitting ? '发送中…' : '发送'}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+type CommentItemProps = {
+  thread: CommentThread;
+  sessionUser: SessionUser | null;
+  onReply: (parentId: string, body: string) => Promise<void>;
+  onDelete: (id: string) => Promise<void>;
+  replyingTo: string | null;
+  setReplyingTo: (id: string | null) => void;
+  replySubmitting: Set<string>;
+};
+
+function CommentItem({
+  thread,
+  sessionUser,
+  onReply,
+  onDelete,
+  replyingTo,
+  setReplyingTo,
+  replySubmitting,
+}: CommentItemProps) {
+  const canAct =
+    sessionUser != null && (thread.isOwn || sessionUser.role === 'admin');
+
+  async function handleDelete() {
+    if (!canAct) {
+      return;
+    }
+    if (!window.confirm('删除这条评论？')) {
+      return;
+    }
+    // onDelete (the parent handleDelete) catches its own errors and surfaces
+    // them via topError, so it does not throw — no swallow, no unhandled reject.
+    await onDelete(thread.id);
+  }
+
+  return (
+    <li className='flex flex-col gap-2'>
+      <CommentView
+        comment={thread}
+        canAct={canAct}
+        canReply={sessionUser != null}
+        onReply={() =>
+          setReplyingTo(replyingTo === thread.id ? null : thread.id)
+        }
+        onDelete={handleDelete}
+      />
+
+      {replyingTo === thread.id && sessionUser ? (
+        <div className='ml-10'>
+          <Composer
+            placeholder={`回复 @${thread.author.name}…`}
+            submitting={replySubmitting.has(thread.id)}
+            onSubmit={(body) => onReply(thread.id, body)}
+            compact
+          />
+        </div>
+      ) : null}
+
+      {thread.replies.length > 0 ? (
+        <ul className='flex flex-col gap-2'>
+          {thread.replies.map((reply) => {
+            const replyCanAct =
+              sessionUser != null &&
+              (reply.isOwn || sessionUser.role === 'admin');
+            return (
+              <CommentView
+                key={reply.id}
+                comment={reply}
+                canAct={replyCanAct}
+                canReply={false}
+                onReply={undefined}
+                onDelete={async () => {
+                  if (!window.confirm('删除这条回复？')) {
+                    return;
+                  }
+                  await onDelete(reply.id);
+                }}
+              />
+            );
+          })}
+        </ul>
+      ) : null}
+    </li>
+  );
+}
+
+type CommentViewProps = {
+  comment: Comment;
+  canAct: boolean;
+  canReply?: boolean;
+  onReply?: () => void;
+  onDelete: () => void | Promise<void>;
+};
+
+function CommentView({
+  comment,
+  canAct,
+  canReply,
+  onReply,
+  onDelete,
+}: CommentViewProps) {
+  const isReply = comment.parentId !== null;
+
+  return (
+    <div className={isReply ? 'j-letter j-letter-reply' : 'j-letter'}>
+      <div className='j-lhead'>
+        <span className='who'>{comment.author.name}</span>
+        {comment.author.role === 'admin' ? (
+          <span className='badge'>作者</span>
+        ) : null}
+        {comment.status !== 'visible' ? (
+          <span style={{ color: 'var(--j-red)' }}>{comment.status}</span>
+        ) : null}
+        <span className='when'>{formatRelative(comment.createdAt)}</span>
+      </div>
+      <div className='j-lbody'>
+        <CommentMarkdown content={comment.body} />
+      </div>
+      {canReply && onReply ? (
+        <div className='j-lops'>
+          <button type='button' onClick={onReply}>
+            回复
+          </button>
+          {canAct ? (
+            <button type='button' onClick={() => onDelete()}>
+              删除
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+      {!(canReply && onReply) && canAct ? (
+        <div className='j-lops'>
+          <button type='button' onClick={() => onDelete()}>
+            删除
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function JournalComments({
+  slug,
+  initialComments,
+  initialHasMore,
+  initialTotal,
+  sessionUser,
+}: CommentsProps) {
+  const [threads, setThreads] = useState<CommentThread[]>(initialComments);
+  const [hasMore, setHasMore] = useState(initialHasMore);
+  const [total, setTotal] = useState(initialTotal);
+  const [submitting, setSubmitting] = useState(false);
+  const [topError, setTopError] = useState<string | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [replyingTo, setReplyingTo] = useState<string | null>(null);
+  const [replySubmitting, setReplySubmitting] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  async function handleCreateTopLevel(body: string) {
+    setSubmitting(true);
+    try {
+      const { comment } = await createCommentServerFn({
+        data: { slug, body },
+      });
+      // Newest-first: a fresh top-level comment goes to the front.
+      setThreads((prev) => [{ ...comment, replies: [] }, ...prev]);
+      setTotal((count) => count + 1);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleReply(parentId: string, body: string) {
+    setReplySubmitting((prev) => new Set(prev).add(parentId));
+    try {
+      const { comment } = await createCommentServerFn({
+        data: { slug, body, parentId },
+      });
+      setThreads((prev) =>
+        prev.map((thread) =>
+          thread.id === parentId
+            ? { ...thread, replies: [...thread.replies, comment] }
+            : thread,
+        ),
+      );
+      setReplyingTo(null);
+    } finally {
+      setReplySubmitting((prev) => {
+        const next = new Set(prev);
+        next.delete(parentId);
+        return next;
+      });
+    }
+  }
+
+  async function handleDelete(id: string) {
+    setTopError(null);
+    try {
+      await deleteCommentServerFn({ data: { id } });
+    } catch (err) {
+      setTopError(err instanceof Error ? err.message : '删除失败，请重试');
+      return;
+    }
+    const wasTopLevel = threads.some((thread) => thread.id === id);
+    setThreads((prev) =>
+      prev
+        .map((thread) => ({
+          ...thread,
+          replies: thread.replies.filter((reply) => reply.id !== id),
+        }))
+        .filter((thread) => thread.id !== id),
+    );
+    if (wasTopLevel) {
+      setTotal((count) => Math.max(0, count - 1));
+    }
+  }
+
+  async function handleLoadMore() {
+    setLoadingMore(true);
+    try {
+      const result = await getCommentsServerFn({
+        data: { slug, offset: threads.length, limit: PAGE_SIZE },
+      });
+      setThreads((prev) => [...prev, ...result.comments]);
+      setHasMore(result.hasMore);
+      setTotal(result.total);
+      setTopError(null);
+    } catch (err) {
+      setTopError(err instanceof Error ? err.message : '加载更多失败');
+    } finally {
+      setLoadingMore(false);
+    }
+  }
+
+  return (
+    <section className='mt-10'>
+      <h3 className='j-blockhead'>评论 {total > 0 ? `(${total})` : ''}</h3>
+
+      {sessionUser ? (
+        <div className='mb-6'>
+          <Composer
+            placeholder='写下你的评论…（支持 Markdown）'
+            submitting={submitting}
+            onSubmit={handleCreateTopLevel}
+          />
+        </div>
+      ) : (
+        <p
+          className='mb-6 text-sm'
+          style={{ color: 'var(--j-faded)', fontFamily: 'var(--j-sans)' }}
+        >
+          <Link to='/login' className='underline'>
+            入会
+          </Link>{' '}
+          后即可评论。
+        </p>
+      )}
+
+      {topError ? <p className='j-err mb-4'>{topError}</p> : null}
+
+      {threads.length === 0 ? (
+        <p
+          className='py-8 text-center text-sm'
+          style={{ color: 'var(--j-faint)', fontFamily: 'var(--j-sans)' }}
+        >
+          还没有评论，来抢沙发。
+        </p>
+      ) : (
+        <ul className='flex flex-col gap-3'>
+          {threads.map((thread) => (
+            <CommentItem
+              key={thread.id}
+              thread={thread}
+              sessionUser={sessionUser}
+              onReply={handleReply}
+              onDelete={handleDelete}
+              replyingTo={replyingTo}
+              setReplyingTo={setReplyingTo}
+              replySubmitting={replySubmitting}
+            />
+          ))}
+        </ul>
+      )}
+
+      {hasMore ? (
+        <div className='mt-6 text-center'>
+          <button
+            type='button'
+            onClick={handleLoadMore}
+            disabled={loadingMore}
+            className='j-btn'
+          >
+            {loadingMore ? '加载中…' : '加载更多'}
+          </button>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/skins/journal/footer.tsx
+++ b/apps/web/src/skins/journal/footer.tsx
@@ -1,0 +1,8 @@
+export function JournalFooter() {
+  return (
+    <footer className='j-colophon'>
+      © {new Date().getFullYear()}, Built with{' '}
+      <a href='https://tanstack.com/start/latest'>TanStack Start</a>
+    </footer>
+  );
+}

--- a/apps/web/src/skins/journal/header.tsx
+++ b/apps/web/src/skins/journal/header.tsx
@@ -1,0 +1,123 @@
+import { Link } from '@tanstack/react-router';
+import { Github, LogOut, Rss, Search, UserRound } from 'lucide-react';
+import { searchPalette } from '../../components/search-palette-store.js';
+import { authClient } from '../../lib/auth-client.js';
+
+function getRoleLabel(role?: string | null): string {
+  if (role === 'admin') {
+    return 'ADMIN';
+  }
+
+  if (role === 'vip') {
+    return 'VIP';
+  }
+
+  return 'MEMBER';
+}
+
+import { Terminal } from 'lucide-react';
+import { useSkin } from '../context.js';
+
+/** Journal masthead: warm-paper shell with the site's original wording. */
+export function JournalHeader() {
+  const { data: sessionData } = authClient.useSession();
+  const sessionUser = sessionData?.user ?? null;
+
+  return (
+    <div>
+      <header className='j-masthead'>
+        <div className='j-brand'>
+          <Link to='/'>
+            PerfectPan<span className='j-dot'>.</span>
+          </Link>
+        </div>
+        <nav aria-label='主导航'>
+          <Link to='/'>Home</Link>
+          <Link to='/blog'>Blog</Link>
+          <Link to='/projects'>Projects</Link>
+          {sessionUser?.role === 'admin' ? (
+            <Link to='/admin'>Admin</Link>
+          ) : null}
+        </nav>
+        <div className='ml-auto flex items-center gap-3'>
+          {sessionUser ? (
+            <span className='j-user-chip hidden md:flex'>
+              <UserRound size={13} aria-hidden='true' />
+              <span className='max-w-[200px] truncate'>
+                {sessionUser.email}
+              </span>
+              <span className='j-user-role'>
+                {getRoleLabel(sessionUser.role)}
+              </span>
+            </span>
+          ) : null}
+          {sessionUser ? (
+            <Link to='/logout' data-testid='nav-logout' aria-label='Logout'>
+              <LogOut size={17} className='opacity-60 hover:opacity-100' />
+            </Link>
+          ) : (
+            <>
+              <Link
+                to='/login'
+                data-testid='nav-login'
+                className='text-[13.5px]'
+                style={{ letterSpacing: '0.28em', color: 'var(--j-faded)' }}
+              >
+                Login
+              </Link>
+              <Link
+                to='/signup'
+                className='text-[13.5px]'
+                style={{ letterSpacing: '0.28em', color: 'var(--j-faded)' }}
+              >
+                Sign Up
+              </Link>
+            </>
+          )}
+          <SkinSwitch />
+          <button
+            type='button'
+            aria-label='Search posts (Cmd+K)'
+            onClick={() => searchPalette.open()}
+          >
+            <Search size={17} className='opacity-60 hover:opacity-100' />
+          </button>
+          <a
+            href='https://github.com/PerfectPan'
+            target='_blank'
+            rel='noreferrer'
+            aria-label='GitHub'
+          >
+            <Github size={17} className='opacity-60 hover:opacity-100' />
+          </a>
+          <a href='/rss.xml' target='_blank' rel='noreferrer' aria-label='RSS'>
+            <Rss size={17} className='opacity-60 hover:opacity-100' />
+          </a>
+        </div>
+      </header>
+      <div className='j-headrule'>
+        <hr />
+      </div>
+    </div>
+  );
+}
+
+function SkinSwitch() {
+  const { setSkin } = useSkin();
+  return (
+    <button
+      type='button'
+      aria-label='Switch to terminal theme'
+      onClick={() => setSkin('terminal')}
+      style={{
+        color: 'var(--j-faint)',
+        cursor: 'pointer',
+        background: 'none',
+        border: 0,
+        padding: 0,
+      }}
+    >
+      <Terminal size={16} />
+    </button>
+  );
+}

--- a/apps/web/src/skins/journal/home.tsx
+++ b/apps/web/src/skins/journal/home.tsx
@@ -1,0 +1,65 @@
+import type { PostSummary } from '@blog/shared';
+import { Link } from '@tanstack/react-router';
+import { PROJECTS } from '../../lib/projects.js';
+
+export function JournalHomePage({
+  data,
+}: {
+  data: { posts: PostSummary[]; total: number };
+}) {
+  const latest = data.posts.slice(0, 5);
+
+  return (
+    <div className='j-sheet'>
+      <div className='j-home'>
+        <div>
+          <h1>是个什么都不会的废物.jpg</h1>
+          <p className='j-tagline'>
+            算法竞赛退役选手，现在的兴趣在前端工程、类型体操和把东西跑在
+            Cloudflare 免费额度上。这里收着题解、笔记和一些随想。
+          </p>
+          <div className='j-facts'>
+            <span>{data.total} 篇文章</span>
+            <span>2019 — 2023</span>
+            <span>{PROJECTS.length} 个开源项目</span>
+          </div>
+          <div className='j-home-cta'>
+            <Link to='/blog' className='j-btn j-btn-red'>
+              Blog
+            </Link>
+            <Link to='/projects' className='j-btn'>
+              Projects
+            </Link>
+          </div>
+          <div className='j-home-seal'>
+            <span className='j-seal' aria-hidden='true'>
+              潘
+            </span>
+            <div className='sign'>
+              PerfectPan
+              <br />
+              perfectpan.org
+            </div>
+          </div>
+        </div>
+        <div className='j-home-panel'>
+          <div className='j-blockhead'>最 近 文 章</div>
+          {latest.map((post: PostSummary) => (
+            <div className='j-latest-item' key={post.slug}>
+              <Link className='t' to='/blog/$slug' params={{ slug: post.slug }}>
+                {post.title}
+              </Link>
+              <span className='d'>
+                {new Date(post.publishedAt).toLocaleDateString('en-US', {
+                  month: 'short',
+                  day: 'numeric',
+                  year: 'numeric',
+                })}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/skins/journal/misc.tsx
+++ b/apps/web/src/skins/journal/misc.tsx
@@ -1,0 +1,32 @@
+import { Link } from '@tanstack/react-router';
+
+export function JournalNotFound() {
+  return (
+    <div className='j-nf'>
+      <span className='j-seal' aria-hidden='true'>
+        阙
+      </span>
+      <div className='zh' style={{ marginTop: 30 }}>
+        404 Not Found
+      </div>
+      <p>你闯入了无人之境...</p>
+      <p style={{ marginTop: 26 }}>
+        <Link to='/blog' className='j-btn'>
+          Back to blog
+        </Link>
+      </p>
+    </div>
+  );
+}
+
+export function JournalError({ error }: { error: unknown }) {
+  return (
+    <div className='j-sheet'>
+      <h1 className='j-entry-title text-center'>Request Failed</h1>
+      <p className='j-entry-meta text-center'>{String(error)}</p>
+      <p className='j-backlink'>
+        <Link to='/blog'>Back to blog</Link>
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/skins/journal/projects.tsx
+++ b/apps/web/src/skins/journal/projects.tsx
@@ -1,0 +1,45 @@
+import { PROJECTS, type Project } from '../../lib/projects.js';
+
+function sortProjects(projects: Project[]): Project[] {
+  return [...projects].sort((a, b) => {
+    if (Boolean(a.featured) === Boolean(b.featured)) {
+      return a.name.localeCompare(b.name);
+    }
+    return a.featured ? -1 : 1;
+  });
+}
+
+export function JournalProjectsPage() {
+  const projects = sortProjects(PROJECTS);
+
+  return (
+    <div className='j-sheet'>
+      <h1 className='j-entry-title text-center'>Projects</h1>
+      <p className='j-entry-meta text-center'>我做过的一些东西，按需更新。</p>
+
+      {projects.map((project, index) => (
+        <div className='j-ware' key={project.name}>
+          <div className='no'>
+            {String(index + 1).padStart(2, '0')}
+            {project.featured ? <small>FEATURED</small> : null}
+          </div>
+          <div>
+            <h2>{project.name}</h2>
+            <p>{project.description}</p>
+            <div className='tags'>{project.tags.join('　')}</div>
+            <div className='wlinks'>
+              <a href={project.repo} target='_blank' rel='noreferrer'>
+                Code ↗
+              </a>
+              {project.demo ? (
+                <a href={project.demo} target='_blank' rel='noreferrer'>
+                  Demo ↗
+                </a>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/skins/terminal/article.tsx
+++ b/apps/web/src/skins/terminal/article.tsx
@@ -1,0 +1,78 @@
+import type { CommentThread, SessionUser } from '@blog/shared';
+import { Link } from '@tanstack/react-router';
+import { Markdown } from '../../components/markdown.js';
+import { TerminalComments } from './comments.js';
+
+export function TerminalArticle({
+  post,
+  comments,
+  hasMoreComments,
+  totalComments,
+  sessionUser,
+}: {
+  post: {
+    slug: string;
+    title: string;
+    contentMdx: string;
+    publishedAt: string;
+    visibility: string;
+    tags: string[];
+  };
+  comments: CommentThread[];
+  hasMoreComments: boolean;
+  totalComments: number;
+  sessionUser: SessionUser | null;
+}) {
+  const date = new Date(post.publishedAt).toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+  return (
+    <div className='th-page'>
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>perfectpan</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>blog</span>{' '}
+        <span className='th-prompt-p'>~/posts %</span>{' '}
+        <span className='th-cmd'>
+          cat {new Date(post.publishedAt).getFullYear()}/{post.slug}.md
+        </span>
+      </div>
+
+      <div className='th-art-head'>
+        <h1 className='th-art-title'>{post.title}</h1>
+        <div className='th-art-meta'>
+          <span>{date}</span>
+          <span>·</span>
+          <span>{post.visibility}</span>
+          {post.tags.length > 0 ? (
+            <>
+              <span>·</span>
+              <span>#{post.tags.join(' #')}</span>
+            </>
+          ) : null}
+        </div>
+      </div>
+      <Markdown content={post.contentMdx} skin='terminal' />
+      <div className='th-prompt mt-6'>
+        <span className='th-prompt-u'>perfectpan</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>blog</span>{' '}
+        <span className='th-prompt-p'>~/posts %</span>{' '}
+        <Link to='/blog' className='th-cmd th-cmd-dim'>
+          cd ..
+        </Link>
+      </div>
+      <TerminalComments
+        key={post.slug}
+        slug={post.slug}
+        initialComments={comments}
+        initialHasMore={hasMoreComments}
+        initialTotal={totalComments}
+        sessionUser={sessionUser}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/skins/terminal/auth.tsx
+++ b/apps/web/src/skins/terminal/auth.tsx
@@ -1,0 +1,307 @@
+import { Link, useNavigate } from '@tanstack/react-router';
+import { useEffect, useState, useTransition } from 'react';
+import { authClient } from '../../lib/auth-client.js';
+
+export function TerminalLoginPage() {
+  const navigate = useNavigate();
+  const { data: sessionData, isPending: isSessionPending } =
+    authClient.useSession();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (sessionData?.user?.id) {
+      navigate({ to: '/blog', replace: true });
+    }
+  }, [navigate, sessionData?.user?.id]);
+
+  if (sessionData?.user?.id || isSessionPending) {
+    return (
+      <div className='th-page'>
+        <p className='th-comment'># checking session…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className='th-page'>
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>guest</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>perfectpan.org</span>{' '}
+        <span className='th-prompt-p'>~ %</span>{' '}
+        <span className='th-cmd'>ssh member@perfectpan.org</span>
+      </div>
+      <p className='th-out th-comment mt-2'>
+        # 邮箱密码登录；或者走 GitHub OAuth。
+      </p>
+      <form
+        className='mt-4'
+        method='post'
+        onSubmit={(event) => {
+          event.preventDefault();
+          setError(null);
+          startTransition(async () => {
+            const result = await authClient.signIn.email({
+              email,
+              password,
+              callbackURL: '/blog',
+            });
+
+            if (result.error) {
+              setError(result.error.message ?? '登录失败');
+              return;
+            }
+
+            navigate({ to: '/blog' });
+          });
+        }}
+      >
+        <div className='th-field'>
+          <label htmlFor='email'>email</label>
+          <input
+            id='email'
+            name='email'
+            type='email'
+            required
+            autoComplete='email'
+            className='th-input'
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+          />
+        </div>
+        <div className='th-field'>
+          <label htmlFor='password'>password</label>
+          <input
+            id='password'
+            name='password'
+            type='password'
+            required
+            autoComplete='current-password'
+            className='th-input'
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+          />
+        </div>
+        <div className='mt-5 flex flex-wrap gap-3'>
+          <button
+            type='submit'
+            className='th-btn th-btn-primary'
+            disabled={isPending}
+          >
+            {isPending ? 'signing in…' : 'sign in'}
+          </button>
+          <button
+            type='button'
+            className='th-btn'
+            onClick={async () => {
+              setError(null);
+              const result = await authClient.signIn.social({
+                provider: 'github',
+                callbackURL: '/blog',
+              });
+              if (result.error) {
+                setError(result.error.message ?? 'GitHub 登录失败');
+              }
+            }}
+          >
+            continue with github
+          </button>
+        </div>
+        {error ? <p className='th-err'>{error}</p> : null}
+      </form>
+      <p className='th-out mt-4'>
+        <span className='th-comment'># 还没有账号？</span>{' '}
+        <a href='/signup'>signup</a>
+      </p>
+    </div>
+  );
+}
+
+export function TerminalSignupPage() {
+  const navigate = useNavigate();
+  const { data: sessionData, isPending: isSessionPending } =
+    authClient.useSession();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [name, setName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (sessionData?.user?.id) {
+      navigate({ to: '/blog', replace: true });
+    }
+  }, [navigate, sessionData?.user?.id]);
+
+  if (sessionData?.user?.id || isSessionPending) {
+    return (
+      <div className='th-page'>
+        <p className='th-comment'># checking session…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className='th-page'>
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>guest</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>perfectpan.org</span>{' '}
+        <span className='th-prompt-p'>~ %</span>{' '}
+        <span className='th-cmd'>useradd --join</span>
+      </div>
+      <p className='th-out th-comment mt-2'>
+        # 注册成为 member，可读 member 可见性的文章。
+      </p>
+      <form
+        className='mt-4'
+        method='post'
+        onSubmit={(event) => {
+          event.preventDefault();
+          setError(null);
+          startTransition(async () => {
+            const result = await authClient.signUp.email({
+              email,
+              password,
+              name,
+              callbackURL: '/blog',
+            });
+
+            if (result.error) {
+              setError(result.error.message ?? '注册失败');
+              return;
+            }
+
+            navigate({ to: '/blog' });
+          });
+        }}
+      >
+        <div className='th-field'>
+          <label htmlFor='name'>name</label>
+          <input
+            id='name'
+            name='name'
+            type='text'
+            required
+            autoComplete='name'
+            className='th-input'
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+          />
+        </div>
+        <div className='th-field'>
+          <label htmlFor='email'>email</label>
+          <input
+            id='email'
+            name='email'
+            type='email'
+            required
+            autoComplete='email'
+            className='th-input'
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+          />
+        </div>
+        <div className='th-field'>
+          <label htmlFor='password'>password</label>
+          <input
+            id='password'
+            name='password'
+            type='password'
+            required
+            autoComplete='new-password'
+            className='th-input'
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+          />
+        </div>
+        <div className='mt-5 flex flex-wrap gap-3'>
+          <button
+            type='submit'
+            className='th-btn th-btn-primary'
+            disabled={isPending}
+          >
+            {isPending ? 'creating…' : 'create account'}
+          </button>
+          <button
+            type='button'
+            className='th-btn'
+            onClick={async () => {
+              setError(null);
+              const result = await authClient.signIn.social({
+                provider: 'github',
+                callbackURL: '/blog',
+              });
+              if (result.error) {
+                setError(result.error.message ?? 'GitHub 注册失败');
+              }
+            }}
+          >
+            continue with github
+          </button>
+        </div>
+        {error ? <p className='th-err'>{error}</p> : null}
+      </form>
+    </div>
+  );
+}
+
+export function TerminalUnlockPage({
+  slug,
+  search,
+}: {
+  slug: string;
+  search?: Record<string, string | undefined>;
+}) {
+  const { error: searchError } = (search ?? {}) as { error?: string };
+  const errorLabel =
+    searchError === 'missing'
+      ? '请输入访问密码'
+      : searchError === 'invalid'
+        ? '密码错误，请重试'
+        : undefined;
+
+  return (
+    <div className='th-page'>
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>guest</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>perfectpan.org</span>{' '}
+        <span className='th-prompt-p'>~ %</span>{' '}
+        <span className='th-cmd'>cat posts/{slug}.md</span>
+      </div>
+      <p className='th-out'>
+        <span className='th-nf-big'>
+          cat: posts/{slug}.md: Permission denied
+        </span>
+      </p>
+      <p className='th-out th-comment'>
+        # 这篇文章是密码保护的。输入单文密码后 24 小时内免密阅读。
+      </p>
+      <form method='post' className='mt-4'>
+        <div className='th-field'>
+          <label htmlFor='password'>password for this post</label>
+          <input
+            id='password'
+            name='password'
+            type='password'
+            required
+            className='th-input'
+          />
+        </div>
+        <div className='mt-5 flex flex-wrap items-center gap-3'>
+          <button type='submit' className='th-btn th-btn-primary'>
+            sudo unlock
+          </button>
+          <Link to='/blog/$slug' params={{ slug }} className='th-cd'>
+            ← 返回文章
+          </Link>
+        </div>
+        {errorLabel ? <p className='th-err'>{errorLabel}</p> : null}
+      </form>
+    </div>
+  );
+}

--- a/apps/web/src/skins/terminal/blog-list.tsx
+++ b/apps/web/src/skins/terminal/blog-list.tsx
@@ -1,0 +1,156 @@
+import type { PostSummary } from '@blog/shared';
+import { Link } from '@tanstack/react-router';
+
+export type BlogListData = {
+  posts: PostSummary[];
+  total: number;
+  page: number;
+  totalPages: number;
+};
+
+function groupByYear(
+  posts: PostSummary[],
+): { year: string; blogs: PostSummary[] }[] {
+  const groups = new Map<string, PostSummary[]>();
+  for (const post of posts) {
+    const year = new Date(post.publishedAt).getFullYear().toString();
+    const existing = groups.get(year);
+    if (existing) {
+      existing.push(post);
+    } else {
+      groups.set(year, [post]);
+    }
+  }
+  return [...groups.entries()]
+    .sort((a, b) => Number(b[0]) - Number(a[0]))
+    .map(([year, blogs]) => ({
+      year,
+      blogs: [...blogs].sort((a, b) =>
+        b.publishedAt.localeCompare(a.publishedAt),
+      ),
+    }));
+}
+
+const PERM_CLASS: Record<PostSummary['visibility'], string> = {
+  public: 'th-perm th-perm-pub',
+  member: 'th-perm th-perm-mem',
+  vip: 'th-perm th-perm-vip',
+  admin: 'th-perm th-perm-adm',
+  password: 'th-perm th-perm-pw',
+};
+const PERM_BITS: Record<PostSummary['visibility'], string> = {
+  public: '-r--r--r--',
+  member: '-r--r-----',
+  vip: '-r----r--',
+  admin: '-r--------',
+  password: '-r--------',
+};
+
+export function TerminalBlogList({
+  data,
+  showDevHint,
+  devScopeHint,
+}: {
+  data: BlogListData;
+  showDevHint: boolean;
+  devScopeHint: string;
+}) {
+  const blogGroups = groupByYear(data.posts);
+
+  return (
+    <div className='th-page'>
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>perfectpan</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>blog</span>{' '}
+        <span className='th-prompt-p'>~/posts %</span>{' '}
+        <span className='th-cmd'>ls -la --group-directories-first</span>
+      </div>
+
+      {showDevHint ? (
+        <div className='th-devhint mt-4'>{devScopeHint}</div>
+      ) : null}
+
+      <div className='th-ls'>
+        <div className='th-ls-row th-ls-head'>
+          <span>perms</span>
+          <span>date</span>
+          <span>vis</span>
+          <span>title</span>
+          <span className='text-right'>tags</span>
+        </div>
+        {blogGroups.map((group) => (
+          <div key={group.year}>
+            <div className='th-ls-row'>
+              <span className='th-ls-year'>{group.year}</span>
+            </div>
+            {group.blogs.map((blog: PostSummary) => (
+              <Link
+                key={blog.slug}
+                to='/blog/$slug'
+                params={{ slug: blog.slug }}
+                className='th-ls-row'
+              >
+                <span className={PERM_CLASS[blog.visibility]}>
+                  {PERM_BITS[blog.visibility]}
+                </span>
+                <span className='th-ls-date'>
+                  {new Date(blog.publishedAt).toLocaleDateString('en-US', {
+                    month: '2-digit',
+                    day: '2-digit',
+                  })}
+                </span>
+                <span className='th-ls-vis th-comment'>{blog.visibility}</span>
+                <span className='th-ls-title'>{blog.title}</span>
+                <span className='th-ls-tags text-right'>
+                  {blog.tags.join(' · ')}
+                </span>
+              </Link>
+            ))}
+          </div>
+        ))}
+      </div>
+
+      {data.totalPages > 1 ? (
+        <nav className='th-pager' aria-label='Pagination'>
+          {data.page > 1 ? (
+            <Link to='/blog' search={{ page: data.page - 1 }}>
+              ← prev
+            </Link>
+          ) : (
+            <span className='th-pager-off'>← prev</span>
+          )}
+          <span>
+            page {data.page} / {data.totalPages}
+          </span>
+          {data.page < data.totalPages ? (
+            <Link to='/blog' search={{ page: data.page + 1 }}>
+              next →
+            </Link>
+          ) : (
+            <span className='th-pager-off'>next →</span>
+          )}
+        </nav>
+      ) : null}
+
+      <p className='th-legend'>
+        # perms = 可见性：owner / member / guest 读权限
+        <br /># <span className='th-perm-pub'>-r--r--r--</span> 公开 ·{' '}
+        <span className='th-perm-mem'>-r--r-----</span> 登录可见 ·{' '}
+        <span className='th-perm-vip'>-r----r--</span> VIP ·{' '}
+        <span className='th-perm-pw'>-r--------</span> 需密码
+      </p>
+
+      <hr className='th-hr' />
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>perfectpan</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>blog</span>{' '}
+        <span className='th-prompt-p'>~/posts %</span>{' '}
+        <Link to='/' className='th-cmd th-cmd-dim'>
+          cd ..
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/skins/terminal/comments.tsx
+++ b/apps/web/src/skins/terminal/comments.tsx
@@ -3,12 +3,12 @@
 import type { Comment, CommentThread, SessionUser } from '@blog/shared';
 import { Link } from '@tanstack/react-router';
 import { useState } from 'react';
+import { CommentMarkdown } from '../../components/comment-markdown.js';
 import {
   createCommentServerFn,
   deleteCommentServerFn,
   getCommentsServerFn,
-} from '../lib/comments-service.js';
-import { CommentMarkdown } from './comment-markdown.js';
+} from '../../lib/comments-service.js';
 
 type CommentsProps = {
   slug: string;
@@ -244,7 +244,7 @@ function CommentView({
   );
 }
 
-export function Comments({
+export function TerminalComments({
   slug,
   initialComments,
   initialHasMore,

--- a/apps/web/src/skins/terminal/footer.tsx
+++ b/apps/web/src/skins/terminal/footer.tsx
@@ -1,12 +1,12 @@
 import { Link } from '@tanstack/react-router';
-import { authClient } from '../lib/auth-client.js';
+import { authClient } from '../../lib/auth-client.js';
 
 /**
  * tmux-style status bar: session name + clickable windows on the left, site
  * info on the right. Doubles as secondary navigation (the active window is
  * highlighted by the current route).
  */
-export function Footer() {
+export function TerminalFooter() {
   const { data: sessionData } = authClient.useSession();
   const isAdmin = sessionData?.user?.role === 'admin';
 

--- a/apps/web/src/skins/terminal/header.tsx
+++ b/apps/web/src/skins/terminal/header.tsx
@@ -1,8 +1,8 @@
 import { Link } from '@tanstack/react-router';
 import { Github, LogOut, Rss, Search, UserRound } from 'lucide-react';
-import { authClient } from '../lib/auth-client.js';
-import { DarkMode } from './dark-mode.js';
-import { searchPalette } from './search-palette-store.js';
+import { DarkMode } from '../../components/dark-mode.js';
+import { searchPalette } from '../../components/search-palette-store.js';
+import { authClient } from '../../lib/auth-client.js';
 
 function getRoleLabel(role?: string | null): string {
   if (role === 'admin') {
@@ -16,8 +16,11 @@ function getRoleLabel(role?: string | null): string {
   return 'MEMBER';
 }
 
+import { BookOpen } from 'lucide-react';
+import { useSkin } from '../context.js';
+
 /** Terminal title bar: window dots + session name + right-aligned tools. */
-export function Header() {
+export function TerminalHeader() {
   const { data: sessionData } = authClient.useSession();
   const sessionUser = sessionData?.user ?? null;
 
@@ -61,6 +64,7 @@ export function Header() {
             </Link>
           </>
         )}
+        <SkinSwitch />
         <DarkMode />
         <button
           type='button'
@@ -91,5 +95,20 @@ export function Header() {
         </a>
       </div>
     </header>
+  );
+}
+
+function SkinSwitch() {
+  const { setSkin } = useSkin();
+  return (
+    <button
+      type='button'
+      className='th-tool-btn'
+      aria-label='Switch to journal theme'
+      onClick={() => setSkin('journal')}
+    >
+      <BookOpen size={15} aria-hidden='true' />
+      <span className='hidden sm:inline'>journal</span>
+    </button>
   );
 }

--- a/apps/web/src/skins/terminal/home.tsx
+++ b/apps/web/src/skins/terminal/home.tsx
@@ -1,0 +1,52 @@
+import { Link } from '@tanstack/react-router';
+
+const FIGLET = `  ____              _   _        _   ____  __  __ ____
+ |  _ \\ _   _  __ _| |_| |__    / \\ |  _ \\|  \\/  |  _ \\
+ | |_) | | | |/ _\` | __| '_ \\  / _ \\| |_) | |\\/| | |_) |
+ |  __/| |_| | (_| | |_| | | |/ ___ \\  __/| |  | |  __/
+ |_|    \\__,_|\\__,_|\\__|_| |_/_/   \\_\\_|  |_|  |_|_|   `;
+
+export function TerminalHomePage() {
+  return (
+    <div className='th-page'>
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>perfectpan</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>blog</span>{' '}
+        <span className='th-prompt-p'>~ %</span>{' '}
+        <span className='th-cmd'>whoami --verbose</span>
+      </div>
+      <div className='th-out'>
+        <div className='th-hero-name'>PerfectPan</div>
+        <p className='th-hero-desc'>
+          写代码的人。算法竞赛退役选手，现在的兴趣在前端工程、类型体操和把东西跑在
+          Cloudflare 免费额度上。
+        </p>
+        <pre className='th-figlet' aria-hidden='true'>
+          {FIGLET}
+          <b>.dev</b>
+        </pre>
+      </div>
+      <div className='th-prompt mt-6'>
+        <span className='th-prompt-u'>perfectpan</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>blog</span>{' '}
+        <span className='th-prompt-p'>~ %</span>{' '}
+        <span className='th-cmd'>cat motd.txt</span>
+      </div>
+      <p className='th-out th-comment'>
+        # 是个什么都不会的废物.jpg —— 但还在写。
+      </p>
+      <div className='th-home-links'>
+        <Link to='/blog'>
+          <span className='k'>open blog/</span>
+          <small>算法 / TypeScript / 随笔</small>
+        </Link>
+        <Link to='/projects'>
+          <span className='k'>open projects/</span>
+          <small>Rust / TS / Moonbit 开源项目</small>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/skins/terminal/misc.tsx
+++ b/apps/web/src/skins/terminal/misc.tsx
@@ -1,0 +1,45 @@
+import { Link } from '@tanstack/react-router';
+
+export function TerminalNotFound() {
+  return (
+    <div className='th-page'>
+      <div className='nf'>
+        <div className='th-prompt'>
+          <span className='th-prompt-u'>guest</span>
+          <span className='th-prompt-at'>@</span>
+          <span className='th-prompt-h'>perfectpan.org</span>{' '}
+          <span className='th-prompt-p'>~ %</span>{' '}
+          <span className='th-cmd'>cd /nowhere</span>
+        </div>
+        <p className='th-out th-nf-big'>
+          bash: cd: /nowhere: No such file or directory
+        </p>
+        <p className='th-out th-comment'># 你闯入了无人之境。</p>
+        <p className='th-out mt-4'>
+          <Link to='/blog' className='th-cd'>
+            cd ~/blog
+          </Link>
+          <span className='th-comment'> ← 回到博客列表</span>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function TerminalError({ error }: { error: unknown }) {
+  return (
+    <div className='th-page'>
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>guest</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>perfectpan.org</span>{' '}
+        <span className='th-prompt-p'>~ %</span>{' '}
+        <span className='th-cmd'>curl -I $(hostname)</span>
+      </div>
+      <p className='th-out th-nf-big'>Request failed: {String(error)}</p>
+      <Link to='/blog' className='th-cd'>
+        cd ~/blog
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/skins/terminal/projects.tsx
+++ b/apps/web/src/skins/terminal/projects.tsx
@@ -1,0 +1,73 @@
+import { Link } from '@tanstack/react-router';
+import { PROJECTS, type Project } from '../../lib/projects.js';
+
+function sortProjects(projects: Project[]): Project[] {
+  return [...projects].sort((a, b) => {
+    if (Boolean(a.featured) === Boolean(b.featured)) {
+      return a.name.localeCompare(b.name);
+    }
+    return a.featured ? -1 : 1;
+  });
+}
+
+export function TerminalProjectsPage() {
+  const projects = sortProjects(PROJECTS);
+
+  return (
+    <div className='th-page'>
+      <div className='th-prompt'>
+        <span className='th-prompt-u'>perfectpan</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>blog</span>{' '}
+        <span className='th-prompt-p'>~ %</span>{' '}
+        <span className='th-cmd'>ls -la ~/projects</span>
+      </div>
+
+      <div className='th-ls mt-3'>
+        <div className='th-ls-proj th-ls-proj-head'>
+          <span>star</span>
+          <span>project</span>
+          <span className='text-right'>stack</span>
+          <span>link</span>
+        </div>
+        {projects.map((project) => (
+          <div key={project.name} className='th-ls-proj'>
+            <span className={project.featured ? 'th-perm-pw' : 'th-comment'}>
+              {project.featured ? '★' : ' '}
+            </span>
+            <span>
+              <span className='th-ls-title'>{project.name}</span>
+              <span className='th-comment'> — {project.description}</span>
+            </span>
+            <span className='th-ls-tags text-right'>
+              {project.tags.join(' · ')}
+            </span>
+            <span className='th-ls-link'>
+              <a href={project.repo} target='_blank' rel='noreferrer'>
+                code ↗
+              </a>
+              {project.demo ? (
+                <>
+                  {' '}
+                  <a href={project.demo} target='_blank' rel='noreferrer'>
+                    demo ↗
+                  </a>
+                </>
+              ) : null}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <div className='th-prompt mt-6'>
+        <span className='th-prompt-u'>perfectpan</span>
+        <span className='th-prompt-at'>@</span>
+        <span className='th-prompt-h'>blog</span>{' '}
+        <span className='th-prompt-p'>~ %</span>{' '}
+        <Link to='/' className='th-cmd th-cmd-dim'>
+          cd ..
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -939,3 +939,105 @@ html.dark .md pre.th-pre span {
   font-size: 13px;
   margin-bottom: 18px;
 }
+
+/* ---------- terminal search palette (grep) ---------- */
+/* Scoped reskin of the shadcn Dialog + cmdk palette: drop from the top like a
+   terminal window, mono throughout, `~ %` prompt instead of a magnifier. */
+.th-pal {
+  top: 14vh;
+  transform: none;
+  translate: -50% 0;
+  max-width: min(640px, calc(100vw - 32px));
+  border: 1px solid var(--t-line);
+  border-radius: 10px;
+  background: var(--t-term);
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.35);
+  font-family: var(--t-mono);
+}
+.th-pal > button {
+  display: none; /* terminals close with esc, not an ✕ */
+}
+.th-pal-cmd {
+  background: var(--t-term);
+  color: var(--t-text);
+  border-radius: 10px;
+  overflow: hidden;
+}
+.th-pal [cmdk-input-wrapper] {
+  border-bottom: 1px dashed var(--t-line);
+  padding: 13px 16px;
+  gap: 10px;
+}
+.th-pal [cmdk-input-wrapper] svg {
+  display: none;
+}
+.th-pal [cmdk-input-wrapper]::before {
+  content: "~ %";
+  color: var(--t-amber);
+  font-family: var(--t-mono);
+  font-size: 15px;
+  flex: none;
+}
+.th-pal [cmdk-input] {
+  height: auto;
+  font-family: var(--t-mono);
+  font-size: 15px;
+  color: var(--t-text);
+  caret-color: var(--t-amber);
+  padding: 0;
+}
+.th-pal [cmdk-input]::placeholder {
+  color: var(--t-faint);
+}
+.th-pal [cmdk-list] {
+  height: auto;
+  max-height: 320px;
+  padding: 6px 0;
+}
+.th-pal [cmdk-empty] {
+  padding: 18px 16px;
+  text-align: left;
+  color: var(--t-faint);
+  font-size: 13px;
+}
+.th-pal [cmdk-group] {
+  padding: 0 8px;
+}
+.th-pal [cmdk-item] {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  padding: 8px 10px;
+  border-radius: 4px;
+  font-family: var(--t-mono);
+  font-size: 14px;
+  color: var(--t-text);
+}
+.th-pal-date {
+  color: var(--t-faint);
+  font-size: 11.5px;
+  min-width: 6ch;
+}
+.th-pal-title {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.th-pal-vis {
+  color: var(--t-dim);
+  font-size: 11px;
+}
+.th-pal [cmdk-item][aria-selected="true"] {
+  background: var(--t-sel);
+  color: var(--t-text);
+}
+.th-pal [cmdk-item][aria-selected="true"] .th-pal-title {
+  color: var(--t-amber);
+}
+.th-pal-foot {
+  border-top: 1px solid var(--t-line);
+  padding: 7px 16px;
+  color: var(--t-faint);
+  font-size: 11.5px;
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -149,12 +149,59 @@ html.dark ::-webkit-scrollbar-thumb:hover {
  * THEME A — Terminal Session (UX redesign direction A)
  * The site is one persistent terminal session: title bar header, tmux
  * status bar footer, `ls -la` post list with permission bits encoding
- * visibility. Dark-native: html renders with .dark by default (root.tsx)
- * so existing dark: variants and shiki dual-themes stay coherent.
+ * visibility. Dual theme: LIGHT paper-terminal by default, dark via the
+ * header toggle (html.dark).
  * =================================================================== */
-:root,
-.dark {
-  /* shadcn token layer → terminal palette (search palette & dialogs) */
+:root {
+  /* shadcn token layer → terminal LIGHT palette (search palette & dialogs) */
+  --background: 45 25% 95%;
+  --foreground: 215 15% 22%;
+  --card: 45 30% 97%;
+  --card-foreground: 215 15% 22%;
+  --popover: 45 30% 98%;
+  --popover-foreground: 215 15% 22%;
+  --primary: 39 62% 42%;
+  --primary-foreground: 45 30% 97%;
+  --secondary: 45 20% 91%;
+  --secondary-foreground: 215 15% 22%;
+  --muted: 45 20% 91%;
+  --muted-foreground: 215 8% 42%;
+  --accent: 45 20% 88%;
+  --accent-foreground: 215 15% 22%;
+  --destructive: 2 56% 48%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 43 16% 82%;
+  --input: 43 16% 82%;
+  --ring: 39 62% 42%;
+  --radius: 0.375rem;
+
+  /* terminal LIGHT (paper terminal): default */
+  --t-bg: #f4f2ec;
+  --t-term: #fbfaf7;
+  --t-panel: #f0ede5;
+  --t-line: #ddd8cb;
+  --t-text: #33363b;
+  --t-dim: #6f7480;
+  --t-faint: #a6a49a;
+  --t-amber: #a8752b;
+  --t-cyan: #0e7d92;
+  --t-green: #3c7a52;
+  --t-red: #b8483f;
+  --t-violet: #7a5fa8;
+  --t-sel: #ece7da;
+  --t-titlebar-a: #f7f5ef;
+  --t-titlebar-b: #f4f2ec;
+  --t-tmux-bg: #eeebe2;
+  --t-tmux-ink: #33363b;
+  --t-pre-bg: #fbfaf7;
+  --t-amber-ink: #fbfaf7;
+  --t-mono:
+    ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo, Consolas,
+    "PingFang SC", "Microsoft YaHei", monospace;
+}
+
+html.dark {
+  /* shadcn token layer → terminal DARK palette */
   --background: 210 29% 7%;
   --foreground: 210 20% 83%;
   --card: 211 30% 10%;
@@ -174,10 +221,8 @@ html.dark ::-webkit-scrollbar-thumb:hover {
   --border: 211 26% 17%;
   --input: 211 26% 17%;
   --ring: 39 77% 60%;
-  --radius: 0.375rem;
-}
 
-:root {
+  /* terminal DARK (original) */
   --t-bg: #0a0f14;
   --t-term: #0c1218;
   --t-panel: #101923;
@@ -191,15 +236,17 @@ html.dark ::-webkit-scrollbar-thumb:hover {
   --t-red: #e06c75;
   --t-violet: #a78bc4;
   --t-sel: #16222e;
-  --t-mono:
-    ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo, Consolas,
-    "PingFang SC", "Microsoft YaHei", monospace;
+  --t-titlebar-a: #0e1620;
+  --t-titlebar-b: #0c1218;
+  --t-tmux-bg: #10161d;
+  --t-tmux-ink: #0a0f14;
+  --t-pre-bg: #0a1016;
+  --t-amber-ink: #171106;
 }
 
-html,
-html.dark {
+html {
   background-color: var(--t-bg);
-  scrollbar-color: #24313e var(--t-bg);
+  scrollbar-color: var(--t-line) var(--t-bg);
 }
 
 html body {
@@ -227,7 +274,7 @@ html body {
   gap: 8px;
   padding: 10px 18px;
   border-bottom: 1px solid var(--t-line);
-  background: linear-gradient(#0e1620, #0c1218);
+  background: linear-gradient(var(--t-titlebar-a), var(--t-titlebar-b));
 }
 
 .th-dot {
@@ -283,7 +330,7 @@ html body {
   font-size: 12.5px;
 }
 .th-tmux-sess {
-  color: #0a0f14;
+  color: var(--t-tmux-ink);
   background: var(--t-green);
   padding: 1px 8px;
   border-radius: 3px;
@@ -388,7 +435,7 @@ a.th-tmux-win:hover {
 }
 .th-role-badge {
   background: var(--t-amber);
-  color: #171106;
+  color: var(--t-amber-ink);
   border-radius: 999px;
   font-size: 10px;
   font-weight: 700;
@@ -740,7 +787,7 @@ a.th-ls-row:hover {
   align-items: center;
   gap: 4px;
   border: 1px solid var(--t-line);
-  background: rgba(16, 25, 35, 0.85);
+  background: var(--t-panel);
   color: var(--t-dim);
   border-radius: 4px;
   padding: 2px 8px;
@@ -769,15 +816,18 @@ a.th-ls-row:hover {
   font-size: 13px;
   margin: 0;
 }
-/* shiki writes inline light bg/color on <pre>; force the terminal panel. */
+/* shiki writes inline light bg on <pre>; force the themed panel (light keeps
+   the vitesse-light tokens, dark swaps to vitesse-dark via the span rule). */
 .md pre.th-pre {
   /* biome-ignore lint/complexity/noImportantStyles: shiki inline light bg must be overridden. */
-  background: #0a1016 !important;
-  /* biome-ignore lint/complexity/noImportantStyles: shiki inline light color must be overridden. */
+  background: var(--t-pre-bg) !important;
+}
+html.dark .md pre.th-pre {
+  /* biome-ignore lint/complexity/noImportantStyles: shiki inline light color must be overridden in dark mode. */
   color: var(--t-text) !important;
 }
-.md pre.th-pre span {
-  /* biome-ignore lint/complexity/noImportantStyles: force shiki dark tokens without html.dark (SSR-safe). */
+html.dark .md pre.th-pre span {
+  /* biome-ignore lint/complexity/noImportantStyles: force shiki dark tokens in dark mode (SSR-safe). */
   color: var(--shiki-dark) !important;
 }
 .md .th-pre code {
@@ -839,7 +889,7 @@ a.th-ls-row:hover {
 }
 .th-cmt-replies {
   border-top: 1px dashed var(--t-line);
-  background: rgba(16, 25, 35, 0.45);
+  background: var(--t-sel);
   padding: 10px 14px;
   display: flex;
   flex-direction: column;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -194,6 +194,7 @@ html.dark ::-webkit-scrollbar-thumb:hover {
   --t-tmux-bg: #eeebe2;
   --t-tmux-ink: #33363b;
   --t-pre-bg: #fbfaf7;
+  --t-heading: #2b2f36;
   --t-amber-ink: #fbfaf7;
   --t-mono:
     ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo, Consolas,
@@ -241,6 +242,7 @@ html.dark {
   --t-tmux-bg: #10161d;
   --t-tmux-ink: #0a0f14;
   --t-pre-bg: #0a1016;
+  --t-heading: #eaf1f7;
   --t-amber-ink: #171106;
 }
 
@@ -326,7 +328,7 @@ html body {
   flex-wrap: wrap;
   padding: 6px 14px;
   border-top: 1px solid var(--t-line);
-  background: #10161d;
+  background: var(--t-tmux-bg);
   font-size: 12.5px;
 }
 .th-tmux-sess {
@@ -515,7 +517,7 @@ a.th-tmux-win:hover {
 /* ---------- home ---------- */
 .th-hero-name {
   font-size: 21px;
-  color: #eaf1f7;
+  color: var(--t-heading);
   font-weight: 700;
   margin-top: 12px;
 }
@@ -698,7 +700,7 @@ a.th-ls-row:hover {
 }
 .th-art-title {
   font-size: 24px;
-  color: #eaf1f7;
+  color: var(--t-heading);
   font-weight: 700;
   line-height: 1.4;
 }
@@ -721,7 +723,7 @@ a.th-ls-row:hover {
 }
 .md h2 {
   font-size: 17px;
-  color: #eaf1f7;
+  color: var(--t-heading);
   font-weight: 700;
   margin: 30px 0 10px;
   scroll-margin-top: 20px;
@@ -807,7 +809,7 @@ a.th-ls-row:hover {
   }
 }
 .md pre.th-pre {
-  background: #0a1016;
+  background: var(--t-pre-bg);
   border: 1px solid var(--t-line);
   border-radius: 8px;
   padding: 18px;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -152,7 +152,7 @@ html.dark ::-webkit-scrollbar-thumb:hover {
  * visibility. Dual theme: LIGHT paper-terminal by default, dark via the
  * header toggle (html.dark).
  * =================================================================== */
-:root {
+html[data-theme="terminal"] {
   /* shadcn token layer → terminal LIGHT palette (search palette & dialogs) */
   --background: 45 25% 95%;
   --foreground: 215 15% 22%;
@@ -201,7 +201,7 @@ html.dark ::-webkit-scrollbar-thumb:hover {
     "PingFang SC", "Microsoft YaHei", monospace;
 }
 
-html.dark {
+html[data-theme="terminal"].dark {
   /* shadcn token layer → terminal DARK palette */
   --background: 210 29% 7%;
   --foreground: 210 20% 83%;
@@ -246,12 +246,7 @@ html.dark {
   --t-amber-ink: #171106;
 }
 
-html {
-  background-color: var(--t-bg);
-  scrollbar-color: var(--t-line) var(--t-bg);
-}
-
-html body {
+html[data-theme="terminal"] body {
   font-family: var(--t-mono);
   background-color: var(--t-bg);
   color: var(--t-text);
@@ -259,7 +254,7 @@ html body {
   line-height: 1.75;
 }
 
-::selection {
+html[data-theme="terminal"] ::selection {
   background: rgba(233, 180, 76, 0.25);
 }
 
@@ -714,14 +709,14 @@ a.th-ls-row:hover {
 }
 
 /* markdown body (article prose) */
-.md {
+html[data-theme="terminal"] .md {
   max-width: 74ch;
 }
-.md p {
+html[data-theme="terminal"] .md p {
   margin: 14px 0;
   color: var(--t-text);
 }
-.md h2 {
+html[data-theme="terminal"] .md h2 {
   font-size: 17px;
   color: var(--t-heading);
   font-weight: 700;
@@ -736,23 +731,23 @@ a.th-ls-row:hover {
 .md h2 a {
   color: inherit;
 }
-.md ul {
+html[data-theme="terminal"] .md ul {
   margin: 12px 0 12px 22px;
   list-style: disc;
 }
-.md li {
+html[data-theme="terminal"] .md li {
   margin: 4px 0;
 }
-.md li::marker {
+html[data-theme="terminal"] .md li::marker {
   color: var(--t-amber);
 }
-.md a {
+html[data-theme="terminal"] .md a {
   color: var(--t-cyan);
 }
 .md a:hover {
   text-decoration: underline;
 }
-.md blockquote {
+html[data-theme="terminal"] .md blockquote {
   border-left: 2px solid var(--t-amber);
   background: var(--t-panel);
   padding: 10px 16px;
@@ -768,7 +763,7 @@ a.th-ls-row:hover {
   font-size: 0.9em;
   color: var(--t-amber);
 }
-.md code.md-inline {
+html[data-theme="terminal"] .md code.md-inline {
   background: var(--t-panel);
   border: 1px solid var(--t-line);
   padding: 1px 6px;
@@ -808,7 +803,7 @@ a.th-ls-row:hover {
     opacity: 0.75;
   }
 }
-.md pre.th-pre {
+html[data-theme="terminal"] .md pre.th-pre {
   background: var(--t-pre-bg);
   border: 1px solid var(--t-line);
   border-radius: 8px;
@@ -820,19 +815,19 @@ a.th-ls-row:hover {
 }
 /* shiki writes inline light bg on <pre>; force the themed panel (light keeps
    the vitesse-light tokens, dark swaps to vitesse-dark via the span rule). */
-.md pre.th-pre {
+html[data-theme="terminal"] .md pre.th-pre {
   /* biome-ignore lint/complexity/noImportantStyles: shiki inline light bg must be overridden. */
   background: var(--t-pre-bg) !important;
 }
-html.dark .md pre.th-pre {
+html[data-theme="terminal"].dark .md pre.th-pre {
   /* biome-ignore lint/complexity/noImportantStyles: shiki inline light color must be overridden in dark mode. */
   color: var(--t-text) !important;
 }
-html.dark .md pre.th-pre span {
+html[data-theme="terminal"].dark .md pre.th-pre span {
   /* biome-ignore lint/complexity/noImportantStyles: force shiki dark tokens in dark mode (SSR-safe). */
   color: var(--shiki-dark) !important;
 }
-.md .th-pre code {
+html[data-theme="terminal"] .md .th-pre code {
   background: none;
   padding: 0;
 }
@@ -860,13 +855,13 @@ html.dark .md pre.th-pre span {
 .th-cmt-body {
   padding: 10px 14px;
 }
-.th-cmt-body p {
+.th-cmt-body :where(p) {
   margin: 0 0 8px;
 }
 .th-cmt-body p:last-child {
   margin-bottom: 0;
 }
-.th-cmt-body blockquote {
+.th-cmt-body :where(blockquote) {
   border-left: 2px solid var(--t-line);
   padding-left: 12px;
   color: var(--t-dim);
@@ -1042,4 +1037,928 @@ html.dark .md pre.th-pre span {
   padding: 7px 16px;
   color: var(--t-faint);
   font-size: 11.5px;
+}
+
+/* =====================================================================
+ * THEME B — Literary Journal 《废墨集》 (UX redesign direction B)
+ * Paper-native Chinese literary journal: serif display, seal red,
+ * vertical spine label, TOC dot leaders, drop caps. Light-only.
+ * =================================================================== */
+html[data-theme="journal"] {
+  /* shadcn token layer → paper palette (search palette & dialogs) */
+  --background: 45 30% 94%;
+  --foreground: 30 6% 14%;
+  --card: 45 27% 96%;
+  --card-foreground: 30 6% 14%;
+  --popover: 45 27% 96%;
+  --popover-foreground: 30 6% 14%;
+  --primary: 8 58% 42%;
+  --primary-foreground: 40 33% 94%;
+  --secondary: 45 22% 90%;
+  --secondary-foreground: 30 6% 14%;
+  --muted: 45 22% 90%;
+  --muted-foreground: 40 8% 42%;
+  --accent: 45 22% 88%;
+  --accent-foreground: 30 6% 14%;
+  --destructive: 8 58% 42%;
+  --destructive-foreground: 40 33% 94%;
+  --border: 44 18% 80%;
+  --input: 44 18% 80%;
+  --ring: 8 58% 42%;
+  --radius: 0.125rem;
+
+  --j-paper: #f6f3ec;
+  --j-paper2: #efeae0;
+  --j-ink: #262523;
+  --j-faded: #6e6a60;
+  --j-faint: #a29c8e;
+  --j-red: #a63a2b;
+  --j-indigo: #2e4a68;
+  --j-rule: #dad4c6;
+  --j-serif:
+    "Songti SC", "Noto Serif SC", "Source Han Serif SC", "SimSun", serif;
+  --j-sans:
+    "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", system-ui, sans-serif;
+  --j-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}
+
+html {
+  background-color: var(--j-paper);
+  scrollbar-color: #cfc8b8 var(--j-paper);
+}
+
+html[data-theme="journal"] body {
+  font-family: var(--j-serif);
+  background-color: var(--j-paper);
+  color: var(--j-ink);
+  font-size: 16.5px;
+  line-height: 2;
+}
+
+html[data-theme="journal"] ::selection {
+  background: rgba(166, 58, 43, 0.16);
+}
+
+/* ---------- masthead ---------- */
+.j-masthead {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 30px 24px 0;
+  display: flex;
+  align-items: flex-end;
+  gap: 24px;
+}
+.j-brand {
+  font-size: 30px;
+  font-weight: 900;
+  letter-spacing: 0.22em;
+  white-space: nowrap;
+}
+.j-brand a {
+  color: var(--j-ink);
+}
+.j-brand a:hover {
+  color: var(--j-ink);
+  text-decoration: none;
+}
+.j-brand .j-dot {
+  color: var(--j-red);
+}
+.j-masthead nav {
+  display: flex;
+  gap: 26px;
+  font-family: var(--j-sans);
+  font-size: 13.5px;
+  letter-spacing: 0.28em;
+  margin-left: auto;
+}
+.j-masthead nav a,
+.j-masthead nav button {
+  color: var(--j-faded);
+  font-family: var(--j-sans);
+  font-size: 13.5px;
+  letter-spacing: 0.28em;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  padding: 0;
+}
+.j-masthead nav a:hover,
+.j-masthead nav button:hover {
+  color: var(--j-red);
+  text-decoration: none;
+}
+.j-headrule {
+  max-width: 1120px;
+  margin: 14px auto 0;
+  padding: 0 24px;
+}
+.j-headrule hr {
+  border: 0;
+  border-top: 2.5px solid var(--j-ink);
+  position: relative;
+}
+.j-headrule hr::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 3px;
+  border-top: 1px solid var(--j-ink);
+}
+
+/* ---------- shell ---------- */
+.j-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+}
+.j-main {
+  flex: 1;
+  overflow-y: auto;
+}
+.j-sheet {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 40px 24px 60px;
+  position: relative;
+}
+.j-colophon {
+  border-top: 2.5px solid var(--j-ink);
+  position: relative;
+  margin: 48px auto 0;
+  max-width: 1120px;
+  padding: 18px 24px 26px;
+  text-align: center;
+  font-family: var(--j-sans);
+  font-size: 12px;
+  color: var(--j-faint);
+  letter-spacing: 0.2em;
+}
+.j-colophon::before {
+  content: "";
+  position: absolute;
+  left: 24px;
+  right: 24px;
+  top: 3px;
+  border-top: 1px solid var(--j-ink);
+}
+.j-colophon a {
+  color: var(--j-indigo);
+}
+
+/* ---------- seal & notes ---------- */
+.j-seal {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 46px;
+  height: 46px;
+  background: var(--j-red);
+  color: #f8f4ea;
+  font-size: 24px;
+  font-weight: 900;
+  border-radius: 7px;
+  box-shadow:
+    inset 0 0 0 2px rgba(248, 244, 234, 0.55),
+    inset 0 0 0 4px var(--j-red);
+  transform: rotate(-4deg);
+}
+.j-note {
+  font-family: var(--j-sans);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  color: var(--j-faded);
+  border: 1px solid var(--j-rule);
+  border-radius: 2px;
+  padding: 0 6px;
+  margin-left: 10px;
+  white-space: nowrap;
+  vertical-align: 2px;
+}
+.j-note.vip,
+.j-note.mem {
+  color: var(--j-indigo);
+  border-color: #c9d4df;
+}
+.j-note.pw {
+  color: var(--j-red);
+  border-color: #dfc0ba;
+}
+.j-note.adm {
+  color: var(--j-faded);
+}
+
+/* ---------- home: wide two-column ---------- */
+.j-home {
+  display: grid;
+  grid-template-columns: 1.15fr 1fr;
+  gap: 56px;
+  align-items: start;
+  padding-top: 44px;
+}
+.j-home h1 {
+  font-family: var(--j-serif);
+  font-size: clamp(30px, 3.4vw, 44px);
+  font-weight: 900;
+  line-height: 1.55;
+  letter-spacing: 0.04em;
+}
+.j-tagline {
+  font-size: 17px;
+  line-height: 2.05;
+  max-width: 40ch;
+}
+.j-facts {
+  margin-top: 24px;
+  font-family: var(--j-sans);
+  font-size: 13px;
+  color: var(--j-faded);
+  display: flex;
+  gap: 22px;
+  flex-wrap: wrap;
+  letter-spacing: 0.1em;
+}
+.j-facts b {
+  color: var(--j-ink);
+  font-weight: 600;
+}
+.j-home-cta {
+  margin-top: 30px;
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+.j-home-seal {
+  margin-top: 36px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.j-home-seal .sign {
+  font-family: var(--j-sans);
+  font-size: 12px;
+  color: var(--j-faint);
+  letter-spacing: 0.2em;
+  line-height: 1.9;
+}
+.j-home-panel {
+  border: 1px solid var(--j-rule);
+  background: rgba(255, 255, 255, 0.45);
+  padding: 26px 30px 30px;
+}
+.j-latest-item {
+  display: flex;
+  gap: 12px;
+  padding: 9px 0;
+  border-bottom: 1px dotted var(--j-rule);
+  align-items: baseline;
+}
+.j-latest-item:last-child {
+  border-bottom: 0;
+}
+.j-latest-item .t {
+  flex: 1;
+  color: var(--j-ink);
+  font-weight: 600;
+  font-size: 15px;
+}
+.j-latest-item .t:hover {
+  color: var(--j-red);
+  text-decoration: none;
+}
+.j-latest-item .d {
+  font-family: var(--j-mono);
+  font-size: 11.5px;
+  color: var(--j-faint);
+  white-space: nowrap;
+}
+@media (max-width: 860px) {
+  .j-home {
+    grid-template-columns: 1fr;
+    gap: 34px;
+    padding-top: 28px;
+  }
+}
+
+/* ---------- 目次 TOC ---------- */
+.j-entry-title {
+  font-size: 32px;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+}
+.j-entry-meta {
+  font-family: var(--j-sans);
+  font-size: 13px;
+  color: var(--j-indigo);
+  letter-spacing: 0.06em;
+  margin-top: 10px;
+}
+.j-juan {
+  display: flex;
+  align-items: baseline;
+  gap: 18px;
+  margin: 40px 0 8px;
+}
+.j-juan :where(h2) {
+  font-size: 24px;
+  font-weight: 900;
+  letter-spacing: 0.3em;
+}
+.j-juan .sub {
+  font-family: var(--j-sans);
+  font-size: 12px;
+  color: var(--j-faint);
+  letter-spacing: 0.2em;
+}
+.j-juan::after {
+  content: "";
+  flex: 1;
+  border-bottom: 1px solid var(--j-rule);
+  transform: translateY(-6px);
+}
+.j-toc-line {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 8px 0;
+  font-size: 17px;
+}
+.j-toc-line a {
+  display: flex;
+  flex: 1;
+  align-items: baseline;
+  gap: 10px;
+  color: var(--j-ink);
+}
+.j-toc-line a:hover {
+  text-decoration: none;
+}
+.j-toc-line .t {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.j-toc-line a:hover .t {
+  color: var(--j-red);
+}
+.j-toc-line .dots {
+  flex: 1;
+  border-bottom: 2px dotted var(--j-faint);
+  transform: translateY(-5px);
+  min-width: 24px;
+}
+.j-toc-line .n {
+  font-family: var(--j-mono);
+  font-size: 12.5px;
+  color: var(--j-faded);
+  white-space: nowrap;
+}
+.j-pager {
+  display: flex;
+  justify-content: center;
+  gap: 30px;
+  margin-top: 50px;
+  font-family: var(--j-sans);
+  font-size: 13px;
+  letter-spacing: 0.15em;
+  color: var(--j-faded);
+}
+.j-pager a {
+  color: var(--j-red);
+}
+.j-devhint {
+  font-family: var(--j-sans);
+  border: 1px dashed var(--j-rule);
+  background: var(--j-paper2);
+  color: var(--j-faded);
+  border-radius: 3px;
+  padding: 8px 14px;
+  font-size: 13px;
+  margin-bottom: 18px;
+}
+
+/* ---------- 正文 article ---------- */
+.j-article {
+  max-width: 46em;
+  margin: 0 auto;
+}
+.j-running-head {
+  font-family: var(--j-sans);
+  font-size: 11.5px;
+  color: var(--j-faint);
+  letter-spacing: 0.3em;
+  text-align: center;
+  margin-bottom: 26px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--j-rule);
+}
+.j-article .j-entry-title,
+.j-article .j-entry-meta {
+  text-align: center;
+}
+.j-article .j-entry-meta {
+  margin: 14px 0 34px;
+}
+.j-backlink {
+  text-align: center;
+  margin-top: 54px;
+  font-family: var(--j-sans);
+  font-size: 13px;
+  letter-spacing: 0.3em;
+}
+.j-backlink a {
+  color: var(--j-faded);
+}
+.j-backlink a:hover {
+  color: var(--j-red);
+}
+
+html[data-theme="journal"] .md p {
+  margin: 18px 0;
+  text-align: justify;
+}
+.md > p:first-of-type::first-letter,
+.md > p:first-child::first-letter {
+  font-size: 3em;
+  font-weight: 900;
+  float: left;
+  line-height: 1;
+  margin: 8px 12px 0 0;
+  color: var(--j-red);
+}
+html[data-theme="journal"] .md h2 {
+  font-size: 21px;
+  font-weight: 900;
+  margin: 40px 0 14px;
+  letter-spacing: 0.08em;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  scroll-margin-top: 20px;
+}
+html[data-theme="journal"] .md h2::before,
+html[data-theme="journal"] .md h2::after {
+  content: "";
+  height: 1px;
+  background: var(--j-rule);
+  flex: 1;
+}
+.md h2 a {
+  color: inherit;
+}
+html[data-theme="journal"] .md ul {
+  padding-left: 0;
+  list-style: none;
+  margin: 16px 0;
+}
+html[data-theme="journal"] .md ul li {
+  padding-left: 1.6em;
+  position: relative;
+  margin: 8px 0;
+}
+html[data-theme="journal"] .md ul li::before {
+  content: "—";
+  position: absolute;
+  left: 0;
+  color: var(--j-red);
+}
+html[data-theme="journal"] .md a {
+  color: var(--j-indigo);
+}
+.md a:hover {
+  color: var(--j-red);
+}
+html[data-theme="journal"] .md blockquote {
+  margin: 26px 0;
+  padding: 14px 22px;
+  background: var(--j-paper2);
+  border-left: 3px solid var(--j-red);
+  color: var(--j-faded);
+  font-size: 15.5px;
+}
+html[data-theme="journal"] .md :where(code.j-inline) {
+  font-family: var(--j-mono);
+  font-size: 0.84em;
+  background: var(--j-paper2);
+  border: 1px solid var(--j-rule);
+  border-radius: 2px;
+  padding: 1px 6px;
+  color: var(--j-red);
+}
+
+/* code panel: ink-dark paper (force shiki dark palette without html.dark) */
+.j-code {
+  position: relative;
+  margin: 24px 0;
+}
+.j-code-copy {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  z-index: 10;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid #4a463e;
+  background: rgba(43, 41, 38, 0.9);
+  color: #b5ae9f;
+  border-radius: 3px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-family: var(--j-mono);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.j-code:hover .j-code-copy,
+.j-code-copy:focus-visible {
+  opacity: 1;
+}
+@media not (hover: hover) {
+  .j-code-copy {
+    opacity: 0.75;
+  }
+}
+html[data-theme="journal"] .md pre.j-pre {
+  font-family: var(--j-mono);
+  font-size: 13px;
+  line-height: 1.8;
+  background: #2b2926;
+  color: #e8e2d5;
+  border-radius: 4px;
+  padding: 20px 22px;
+  overflow-x: auto;
+  margin: 0;
+}
+html[data-theme="journal"] .md pre.j-pre {
+  /* biome-ignore lint/complexity/noImportantStyles: shiki writes an inline light bg; the journal uses an ink panel. */
+  background: #2b2926 !important;
+}
+html[data-theme="journal"] .md pre.j-pre span {
+  /* biome-ignore lint/complexity/noImportantStyles: force shiki dark tokens without html.dark. */
+  color: var(--shiki-dark) !important;
+}
+html[data-theme="journal"] .md .j-pre code {
+  background: none;
+  padding: 0;
+}
+
+/* ---------- 读者来函 comments ---------- */
+.j-letters {
+  max-width: 46em;
+  margin: 60px auto 0;
+}
+.j-letter {
+  border: 1px solid var(--j-rule);
+  border-radius: 3px;
+  padding: 18px 22px;
+  margin: 14px 0;
+  background: rgba(255, 255, 255, 0.45);
+}
+.j-letter-reply {
+  margin-left: 44px;
+  background: var(--j-paper2);
+}
+.j-lhead {
+  font-family: var(--j-sans);
+  font-size: 12.5px;
+  color: var(--j-indigo);
+  letter-spacing: 0.08em;
+  margin-bottom: 6px;
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+.j-lhead .who {
+  color: var(--j-ink);
+  font-weight: 600;
+}
+.j-lhead .when {
+  color: var(--j-faint);
+}
+.j-lhead .badge {
+  background: var(--j-red);
+  color: #f6f3ec;
+  font-size: 10px;
+  border-radius: 2px;
+  padding: 0 6px;
+  letter-spacing: 0.12em;
+}
+.j-lbody :where(p) {
+  font-size: 15.5px;
+  line-height: 1.95;
+  margin: 0 0 6px;
+}
+.j-lbody p:last-child {
+  margin-bottom: 0;
+}
+.j-lbody :where(code) {
+  font-family: var(--j-mono);
+  font-size: 0.85em;
+  background: var(--j-paper2);
+  border: 1px solid var(--j-rule);
+  border-radius: 2px;
+  padding: 0 5px;
+  color: var(--j-red);
+}
+.j-lbody :where(blockquote) {
+  border-left: 2px solid var(--j-rule);
+  padding-left: 12px;
+  color: var(--j-faded);
+}
+.j-lops {
+  display: flex;
+  gap: 16px;
+  font-family: var(--j-sans);
+  font-size: 12px;
+  margin-top: 8px;
+}
+.j-lops :where(button) {
+  color: var(--j-faded);
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font-family: var(--j-sans);
+  font-size: 12px;
+  padding: 0;
+  letter-spacing: 0.1em;
+}
+.j-lops :where(button):hover {
+  color: var(--j-red);
+}
+.j-cmt-form textarea {
+  width: 100%;
+  resize: vertical;
+  font-family: var(--j-serif);
+  font-size: 15.5px;
+  color: var(--j-ink);
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid var(--j-rule);
+  border-radius: 3px;
+  padding: 10px 14px;
+}
+.j-cmt-form textarea:focus {
+  outline: none;
+  border-color: var(--j-red);
+  box-shadow: 0 0 0 2px rgba(166, 58, 43, 0.12);
+}
+.j-cmt-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 8px;
+}
+.j-cmt-hint {
+  font-family: var(--j-sans);
+  font-size: 12px;
+  color: var(--j-faint);
+}
+.j-cmt-hint :where(.j-err) {
+  color: var(--j-red);
+  margin-left: 8px;
+}
+.j-err {
+  font-family: var(--j-sans);
+  font-size: 13px;
+  color: var(--j-red);
+}
+
+/* ---------- 器物谱 projects ---------- */
+.j-ware {
+  display: grid;
+  grid-template-columns: 72px 1fr;
+  gap: 0 26px;
+  padding: 26px 0;
+  border-bottom: 1px solid var(--j-rule);
+}
+.j-ware .no {
+  font-size: 26px;
+  font-weight: 900;
+  color: var(--j-faint);
+}
+.j-ware .no small {
+  display: block;
+  font-size: 11px;
+  font-family: var(--j-sans);
+  letter-spacing: 0.2em;
+  margin-top: 4px;
+  color: var(--j-red);
+}
+.j-ware :where(h2) {
+  font-size: 21px;
+  font-weight: 900;
+  letter-spacing: 0.04em;
+}
+.j-ware h2 .feat {
+  color: var(--j-red);
+  font-size: 13px;
+  margin-left: 10px;
+  letter-spacing: 0.2em;
+  font-family: var(--j-sans);
+}
+.j-ware :where(p) {
+  color: var(--j-faded);
+  font-size: 15.5px;
+  margin-top: 6px;
+}
+.j-ware .wlinks {
+  margin-top: 10px;
+  font-family: var(--j-sans);
+  font-size: 13px;
+  display: flex;
+  gap: 20px;
+}
+.j-ware .wlinks a {
+  color: var(--j-indigo);
+  border-bottom: 1px solid #c9d4df;
+}
+.j-ware .tags {
+  margin-top: 8px;
+  font-family: var(--j-sans);
+  font-size: 12px;
+  color: var(--j-faint);
+  letter-spacing: 0.1em;
+}
+@media (max-width: 640px) {
+  .j-ware {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ---------- forms ---------- */
+.j-gate {
+  max-width: 460px;
+  margin: 30px auto 0;
+}
+.j-gate-card {
+  border: 1.5px solid var(--j-ink);
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.5);
+  padding: 38px 40px 40px;
+  position: relative;
+  box-shadow: 6px 6px 0 rgba(38, 37, 35, 0.08);
+}
+.j-gate-card .j-seal {
+  position: absolute;
+  right: 26px;
+  top: -23px;
+}
+.j-gate h1 {
+  font-size: 26px;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+}
+.j-gate .sub {
+  font-family: var(--j-sans);
+  font-size: 13px;
+  color: var(--j-faded);
+  margin: 8px 0 26px;
+  letter-spacing: 0.08em;
+}
+.j-field {
+  margin: 16px 0;
+}
+.j-field label {
+  display: block;
+  font-family: var(--j-sans);
+  font-size: 12.5px;
+  letter-spacing: 0.24em;
+  color: var(--j-faded);
+  margin-bottom: 6px;
+}
+.j-input {
+  width: 100%;
+  font-family: var(--j-serif);
+  font-size: 15.5px;
+  color: var(--j-ink);
+  background: var(--j-paper);
+  border: 1px solid var(--j-rule);
+  border-radius: 2px;
+  padding: 10px 14px;
+}
+.j-input:focus {
+  outline: none;
+  border-color: var(--j-red);
+  box-shadow: 0 0 0 2px rgba(166, 58, 43, 0.12);
+}
+.j-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 26px;
+  flex-wrap: wrap;
+}
+.j-aside {
+  text-align: center;
+  margin-top: 22px;
+  font-family: var(--j-sans);
+  font-size: 13px;
+  color: var(--j-faded);
+}
+.j-aside a {
+  color: var(--j-red);
+}
+.j-lockmark {
+  width: 54px;
+  height: 54px;
+  border: 2px solid var(--j-red);
+  border-radius: 4px;
+  color: var(--j-red);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 26px;
+  font-weight: 900;
+  margin: 0 auto 20px;
+  transform: rotate(3deg);
+}
+
+/* ---------- 404 ---------- */
+.j-nf {
+  text-align: center;
+  padding: 90px 0 40px;
+}
+.j-nf .zh {
+  font-size: 40px;
+  font-weight: 900;
+  letter-spacing: 0.3em;
+}
+.j-nf :where(p) {
+  font-family: var(--j-sans);
+  font-size: 14px;
+  color: var(--j-faded);
+  margin-top: 18px;
+  letter-spacing: 0.15em;
+}
+
+/* journal masthead user chip */
+.j-user-chip {
+  align-items: baseline;
+  gap: 8px;
+  font-family: var(--j-sans);
+  font-size: 12px;
+  color: var(--j-faded);
+  letter-spacing: 0.08em;
+}
+.j-user-role {
+  border: 1px solid var(--j-rule);
+  border-radius: 2px;
+  padding: 0 6px;
+  font-size: 10px;
+  color: var(--j-indigo);
+  letter-spacing: 0.12em;
+}
+
+/* search palette under the journal skin: same grep UX, paper materials
+   (--t-* tokens are undefined in this scope, so values are restated). */
+html[data-theme="journal"] .th-pal {
+  top: 14vh;
+  transform: none;
+  translate: -50% 0;
+  max-width: min(640px, calc(100vw - 32px));
+  border: 1.5px solid var(--j-ink);
+  border-radius: 3px;
+  background: var(--j-paper);
+  box-shadow: 6px 6px 0 rgba(38, 37, 35, 0.12);
+  font-family: var(--j-serif);
+}
+html[data-theme="journal"] .th-pal [cmdk-input-wrapper] {
+  border-bottom: 1px solid var(--j-rule);
+}
+html[data-theme="journal"] .th-pal [cmdk-input-wrapper]::before {
+  color: var(--j-red);
+  font-family: var(--j-serif);
+  font-weight: 600;
+}
+html[data-theme="journal"] .th-pal [cmdk-input] {
+  font-family: var(--j-serif);
+  color: var(--j-ink);
+}
+html[data-theme="journal"] .th-pal [cmdk-input]::placeholder {
+  color: var(--j-faint);
+}
+html[data-theme="journal"] .th-pal [cmdk-item] {
+  font-family: var(--j-serif);
+  color: var(--j-ink);
+}
+html[data-theme="journal"] .th-pal [cmdk-item][aria-selected="true"] {
+  background: var(--j-paper2);
+}
+html[data-theme="journal"]
+  .th-pal
+  [cmdk-item][aria-selected="true"]
+  .th-pal-title {
+  color: var(--j-red);
+}
+html[data-theme="journal"] .th-pal-date,
+html[data-theme="journal"] .th-pal-vis {
+  color: var(--j-faded);
+}
+html[data-theme="journal"] .th-pal-foot {
+  border-top: 1px solid var(--j-rule);
+  color: var(--j-faint);
+  font-family: var(--j-sans);
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -776,6 +776,10 @@ a.th-ls-row:hover {
   /* biome-ignore lint/complexity/noImportantStyles: shiki inline light color must be overridden. */
   color: var(--t-text) !important;
 }
+.md pre.th-pre span {
+  /* biome-ignore lint/complexity/noImportantStyles: force shiki dark tokens without html.dark (SSR-safe). */
+  color: var(--shiki-dark) !important;
+}
 .md .th-pre code {
   background: none;
   padding: 0;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -144,3 +144,744 @@ html.dark ::-webkit-scrollbar-thumb {
 html.dark ::-webkit-scrollbar-thumb:hover {
   background: rgb(148 163 184 / 0.55);
 }
+
+/* =====================================================================
+ * THEME A — Terminal Session (UX redesign direction A)
+ * The site is one persistent terminal session: title bar header, tmux
+ * status bar footer, `ls -la` post list with permission bits encoding
+ * visibility. Dark-native: html renders with .dark by default (root.tsx)
+ * so existing dark: variants and shiki dual-themes stay coherent.
+ * =================================================================== */
+:root,
+.dark {
+  /* shadcn token layer → terminal palette (search palette & dialogs) */
+  --background: 210 29% 7%;
+  --foreground: 210 20% 83%;
+  --card: 211 30% 10%;
+  --card-foreground: 210 20% 83%;
+  --popover: 211 30% 9%;
+  --popover-foreground: 210 20% 83%;
+  --primary: 39 77% 60%;
+  --primary-foreground: 30 50% 8%;
+  --secondary: 211 30% 13%;
+  --secondary-foreground: 210 20% 83%;
+  --muted: 211 30% 13%;
+  --muted-foreground: 208 14% 56%;
+  --accent: 211 30% 15%;
+  --accent-foreground: 210 20% 88%;
+  --destructive: 2 66% 65%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 211 26% 17%;
+  --input: 211 26% 17%;
+  --ring: 39 77% 60%;
+  --radius: 0.375rem;
+}
+
+:root {
+  --t-bg: #0a0f14;
+  --t-term: #0c1218;
+  --t-panel: #101923;
+  --t-line: #1d2a37;
+  --t-text: #c9d4de;
+  --t-dim: #71828f;
+  --t-faint: #465666;
+  --t-amber: #e9b44c;
+  --t-cyan: #6fc5d8;
+  --t-green: #7cbf8b;
+  --t-red: #e06c75;
+  --t-violet: #a78bc4;
+  --t-sel: #16222e;
+  --t-mono:
+    ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo, Consolas,
+    "PingFang SC", "Microsoft YaHei", monospace;
+}
+
+html,
+html.dark {
+  background-color: var(--t-bg);
+  scrollbar-color: #24313e var(--t-bg);
+}
+
+html body {
+  font-family: var(--t-mono);
+  background-color: var(--t-bg);
+  color: var(--t-text);
+  font-size: 14.5px;
+  line-height: 1.75;
+}
+
+::selection {
+  background: rgba(233, 180, 76, 0.25);
+}
+
+/* ---------- shell: title bar / main / tmux bar ---------- */
+.th-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+}
+
+.th-titlebar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--t-line);
+  background: linear-gradient(#0e1620, #0c1218);
+}
+
+.th-dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+}
+.th-dot-r {
+  background: #e5544b;
+}
+.th-dot-y {
+  background: #d8a03c;
+}
+.th-dot-g {
+  background: #47a258;
+}
+
+.th-term-title {
+  margin-left: 10px;
+  color: var(--t-dim);
+  font-size: 12.5px;
+}
+.th-term-title b {
+  color: var(--t-text);
+  font-weight: 600;
+}
+.th-term-title .th-path {
+  color: var(--t-cyan);
+}
+
+.th-main {
+  flex: 1;
+  overflow-y: auto;
+  background: var(--t-term);
+}
+
+.th-page {
+  width: 100%;
+  max-width: 1020px;
+  margin: 0 auto;
+  padding: 26px 22px 46px;
+}
+
+/* ---------- tmux footer ---------- */
+.th-tmux {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+  padding: 6px 14px;
+  border-top: 1px solid var(--t-line);
+  background: #10161d;
+  font-size: 12.5px;
+}
+.th-tmux-sess {
+  color: #0a0f14;
+  background: var(--t-green);
+  padding: 1px 8px;
+  border-radius: 3px;
+  margin-right: 8px;
+  font-weight: 700;
+}
+.th-tmux-win {
+  color: var(--t-dim);
+  padding: 1px 8px;
+  border-radius: 3px;
+}
+a.th-tmux-win:hover {
+  color: var(--t-text);
+  text-decoration: none;
+}
+.th-tmux-win.th-on {
+  background: var(--t-term);
+  color: var(--t-amber);
+  box-shadow: inset 0 0 0 1px var(--t-line);
+}
+.th-tmux-right {
+  margin-left: auto;
+  color: var(--t-faint);
+  display: flex;
+  gap: 14px;
+}
+
+/* ---------- prompt primitives ---------- */
+.th-prompt {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+.th-prompt-u {
+  color: var(--t-cyan);
+}
+.th-prompt-at {
+  color: var(--t-faint);
+}
+.th-prompt-h {
+  color: var(--t-green);
+}
+.th-prompt-p {
+  color: var(--t-amber);
+}
+.th-cmd {
+  color: var(--t-text);
+}
+.th-cmd-dim {
+  color: var(--t-dim);
+}
+.th-out {
+  margin: 4px 0;
+}
+.th-comment {
+  color: var(--t-faint);
+}
+.th-hr {
+  border: 0;
+  border-top: 1px dashed var(--t-line);
+  margin: 20px 0;
+}
+
+/* ---------- titlebar tools ---------- */
+.th-tools {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.th-tool-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--t-dim);
+  background: none;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 13px;
+  font-family: inherit;
+}
+.th-tool-btn:hover {
+  color: var(--t-amber);
+  text-decoration: none;
+}
+.th-user-chip {
+  display: none;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--t-line);
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: 12px;
+  color: var(--t-dim);
+}
+@media (min-width: 768px) {
+  .th-user-chip {
+    display: inline-flex;
+  }
+}
+.th-role-badge {
+  background: var(--t-amber);
+  color: #171106;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 1px 7px;
+}
+
+/* ---------- buttons / forms ---------- */
+.th-btn {
+  font-family: var(--t-mono);
+  font-size: 13.5px;
+  cursor: pointer;
+  background: var(--t-panel);
+  color: var(--t-text);
+  border: 1px solid var(--t-line);
+  border-radius: 6px;
+  padding: 9px 18px;
+  transition:
+    border-color 0.12s,
+    color 0.12s;
+}
+.th-btn:hover {
+  border-color: var(--t-amber);
+  color: var(--t-amber);
+}
+.th-btn-primary {
+  background: var(--t-amber);
+  border-color: var(--t-amber);
+  color: #171106;
+  font-weight: 700;
+}
+.th-btn-primary:hover {
+  background: #f0c268;
+  color: #171106;
+}
+
+.th-field {
+  margin: 14px 0;
+  max-width: 460px;
+}
+.th-field label {
+  display: block;
+  color: var(--t-dim);
+  font-size: 13px;
+  margin-bottom: 5px;
+}
+.th-field label::before {
+  content: "▸ ";
+  color: var(--t-amber);
+}
+.th-input {
+  font-family: var(--t-mono);
+  font-size: 14px;
+  color: var(--t-text);
+  background: var(--t-panel);
+  border: 1px solid var(--t-line);
+  border-radius: 6px;
+  padding: 9px 12px;
+  width: 100%;
+}
+.th-input::placeholder {
+  color: var(--t-faint);
+}
+.th-input:focus {
+  outline: none;
+  border-color: var(--t-amber);
+  box-shadow: 0 0 0 2px rgba(233, 180, 76, 0.15);
+}
+.th-err {
+  color: var(--t-red);
+  margin: 10px 0;
+  font-size: 13.5px;
+}
+.th-err::before {
+  content: "✗ ";
+}
+
+/* ---------- home ---------- */
+.th-hero-name {
+  font-size: 21px;
+  color: #eaf1f7;
+  font-weight: 700;
+  margin-top: 12px;
+}
+.th-hero-desc {
+  color: var(--t-dim);
+  max-width: 62ch;
+  margin-top: 6px;
+}
+.th-figlet {
+  white-space: pre;
+  color: var(--t-faint);
+  line-height: 1.25;
+  font-size: 11px;
+  margin-top: 18px;
+  user-select: none;
+}
+.th-figlet b {
+  color: var(--t-amber);
+  font-weight: 400;
+}
+.th-home-links {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 12px;
+  margin-top: 22px;
+}
+.th-home-links a {
+  display: block;
+  border: 1px solid var(--t-line);
+  background: var(--t-panel);
+  padding: 14px 16px;
+  border-radius: 6px;
+  color: var(--t-text);
+}
+.th-home-links a:hover {
+  border-color: var(--t-amber);
+  text-decoration: none;
+  box-shadow: 0 0 18px rgba(233, 180, 76, 0.07);
+}
+.th-home-links .k {
+  color: var(--t-amber);
+}
+.th-home-links small {
+  display: block;
+  color: var(--t-dim);
+  margin-top: 2px;
+}
+
+/* ---------- ls table (blog list) ---------- */
+.th-ls {
+  margin-top: 12px;
+}
+.th-ls-row {
+  display: grid;
+  grid-template-columns: 11ch 7ch 8ch 1fr auto;
+  gap: 0 14px;
+  padding: 5px 8px;
+  border-radius: 4px;
+  align-items: baseline;
+}
+.th-ls-head {
+  color: var(--t-faint);
+  font-size: 12.5px;
+}
+a.th-ls-row {
+  color: var(--t-text);
+}
+a.th-ls-row:hover {
+  background: var(--t-sel);
+  text-decoration: none;
+}
+.th-ls-year {
+  grid-column: 1 / -1;
+  color: var(--t-amber);
+  margin-top: 20px;
+  font-weight: 700;
+}
+.th-ls-year::before {
+  content: "# ";
+  color: var(--t-faint);
+  font-weight: 400;
+}
+.th-perm {
+  letter-spacing: 0.08em;
+}
+.th-perm-pub {
+  color: var(--t-green);
+}
+.th-perm-mem {
+  color: var(--t-cyan);
+}
+.th-perm-vip {
+  color: var(--t-violet);
+}
+.th-perm-pw {
+  color: var(--t-red);
+}
+.th-perm-adm {
+  color: var(--t-dim);
+}
+.th-ls-date,
+.th-ls-vis {
+  color: var(--t-dim);
+  font-size: 13px;
+}
+.th-ls-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.th-ls-tags {
+  color: var(--t-faint);
+  font-size: 12.5px;
+}
+.th-legend {
+  margin-top: 26px;
+  color: var(--t-faint);
+  font-size: 12.5px;
+  line-height: 1.9;
+}
+.th-pager {
+  display: flex;
+  gap: 18px;
+  justify-content: center;
+  margin-top: 26px;
+  color: var(--t-dim);
+  font-size: 13.5px;
+}
+.th-pager a {
+  color: var(--t-amber);
+}
+.th-pager .th-pager-off {
+  color: var(--t-faint);
+  opacity: 0.6;
+}
+.th-cd {
+  color: var(--t-dim);
+}
+.th-cd:hover {
+  color: var(--t-text);
+}
+
+@media (max-width: 720px) {
+  .th-ls-row {
+    grid-template-columns: 11ch 7ch 1fr;
+  }
+  .th-ls-head,
+  .th-ls-vis,
+  .th-ls-tags {
+    display: none;
+  }
+}
+
+/* projects ls rows: star / project+desc / stack / links */
+.th-ls-proj {
+  display: grid;
+  grid-template-columns: 4ch 1fr 18ch auto;
+  gap: 0 16px;
+  padding: 8px;
+  border-radius: 4px;
+  align-items: baseline;
+}
+.th-ls-proj-head {
+  color: var(--t-faint);
+  font-size: 12.5px;
+}
+@media (max-width: 720px) {
+  .th-ls-proj {
+    grid-template-columns: 4ch 1fr;
+  }
+  .th-ls-proj .th-ls-tags,
+  .th-ls-proj .th-ls-link {
+    display: none;
+  }
+}
+
+/* ---------- article ---------- */
+.th-art-head {
+  margin: 16px 0 26px;
+}
+.th-art-title {
+  font-size: 24px;
+  color: #eaf1f7;
+  font-weight: 700;
+  line-height: 1.4;
+}
+.th-art-meta {
+  color: var(--t-dim);
+  margin-top: 6px;
+  font-size: 13px;
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+/* markdown body (article prose) */
+.md {
+  max-width: 74ch;
+}
+.md p {
+  margin: 14px 0;
+  color: var(--t-text);
+}
+.md h2 {
+  font-size: 17px;
+  color: #eaf1f7;
+  font-weight: 700;
+  margin: 30px 0 10px;
+  scroll-margin-top: 20px;
+}
+.md h2::before {
+  content: "## ";
+  color: var(--t-faint);
+  font-weight: 400;
+}
+.md h2 a {
+  color: inherit;
+}
+.md ul {
+  margin: 12px 0 12px 22px;
+  list-style: disc;
+}
+.md li {
+  margin: 4px 0;
+}
+.md li::marker {
+  color: var(--t-amber);
+}
+.md a {
+  color: var(--t-cyan);
+}
+.md a:hover {
+  text-decoration: underline;
+}
+.md blockquote {
+  border-left: 2px solid var(--t-amber);
+  background: var(--t-panel);
+  padding: 10px 16px;
+  margin: 16px 0;
+  color: var(--t-dim);
+  border-radius: 0 6px 6px 0;
+}
+.th-cmt-body code {
+  background: var(--t-panel);
+  border: 1px solid var(--t-line);
+  border-radius: 4px;
+  padding: 0 5px;
+  font-size: 0.9em;
+  color: var(--t-amber);
+}
+.md code.md-inline {
+  background: var(--t-panel);
+  border: 1px solid var(--t-line);
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 13px;
+  color: var(--t-amber);
+}
+.th-code {
+  position: relative;
+  margin: 18px 0;
+}
+.th-code-copy {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  z-index: 10;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid var(--t-line);
+  background: rgba(16, 25, 35, 0.85);
+  color: var(--t-dim);
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-family: var(--t-mono);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.th-code:hover .th-code-copy,
+.th-code-copy:focus-visible {
+  opacity: 1;
+}
+@media not (hover: hover) {
+  .th-code-copy {
+    opacity: 0.75;
+  }
+}
+.md pre.th-pre {
+  background: #0a1016;
+  border: 1px solid var(--t-line);
+  border-radius: 8px;
+  padding: 18px;
+  overflow-x: auto;
+  line-height: 1.7;
+  font-size: 13px;
+  margin: 0;
+}
+/* shiki writes inline light bg/color on <pre>; force the terminal panel. */
+.md pre.th-pre {
+  /* biome-ignore lint/complexity/noImportantStyles: shiki inline light bg must be overridden. */
+  background: #0a1016 !important;
+  /* biome-ignore lint/complexity/noImportantStyles: shiki inline light color must be overridden. */
+  color: var(--t-text) !important;
+}
+.md .th-pre code {
+  background: none;
+  padding: 0;
+}
+
+/* ---------- comments ---------- */
+.th-cmt {
+  border: 1px solid var(--t-line);
+  border-radius: 8px;
+  margin: 12px 0;
+  overflow: hidden;
+}
+.th-cmt-head {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  background: var(--t-panel);
+  padding: 8px 14px;
+  font-size: 13px;
+  color: var(--t-dim);
+  border-bottom: 1px solid var(--t-line);
+}
+.th-cmt-head .who {
+  color: var(--t-text);
+}
+.th-cmt-body {
+  padding: 10px 14px;
+}
+.th-cmt-body p {
+  margin: 0 0 8px;
+}
+.th-cmt-body p:last-child {
+  margin-bottom: 0;
+}
+.th-cmt-body blockquote {
+  border-left: 2px solid var(--t-line);
+  padding-left: 12px;
+  color: var(--t-dim);
+}
+.th-cmt-ops {
+  display: flex;
+  gap: 14px;
+  padding: 0 14px 10px;
+  font-size: 12px;
+}
+.th-cmt-ops button {
+  color: var(--t-dim);
+  cursor: pointer;
+  background: none;
+  font-family: inherit;
+}
+.th-cmt-ops button:hover {
+  color: var(--t-amber);
+}
+.th-cmt-ops .del:hover {
+  color: var(--t-red);
+}
+.th-cmt-replies {
+  border-top: 1px dashed var(--t-line);
+  background: rgba(16, 25, 35, 0.45);
+  padding: 10px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.th-cmt-reply {
+  border-left: 2px solid var(--t-line);
+  padding-left: 12px;
+}
+.th-cmt-form textarea {
+  width: 100%;
+  resize: vertical;
+  font-family: var(--t-mono);
+  font-size: 13.5px;
+  color: var(--t-text);
+  background: var(--t-panel);
+  border: 1px solid var(--t-line);
+  border-radius: 6px;
+  padding: 9px 12px;
+}
+.th-cmt-form textarea:focus {
+  outline: none;
+  border-color: var(--t-amber);
+}
+.th-cmt-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 8px;
+}
+.th-cmt-hint {
+  font-size: 12px;
+  color: var(--t-faint);
+}
+
+/* ---------- misc ---------- */
+.th-nf-big {
+  color: var(--t-red);
+}
+.th-devhint {
+  border: 1px dashed rgba(233, 180, 76, 0.5);
+  background: rgba(233, 180, 76, 0.06);
+  color: var(--t-amber);
+  border-radius: 6px;
+  padding: 8px 14px;
+  font-size: 13px;
+  margin-bottom: 18px;
+}

--- a/tests/e2e/admin-flow.spec.ts
+++ b/tests/e2e/admin-flow.spec.ts
@@ -19,7 +19,7 @@ test('admin can create a post that appears on the blog', async ({ page }) => {
   await page.locator('#password').fill(ADMIN_PASSWORD);
   await page.locator('form button[type="submit"]').click();
 
-  const loggedIn = page.getByRole('link', { name: /logout/i });
+  const loggedIn = page.getByTestId('nav-logout');
   try {
     await expect(loggedIn).toBeVisible({ timeout: 8000 });
   } catch {

--- a/tests/e2e/auth-logout.spec.ts
+++ b/tests/e2e/auth-logout.spec.ts
@@ -8,18 +8,20 @@ function createUniqueEmail(): string {
 test('signup then logout returns to guest header state', async ({ page }) => {
   await page.goto('/signup', { waitUntil: 'domcontentloaded' });
 
-  await page.getByLabel('Name').fill('E2E Logout');
-  await page.getByLabel('Email').fill(createUniqueEmail());
-  await page.getByLabel('Password').fill('Playwright!12345');
-  await page.getByRole('button', { name: 'Sign Up' }).click();
+  // Form anchors are theme-stable: field ids on /signup + the submit button.
+  // Header anchors use data-testid because each UX theme words them
+  // differently (login / 入会 / SIGN IN …).
+  await page.locator('#name').fill('E2E Logout');
+  await page.locator('#email').fill(createUniqueEmail());
+  await page.locator('#password').fill('Playwright!12345');
+  await page.locator('form button[type="submit"]').click();
 
   await page.waitForURL('**/blog');
-  await expect(page.getByRole('link', { name: 'Logout' })).toBeVisible();
+  await expect(page.getByTestId('nav-logout')).toBeVisible();
 
-  await page.getByRole('link', { name: 'Logout' }).click();
+  await page.getByTestId('nav-logout').click();
 
   await page.waitForURL('**/blog');
-  await expect(page.getByRole('link', { name: 'Login' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Sign Up' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Logout' })).toHaveCount(0);
+  await expect(page.getByTestId('nav-login')).toBeVisible();
+  await expect(page.getByTestId('nav-logout')).toHaveCount(0);
 });


### PR DESCRIPTION
## What — 双主题：终端 ⇄ 文学 一键切换

响应用户「两个都保留，支持切换」的决定：把 #94（终端）与 #95（文学）合并为**同一分支的两套可切换皮肤**，顶栏一键互切，选择记入 cookie（一年有效）。

- `src/skins/`：两套完整页面皮肤（header/footer/首页/列表/文章/项目/登录/注册/解锁/404/评论/⌘K 面板各一份），路由层按 `useSkin()` 选择渲染
- 切换入口：终端 title bar 的 `journal` 按钮 ⇄ 文学刊头的终端图标；切换即时生效（无整页刷新）
- **持久化**：`blog-skin` cookie；SSR 恒渲染默认皮肤 + `<head>` 内联 boot 脚本为非默认皮肤隐藏 body，hydration 后立即应用 → 无闪变、无 hydration mismatch
- 终端皮肤保留亮/暗双模式（含 #94 的暗色圆形扩散切换，圆心修复为过渡前捕获）；文学皮肤固定亮色
- CSS 按 `html[data-theme]` 作用域隔离，两套皮肤的正文排版（`.md`）互不污染
- 包含 #94/#95 的全部迭代内容（grep 面板、亮色终端、原文案回归、宽屏优化等）

## 技术说明（值得记录）

TanStack Start 在 workerd 上的**请求上下文会跨请求粘滞**（`getRequest`/`getWebRequest`/AsyncLocalStorage 三种方案实测均泄漏上一次请求的值），因此放弃了「SSR 读 cookie 渲染对应皮肤」的常规方案，改用 boot-script 方案。若上游修复，可低成本切回。

## 验证

- [x] typecheck / lint（0 warning）/ test 36 passed / build + 体积 **1029.5 KiB gzip / 3072 KiB**
- [x] e2e 2/2（auth-logout + admin-flow）
- [x] 生产构建 wrangler dev 全流程实测：默认终端 → 切文学 → reload 保持文学（无闪变）→ 文学下博客/文章/⌘K/404 → 切回终端 → reload 保持 → 暗色切换
- [x] 已知上游问题（非本 PR 引入）：404 页面正文在 wrangler 生产模式下不渲染（master 同样）；偶发 React #418（master 同样）

## 与 #94 / #95 的关系

本 PR **取代** #94 和 #95（内容为其超集 + 切换层）。建议审查通过后 close 这两个，合并本 PR。