### PR TITLE
fix(web): anchor dark-mode reveal animation at the toggle icon

### DIFF
--- a/apps/web/src/components/dark-mode.tsx
+++ b/apps/web/src/components/dark-mode.tsx
@@ -4,8 +4,12 @@ import { Moon, Sun } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 
+type ViewTransitionLike = {
+  finished: Promise<void>;
+};
+
 type ViewTransitionDocument = Document & {
-  startViewTransition?: (cb: () => void) => { ready: Promise<void> };
+  startViewTransition?: (cb: () => void) => ViewTransitionLike;
 };
 
 export function DarkMode() {
@@ -23,7 +27,7 @@ export function DarkMode() {
     document.body.classList.remove('dark:bg-wash-dark', 'dark:text-white');
   }, [isDarkMode]);
 
-  const onTrigger = async () => {
+  const onTrigger = () => {
     const newIsDarkMode = !isDarkMode;
     const doc = document as ViewTransitionDocument;
 
@@ -36,35 +40,35 @@ export function DarkMode() {
       return;
     }
 
-    await doc.startViewTransition(() => {
-      flushSync(() => {
-        setIsDarkMode(newIsDarkMode);
-      });
-    }).ready;
-
+    // Capture the anchor rect BEFORE starting the transition: once the
+    // dark-mode class swap runs, scrollbar / reflow may shift layout and
+    // move the measured origin off the icon.
     const { top, left, width, height } = ref.current.getBoundingClientRect();
     const x = left + width / 2;
     const y = top + height / 2;
     const right = window.innerWidth - left;
     const bottom = window.innerHeight - top;
     const maxRadius = Math.hypot(Math.max(left, right), Math.max(top, bottom));
-    const clipPath = [
-      `circle(0px at ${x}px ${y}px)`,
-      `circle(${maxRadius}px at ${x}px ${y}px)`,
-    ];
 
-    document.documentElement.animate(
-      {
-        clipPath: newIsDarkMode ? clipPath : [...clipPath].reverse(),
-      },
-      {
-        duration: 500,
-        easing: 'ease-in-out',
-        pseudoElement: newIsDarkMode
-          ? '::view-transition-new(root)'
-          : '::view-transition-old(root)',
-      },
-    );
+    // Hand the origin to CSS custom properties and mark the transition with
+    // .vt-dark-reveal. The clip keyframes (see styles.css) then apply to the
+    // transition pseudo-elements from their very first frame — no gap between
+    // `.ready` resolving and a script animation attaching, so the reveal can
+    // never flash the fully-swapped page before the circle starts growing.
+    const root = document.documentElement;
+    root.style.setProperty('--vt-x', `${x}px`);
+    root.style.setProperty('--vt-y', `${y}px`);
+    root.style.setProperty('--vt-r', `${maxRadius}px`);
+    root.classList.add('vt-dark-reveal');
+
+    const transition = doc.startViewTransition(() => {
+      flushSync(() => {
+        setIsDarkMode(newIsDarkMode);
+      });
+    });
+    transition.finished
+      .catch(() => {})
+      .finally(() => root.classList.remove('vt-dark-reveal'));
   };
 
   return (

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -98,6 +98,32 @@
   z-index: 9999;
 }
 
+/* Dark-mode circular reveal. dark-mode.tsx sets --vt-x/--vt-y/--vt-r and adds
+   .vt-dark-reveal on <html> before startViewTransition, so the clip keyframes
+   cover the transition pseudo-elements from their first rendered frame (no
+   flash of the fully-swapped page while a script animation attaches after
+   `.ready`). Scoping by .vt-dark-reveal keeps every other view transition —
+   e.g. router navigations — on the plain swap defined above. */
+.vt-dark-reveal.dark::view-transition-new(root) {
+  animation: dark-mode-reveal 500ms ease-in-out;
+}
+
+.vt-dark-reveal:not(.dark)::view-transition-old(root) {
+  animation: dark-mode-reveal 500ms ease-in-out reverse;
+}
+
+@keyframes dark-mode-reveal {
+  from {
+    clip-path: circle(0px at var(--vt-x, 50%) var(--vt-y, 50%));
+  }
+
+  to {
+    clip-path: circle(
+      var(--vt-r, 150vmax) at var(--vt-x, 50%) var(--vt-y, 50%)
+    );
+  }
+}
+
 /* https://shiki.style/guide/dual-themes */
 html.dark .shiki,
 html.dark .shiki span {


### PR DESCRIPTION
## Problem

The dark-mode circular reveal animation was reported as no longer starting from the toggle icon.

Investigation found two fragile timing windows in the old implementation (master had both):

1. **Measurement timing** — the old code measured the button rect only after `.ready` resolved. The dark-mode class swap can trigger scrollbar/reflow layout shifts that move the button, offsetting the measured origin from the icon. (The redesign branches already carried an equivalent fix in 263ba42; master never picked it up.)
2. **Attach window** — even with a correct rect, the clip animation was attached to the transition pseudo-element via WAAPI only after `.ready`. Frames painted before the attach show the fully-swapped page with no clip; under main-thread contention this reads as a full-page flash instead of a circle growing from the icon.

## Fix

- Measure the button center **before** `startViewTransition` and publish it as `--vt-x/--vt-y/--vt-r` custom properties on `<html>`.
- Mark the transition with `.vt-dark-reveal`; CSS keyframes clip the transition pseudo-elements from their very first frame — no attach window, no origin drift.
- Direction semantics unchanged: light→dark grows the new layer from the icon; dark→light shrinks the old layer back into it.
- Scoped via `.vt-dark-reveal` so other view transitions (router navigations) keep the plain swap; the marker class is cleaned up on `finished` without unhandled rejections.

## Verification

- `pnpm typecheck` / `biome check` / `build` / wrangler dry-run (gzip 1024.71 KiB < 3 MiB) ✅
- wrangler dev, Chromium + WebKit, both toggle directions: per-frame computed-style traces show the clip origin exactly at the icon center, growing from 0px radius; no full-page flash; marker class cleaned up ✅