### PR TITLE
fix(web): make the dark-mode reveal origin legible at the toggle icon

### DIFF
--- a/apps/web/src/components/dark-mode.tsx
+++ b/apps/web/src/components/dark-mode.tsx
@@ -50,16 +50,23 @@ export function DarkMode() {
     const bottom = window.innerHeight - top;
     const maxRadius = Math.hypot(Math.max(left, right), Math.max(top, bottom));
 
-    // Hand the origin to CSS custom properties and mark the transition with
-    // .vt-dark-reveal. The clip keyframes (see styles.css) then apply to the
-    // transition pseudo-elements from their very first frame — no gap between
-    // `.ready` resolving and a script animation attaching, so the reveal can
-    // never flash the fully-swapped page before the circle starts growing.
-    const root = document.documentElement;
-    root.style.setProperty('--vt-x', `${x}px`);
-    root.style.setProperty('--vt-y', `${y}px`);
-    root.style.setProperty('--vt-r', `${maxRadius}px`);
-    root.classList.add('vt-dark-reveal');
+    // Bake the measured origin into the keyframes as literal pixels. Some
+    // engines do not cascade custom properties set on <html> into the
+    // view-transition pseudo-elements, which silently fell back to the
+    // 50%/50% var() defaults and made the circle grow from the screen
+    // center. Literal values sidestep that entirely, and rewriting a
+    // dedicated <style> before startViewTransition keeps the clip active
+    // from the pseudo-element's first frame (no post-`.ready` attach gap).
+    let styleEl = document.getElementById(
+      'vt-dark-reveal-keyframes',
+    ) as HTMLStyleElement | null;
+    if (!styleEl) {
+      styleEl = document.createElement('style');
+      styleEl.id = 'vt-dark-reveal-keyframes';
+      document.head.appendChild(styleEl);
+    }
+    styleEl.textContent = `@keyframes dark-mode-reveal{from{clip-path:circle(0px at ${x}px ${y}px)}30%{clip-path:circle(140px at ${x}px ${y}px)}to{clip-path:circle(${maxRadius}px at ${x}px ${y}px)}}`;
+    document.documentElement.classList.add('vt-dark-reveal');
 
     const transition = doc.startViewTransition(() => {
       flushSync(() => {
@@ -68,7 +75,9 @@ export function DarkMode() {
     });
     transition.finished
       .catch(() => {})
-      .finally(() => root.classList.remove('vt-dark-reveal'));
+      .finally(() =>
+        document.documentElement.classList.remove('vt-dark-reveal'),
+      );
   };
 
   return (

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -105,16 +105,25 @@
    `.ready`). Scoping by .vt-dark-reveal keeps every other view transition —
    e.g. router navigations — on the plain swap defined above. */
 .vt-dark-reveal.dark::view-transition-new(root) {
-  animation: dark-mode-reveal 500ms ease-in-out;
+  animation: dark-mode-reveal 650ms ease-in-out;
 }
 
 .vt-dark-reveal:not(.dark)::view-transition-old(root) {
-  animation: dark-mode-reveal 500ms ease-in-out reverse;
+  animation: dark-mode-reveal 650ms ease-in-out reverse;
 }
 
+/* The toggle sits ~30px from the viewport edge, so a plain 0 → max circle
+   exits the top edge within the first couple of frames and reads as a flat
+   band sweeping across the page. The 30% waypoint holds a ~140px disc around
+   the icon first (~200ms), making the origin legible before the sweep. */
 @keyframes dark-mode-reveal {
   from {
     clip-path: circle(0px at var(--vt-x, 50%) var(--vt-y, 50%));
+  }
+
+  30% {
+    clip-path: circle(140px at var(--vt-x, 50%) var(--vt-y, 50%));
+    animation-timing-function: ease-in-out;
   }
 
   to {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -98,39 +98,22 @@
   z-index: 9999;
 }
 
-/* Dark-mode circular reveal. dark-mode.tsx sets --vt-x/--vt-y/--vt-r and adds
-   .vt-dark-reveal on <html> before startViewTransition, so the clip keyframes
-   cover the transition pseudo-elements from their first rendered frame (no
-   flash of the fully-swapped page while a script animation attaches after
-   `.ready`). Scoping by .vt-dark-reveal keeps every other view transition —
-   e.g. router navigations — on the plain swap defined above. */
+/* Dark-mode circular reveal. dark-mode.tsx bakes the measured icon position
+   into a `dark-mode-reveal` @keyframes rule (literal pixels, injected as a
+   <style> before startViewTransition) and adds .vt-dark-reveal on <html>.
+   Literal values are used because some engines do not cascade custom
+   properties set on <html> into the view-transition pseudo-elements — the
+   var() fallbacks then grew the circle from the screen center. The keyframes
+   cover the pseudo-elements from their first rendered frame (no flash of the
+   fully-swapped page while a script animation attaches after `.ready`).
+   Scoping by .vt-dark-reveal keeps every other view transition — e.g. router
+   navigations — on the plain swap defined above. */
 .vt-dark-reveal.dark::view-transition-new(root) {
   animation: dark-mode-reveal 650ms ease-in-out;
 }
 
 .vt-dark-reveal:not(.dark)::view-transition-old(root) {
   animation: dark-mode-reveal 650ms ease-in-out reverse;
-}
-
-/* The toggle sits ~30px from the viewport edge, so a plain 0 → max circle
-   exits the top edge within the first couple of frames and reads as a flat
-   band sweeping across the page. The 30% waypoint holds a ~140px disc around
-   the icon first (~200ms), making the origin legible before the sweep. */
-@keyframes dark-mode-reveal {
-  from {
-    clip-path: circle(0px at var(--vt-x, 50%) var(--vt-y, 50%));
-  }
-
-  30% {
-    clip-path: circle(140px at var(--vt-x, 50%) var(--vt-y, 50%));
-    animation-timing-function: ease-in-out;
-  }
-
-  to {
-    clip-path: circle(
-      var(--vt-r, 150vmax) at var(--vt-x, 50%) var(--vt-y, 50%)
-    );
-  }
 }
 
 /* https://shiki.style/guide/dual-themes */


### PR DESCRIPTION
## Problem

Two follow-up findings to #107, the second confirmed by a user screen recording:

1. **Illegible origin** — the toggle sits ~30px from the viewport top edge, so a plain 0 → max-radius circle exits the top edge within the first frames. What remains visible is the lower arc of a huge circle — nearly flat on wide screens — sweeping down the page. Reported as a "band swipe" that does not read as starting from the icon.
2. **Circle growing from screen center** (the recording) — some engines do **not** cascade custom properties set on `<html>` into the `::view-transition` pseudo-elements. `var(--vt-x/--vt-y)` silently resolved to its `50%`/`50%` fallbacks, so the reveal originated at the exact center of the screen — visible as darkness entering from the top-center edge. Not reproducible in the (newer) local Chromium/WebKit builds, which is why earlier verification passed.

## Fix

- **Literal-pixel keyframes**: on every toggle, inject/rewrite a dedicated `<style id="vt-dark-reveal-keyframes">` whose `dark-mode-reveal` keyframes carry the measured icon position and max radius as literal values. No custom-property cascade is involved, so engine differences in pseudo-element inheritance cannot move the origin.
- **Legible origin phase**: a 30% keyframe waypoint grows a ~140px disc centered on the icon (~200ms) before the sweep, so the origin is clearly visible; duration 500ms → 650ms. Dark → light plays the same keyframes reversed (darkness collapses back into the icon).
- Static `var()`-based keyframes removed; the `.vt-dark-reveal` class still scopes the animation so router-driven view transitions keep the plain swap.
- Marker class cleaned up on `transition.finished` (with `.catch`, no unhandled rejections).

## Verification

- typecheck / biome / build / wrangler dry-run (gzip 1025.58 KiB < 3 MiB) ✅
- wrangler dev: computed-style trace shows `circle(0px at 1334px 32px)` — the icon center — growing on frame one; injected style carries literal coords; style element reused across toggles; both directions settle with the marker class removed ✅
- Mid-animation frames: ~110px dark disc centered on the sun icon at ~230ms; recognizable arc sweep afterwards; no banding/flash ✅