### PR TITLE
fix(web): make dark-mode reveal DPR-proof with percentage keyframes

### DIFF
--- a/apps/web/src/components/dark-mode.tsx
+++ b/apps/web/src/components/dark-mode.tsx
@@ -50,13 +50,22 @@ export function DarkMode() {
     const bottom = window.innerHeight - top;
     const maxRadius = Math.hypot(Math.max(left, right), Math.max(top, bottom));
 
-    // Bake the measured origin into the keyframes as literal pixels. Some
-    // engines do not cascade custom properties set on <html> into the
-    // view-transition pseudo-elements, which silently fell back to the
-    // 50%/50% var() defaults and made the circle grow from the screen
-    // center. Literal values sidestep that entirely, and rewriting a
-    // dedicated <style> before startViewTransition keeps the clip active
-    // from the pseudo-element's first frame (no post-`.ready` attach gap).
+    // Bake the measured origin into the keyframes as VIEWPORT PERCENTAGES.
+    // Pixel values are wrong on some setups: Chromium interprets clip-path
+    // lengths on view-transition pseudo-elements against the physical
+    // (device-pixel) snapshot box, so CSS-pixel coordinates land at half
+    // the intended position on DPR-2 screens (circle grew from top-center
+    // instead of the icon). Percentages resolve against the pseudo's own
+    // box in whatever space the engine uses, so they stay pinned to the
+    // icon at any DPR / zoom / window size.
+    const xp = (x / window.innerWidth) * 100;
+    const yp = (y / window.innerHeight) * 100;
+    // circle() percentage radius resolves against sqrt(w²+h²)/sqrt(2) of
+    // the reference box — convert the pixel max radius into that space.
+    const radiusRef =
+      Math.hypot(window.innerWidth, window.innerHeight) / Math.SQRT2;
+    const rp = (maxRadius / radiusRef) * 100;
+
     let styleEl = document.getElementById(
       'vt-dark-reveal-keyframes',
     ) as HTMLStyleElement | null;
@@ -65,7 +74,7 @@ export function DarkMode() {
       styleEl.id = 'vt-dark-reveal-keyframes';
       document.head.appendChild(styleEl);
     }
-    styleEl.textContent = `@keyframes dark-mode-reveal{from{clip-path:circle(0px at ${x}px ${y}px)}30%{clip-path:circle(140px at ${x}px ${y}px)}to{clip-path:circle(${maxRadius}px at ${x}px ${y}px)}}`;
+    styleEl.textContent = `@keyframes dark-mode-reveal{from{clip-path:circle(0% at ${xp}% ${yp}%)}to{clip-path:circle(${rp}% at ${xp}% ${yp}%)}}`;
     document.documentElement.classList.add('vt-dark-reveal');
 
     const transition = doc.startViewTransition(() => {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -99,21 +99,26 @@
 }
 
 /* Dark-mode circular reveal. dark-mode.tsx bakes the measured icon position
-   into a `dark-mode-reveal` @keyframes rule (literal pixels, injected as a
-   <style> before startViewTransition) and adds .vt-dark-reveal on <html>.
-   Literal values are used because some engines do not cascade custom
-   properties set on <html> into the view-transition pseudo-elements — the
-   var() fallbacks then grew the circle from the screen center. The keyframes
-   cover the pseudo-elements from their first rendered frame (no flash of the
-   fully-swapped page while a script animation attaches after `.ready`).
-   Scoping by .vt-dark-reveal keeps every other view transition — e.g. router
-   navigations — on the plain swap defined above. */
+   into a `dark-mode-reveal` @keyframes rule as viewport percentages (injected
+   as a <style> before startViewTransition) and adds .vt-dark-reveal on <html>.
+   Percentages are used because (a) some engines do not cascade custom
+   properties set on <html> into the pseudo-elements (pixel var() fell back to
+   50%/50% = screen center) and (b) Chromium resolves pixel clip lengths on
+   view-transition pseudos against the physical snapshot box, which halves CSS
+   pixel coordinates on DPR-2 screens. Percentages resolve against the
+   pseudo's own box, correct in every coordinate space. `forwards` holds the
+   terminal clip so the swapped-away layer cannot flash unclipped for a frame
+   when the animation ends. The slow-start cubic-bezier keeps the circle
+   small (~140px) around the icon for the first ~150ms — the legible origin
+   — then sweeps; a single curve avoids the mid-animation hitch that chained
+   per-segment easings produced. */
 .vt-dark-reveal.dark::view-transition-new(root) {
-  animation: dark-mode-reveal 650ms ease-in-out;
+  animation: dark-mode-reveal 650ms cubic-bezier(0.65, 0, 0.35, 1) forwards;
 }
 
 .vt-dark-reveal:not(.dark)::view-transition-old(root) {
-  animation: dark-mode-reveal 650ms ease-in-out reverse;
+  animation: dark-mode-reveal 650ms cubic-bezier(0.65, 0, 0.35, 1) reverse
+    forwards;
 }
 
 /* https://shiki.style/guide/dual-themes */


### PR DESCRIPTION
## Problem

The literal-pixel keyframes from #108 still rendered the circle from the top-center of the screen on HiDPI displays. Root cause (reproduced headless at `deviceScaleFactor: 2`): **Chromium resolves clip-path pixel lengths on view-transition pseudo-elements against the physical (device-pixel) snapshot box**, so CSS-pixel coordinates land at half the intended position on DPR-2 screens. (The earlier var()-based origin had a separate cascade bug — both bugs produced a circle from the wrong spot, which is why fixing the first one did not change what the reviewer saw.)

Two motion-quality issues were also reported and fixed during dev-server review:

- dark → light **flashed dark on the final frame** — the animation ended without a fill mode, so the swapped-away layer snapped back to unclipped for one frame before the pseudo-elements were destroyed.
- the reveal **hitched mid-animation** — the two-segment keyframes (0 → 140px disc → max) chained two ease-in-out curves; both decelerate to zero velocity at the waypoint, producing a visible stall.

## Fix

- Express the measured origin and max radius as **viewport percentages** in the injected `dark-mode-reveal` keyframes. Percentages resolve against the pseudo-element's own box in whatever coordinate space the engine uses, pinning the circle to the icon at any DPR, zoom, or window size.
- `animation-fill-mode: forwards` holds the terminal clip until the pseudo-elements are removed (no end flash).
- Replace the two-segment keyframes with a single slow-start cubic-bezier (650ms). The slow start keeps a ~140px bloom around the icon for the first ~150ms — the origin stays legible — with continuous velocity throughout (no hitch).

## Verification

- typecheck / biome / build / wrangler dry-run (gzip 1025.89 KiB < 3 MiB) ✅
- Headless Chromium at **DPR 2**: before the fix the arc center rendered at physical (1330, 70) = top-center (reproduces the reported symptom); after, at (2665, 90) = the sun icon (2668, 64) ✅
- DPR 1 regression check: arc center at (1330, 35) = icon CSS position (1334, 32) ✅
- Per-frame radius trace: monotonic growth, no plateau; dark→light terminal clip held at `circle(0%)` until pseudo-element removal, no unclipped frame ✅
- **User-accepted on a local dev server at DPR 2** (both directions, origin / smoothness / no end flash)