### PR TITLE
feat(web): add skin switching infrastructure (provider, cookie, data-theme)

### DIFF
--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -8,6 +8,7 @@ import {
 import { type ReactNode, useEffect } from 'react';
 import { AppLayout } from '../components/layout.js';
 import { SearchPalette } from '../components/search-palette.js';
+import { SkinProvider } from '../skins/context.js';
 import '../styles.css';
 
 export const Route = createRootRoute({
@@ -82,17 +83,19 @@ function RootComponent() {
 
   return (
     <RootDocument>
-      <AppLayout>
-        <Outlet />
-      </AppLayout>
-      <SearchPalette />
+      <SkinProvider initial='terminal'>
+        <AppLayout>
+          <Outlet />
+        </AppLayout>
+        <SearchPalette />
+      </SkinProvider>
     </RootDocument>
   );
 }
 
 function RootDocument({ children }: { children: ReactNode }) {
   return (
-    <html lang='zh-CN'>
+    <html lang='zh-CN' data-theme='terminal'>
       <head>
         <HeadContent />
       </head>

--- a/apps/web/src/skins/context.tsx
+++ b/apps/web/src/skins/context.tsx
@@ -1,0 +1,71 @@
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+export type Skin = 'terminal' | 'journal';
+
+const SkinContext = createContext<{
+  skin: Skin;
+  setSkin: (next: Skin) => void;
+}>({ skin: 'terminal', setSkin: () => {} });
+
+export const SKIN_COOKIE = 'blog-skin';
+
+export function readSkinFromCookie(cookie: string | null): Skin {
+  return /(?:^|;\s*)blog-skin=journal(?:;|$)/.test(cookie ?? '')
+    ? 'journal'
+    : 'terminal';
+}
+
+/**
+ * Runtime skin switcher for the two UX themes (terminal / journal). The
+ * initial value comes from the root loader (cookie), so SSR and the first
+ * client render agree — no flash, no hydration mismatch. Switching updates
+ * <html data-theme>, persists the cookie, and drops `dark` when entering the
+ * light-only journal skin.
+ */
+export function SkinProvider({
+  initial,
+  children,
+}: {
+  initial: Skin;
+  children: ReactNode;
+}) {
+  const [skin, setSkinState] = useState<Skin>(initial);
+
+  // SSR renders the default skin (per-request context is unreliable on
+  // workerd); apply the cookie skin right after hydration. __root's boot
+  // script hid the body for non-default skins so nothing flashes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: run once per page load; `initial` is a mount-time constant.
+  useEffect(() => {
+    const fromCookie = readSkinFromCookie(document.cookie);
+    if (fromCookie !== initial) {
+      setSkin(fromCookie);
+    }
+    document.getElementById('skin-boot')?.remove();
+  }, []);
+
+  const setSkin = useCallback((next: Skin) => {
+    setSkinState(next);
+    document.documentElement.dataset.theme = next;
+    if (next === 'journal') {
+      // Journal is light-only; leave no stale dark class behind.
+      document.documentElement.classList.remove('dark');
+    }
+    // biome-ignore lint/suspicious/noDocumentCookie: skin preference is a non-sensitive UI cookie; document.cookie is the only dependency-free writer here.
+    document.cookie = `${SKIN_COOKIE}=${next}; path=/; max-age=31536000; samesite=lax`;
+  }, []);
+
+  const value = useMemo(() => ({ skin, setSkin }), [skin, setSkin]);
+  return <SkinContext.Provider value={value}>{children}</SkinContext.Provider>;
+}
+
+export function useSkin() {
+  return useContext(SkinContext);
+}


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="gh.io/stacks-feedback">Give Feedback 💬</a></sub>

Adds the skin-switching infrastructure (layer 2 of the skin stack, on top of #102):

- `SkinProvider` React context (`terminal | journal`) with `useSkin()` hook.
- `blog-skin` cookie persistence so the chosen skin survives reloads.
- `html[data-theme]` scoping hook on the document element.
- Route components dispatch to skin components via `useSkin()`; no visual change yet (terminal branch of the dispatch is the only implementation in this layer).